### PR TITLE
Fix FileNotFound when reviewing patches

### DIFF
--- a/src/metis/engine.py
+++ b/src/metis/engine.py
@@ -305,7 +305,7 @@ class MetisEngine:
             relative_path = os.path.relpath(file_diff.path, base_path)
 
             review_dict = self._process_file_reviews(
-                file_diff.path,
+                os.path.join(base_path, file_diff.path),
                 snippet,
                 combined_context,
                 language_prompts,


### PR DESCRIPTION
Minimal fix for #47.

Allows metis to be run from a directory other than where the code is stored and for the patch to be outside the code directory.f