### PR TITLE
added support for html and csv outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metis"
-version = "0.1.3"
+version = "0.2.0"
 description = "Metis is a command line tool for performing security code reviews using LLMs"
 readme = "README.md"
 license = { file = "LICENSE.md" }
@@ -52,3 +52,4 @@ include-package-data = true
 [tool.setuptools.package-data]
 metis = ["metis.yaml"]
 "metis.plugins" = ["plugins.yaml"]
+"metis.cli" = ["report_template.html"]

--- a/src/metis/cli/commands.py
+++ b/src/metis/cli/commands.py
@@ -58,7 +58,7 @@ def run_review(engine, patch_file, args):
         "Reviewing patch...", engine.review_patch, patch_file=patch_file
     )
     pretty_print_reviews(results, args.quiet)
-    save_output(args.output_file, results, args.quiet, args.sarif)
+    save_output(args.output_file, results, args.quiet)
 
 
 def run_file_review(engine, file_path, args):
@@ -74,7 +74,7 @@ def run_file_review(engine, file_path, args):
         results = {"reviews": []}
 
     pretty_print_reviews(results, args.quiet)
-    save_output(args.output_file, results, args.quiet, args.sarif)
+    save_output(args.output_file, results, args.quiet)
 
 
 def run_review_code(engine, args):
@@ -82,7 +82,7 @@ def run_review_code(engine, args):
         "Reviewing codebase...", engine.review_code, False, args.verbose
     )
     pretty_print_reviews(results, args.quiet)
-    save_output(args.output_file, results, args.quiet, args.sarif)
+    save_output(args.output_file, results, args.quiet)
 
 
 def run_index(engine, verbose=False, quiet=False):

--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -142,9 +142,6 @@ def main():
         help="Alternative syntax to provide multiple output files",
     )
     parser.add_argument(
-        "--sarif", action="store_true", help="Flag to generate SARIF output"
-    )
-    parser.add_argument(
         "--non-interactive", action="store_true", help="Run in non-interactive mode"
     )
     parser.add_argument(
@@ -168,12 +165,6 @@ def main():
             False,
         )
         exit(1)
-    if args.sarif and not args.output_file:
-        print_console(
-            "[red]Error:[/red] --sarif requires the --output-file argument", args.quiet
-        )
-        exit(1)
-
     configure_logger(logger, args)
     runtime = load_runtime_config(enable_psql=(args.backend == "postgres"))
 

--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -57,22 +57,27 @@ completer = WordCompleter(list(COMMANDS), ignore_case=True)
 
 
 def determine_output_file(cmd, args, cmd_args):
-    """
-    Set args.output_file if not provided, or extract from cmd_args if present.
-    """
-    if "--output-file" in cmd_args:
+    """Set args.output_file list if not provided, or extract from cmd_args."""
+    existing_outputs = list(args.output_file or [])
+    overrides: list[str] = []
+
+    while "--output-file" in cmd_args:
         idx = cmd_args.index("--output-file")
         if idx + 1 < len(cmd_args):
-            args.output_file = cmd_args[idx + 1]
-            del cmd_args[idx : idx + 2]
-            return
+            overrides.append(cmd_args[idx + 1])
+        del cmd_args[idx : idx + 2]
 
-    if args.output_file:
+    if overrides:
+        args.output_file = overrides
+        return
+
+    if existing_outputs:
+        args.output_file = existing_outputs
         return
 
     Path("results").mkdir(exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    args.output_file = f"results/{cmd}_{timestamp}.json"
+    args.output_file = [f"results/{cmd}_{timestamp}.json"]
 
 
 def execute_command(engine, cmd, cmd_args, args):
@@ -127,7 +132,14 @@ def main():
         "-q", "--quiet", action="store_true", help="Suppress output in CLI"
     )
     parser.add_argument(
-        "--output-file", type=str, help="Save analysis results to this file"
+        "--output-file",
+        action="append",
+        help="Save analysis results to this file (repeatable, supports .json/.html/.sarif)",
+    )
+    parser.add_argument(
+        "--output-files",
+        nargs="+",
+        help="Alternative syntax to provide multiple output files",
     )
     parser.add_argument(
         "--sarif", action="store_true", help="Flag to generate SARIF output"
@@ -142,6 +154,13 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.output_files:
+        if args.output_file:
+            args.output_file.extend(args.output_files)
+        else:
+            args.output_file = list(args.output_files)
+        args.output_files = None
 
     if args.quiet and args.verbose:
         print_console(

--- a/src/metis/cli/exporters.py
+++ b/src/metis/cli/exporters.py
@@ -20,9 +20,7 @@ def export_html(
 ) -> Path:
     """Render the HTML report template with the provided data."""
     issues = _flatten_issues(report_data)
-    document = _build_html_document(
-        issues, output_path.name, template, metis_version
-    )
+    document = _build_html_document(issues, output_path.name, template, metis_version)
     html_path = output_path.with_suffix(".html")
     html_path.parent.mkdir(parents=True, exist_ok=True)
     html_path.write_text(document, encoding="utf-8")
@@ -33,7 +31,9 @@ def export_sarif(
     report_data, output_path: Path, sarif_payload=None
 ) -> Tuple[Path, dict]:
     """Generate SARIF payload (or reuse) and persist it to disk."""
-    payload = sarif_payload if sarif_payload is not None else generate_sarif(report_data)
+    payload = (
+        sarif_payload if sarif_payload is not None else generate_sarif(report_data)
+    )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=4)

--- a/src/metis/cli/exporters.py
+++ b/src/metis/cli/exporters.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import csv
+import html
+import json
+import re
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from metis.sarif.writer import generate_sarif
+
+
+def export_html(
+    report_data, output_path: Path, template: str, metis_version: str
+) -> Path:
+    """Render the HTML report template with the provided data."""
+    issues = _flatten_issues(report_data)
+    document = _build_html_document(
+        issues, output_path.name, template, metis_version
+    )
+    html_path = output_path.with_suffix(".html")
+    html_path.parent.mkdir(parents=True, exist_ok=True)
+    html_path.write_text(document, encoding="utf-8")
+    return html_path
+
+
+def export_sarif(
+    report_data, output_path: Path, sarif_payload=None
+) -> Tuple[Path, dict]:
+    """Generate SARIF payload (or reuse) and persist it to disk."""
+    payload = sarif_payload if sarif_payload is not None else generate_sarif(report_data)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=4)
+    return output_path, payload
+
+
+def export_csv(report_data, output_path: Path) -> Path:
+    """Write flattened issues to a CSV file."""
+    issues = _flatten_issues(report_data)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(
+            [
+                "File",
+                "Line",
+                "Severity",
+                "CWE",
+                "Issue",
+                "Reasoning",
+                "Mitigation",
+                "Confidence",
+            ]
+        )
+        for issue in issues:
+            writer.writerow(
+                [
+                    issue.get("file", ""),
+                    issue.get("line", ""),
+                    issue.get("severity", ""),
+                    issue.get("cwe", ""),
+                    issue.get("issue", ""),
+                    issue.get("reasoning", ""),
+                    issue.get("mitigation", ""),
+                    issue.get("confidence", ""),
+                ]
+            )
+    return output_path
+
+
+def _build_html_document(
+    issues: Iterable[dict], source_name: str, template: str, metis_version: str
+) -> str:
+    generated_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    display_name = Path(source_name).stem if source_name else source_name
+    title = f"Metis Security Report - {display_name}"
+
+    severity_counts = Counter()
+    cwe_counts = Counter()
+    severity_priority = {
+        "Critical": 4,
+        "High": 3,
+        "Medium": 2,
+        "Low": 1,
+        "Unknown": 0,
+    }
+    file_stats: dict[str, dict[str, object]] = {}
+    folder_stats: dict[str, dict[str, object]] = {}
+
+    for issue in issues:
+        severity = issue.get("severity") or "Unknown"
+        cwe = issue.get("cwe") or "CWE-Unknown"
+        severity_counts[severity] += 1
+        cwe_counts[cwe] += 1
+
+        file_name = issue.get("file", "Unknown") or "Unknown"
+        folder = file_name.split("/", 1)[0] if "/" in file_name else file_name
+        file_entry = file_stats.setdefault(
+            file_name,
+            {
+                "count": 0,
+                "maxSeverity": "Unknown",
+                "severityCounts": Counter(),
+            },
+        )
+        file_entry["count"] = int(file_entry["count"]) + 1
+        file_entry["severityCounts"][severity] += 1
+        current_priority = severity_priority.get(file_entry["maxSeverity"], 0)
+        candidate_priority = severity_priority.get(severity, 0)
+        if candidate_priority > current_priority:
+            file_entry["maxSeverity"] = severity
+
+        folder_entry = folder_stats.setdefault(
+            folder,
+            {
+                "count": 0,
+                "severityCounts": Counter(),
+            },
+        )
+        folder_entry["count"] = int(folder_entry["count"]) + 1
+        folder_entry["severityCounts"][severity] += 1
+
+    file_stats_serialized = {
+        file_name: {
+            "count": details["count"],
+            "severityCounts": dict(details["severityCounts"]),
+            "maxSeverity": details["maxSeverity"],
+        }
+        for file_name, details in file_stats.items()
+    }
+
+    folder_stats_serialized = {
+        folder_name: {
+            "count": details["count"],
+            "severityCounts": dict(details["severityCounts"]),
+        }
+        for folder_name, details in folder_stats.items()
+    }
+
+    payload = {
+        "issues": list(issues),
+        "severityCounts": dict(severity_counts),
+        "cweCounts": dict(cwe_counts),
+        "fileStats": file_stats_serialized,
+        "folderStats": folder_stats_serialized,
+    }
+    data_json = json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
+    return (
+        template.replace("__TITLE__", html.escape(title))
+        .replace("__GENERATED_AT__", html.escape(generated_at))
+        .replace("__DATA_JSON__", data_json)
+        .replace("__METIS_VERSION__", html.escape(metis_version))
+    )
+
+
+def _flatten_issues(report_data) -> list[dict]:
+    issues = []
+    if not isinstance(report_data, dict):
+        return issues
+
+    reviews = report_data.get("reviews", [])
+    for file_entry in reviews:
+        file_name = file_entry.get("file") or file_entry.get("file_path") or "Unknown"
+        try:
+            file_name = str(file_name)
+        except Exception:  # pragma: no cover - defensive
+            file_name = "Unknown"
+
+        for issue in file_entry.get("reviews", []):
+            severity = issue.get("severity") or "Unknown"
+            if isinstance(severity, str):
+                severity = severity.strip() or "Unknown"
+            else:
+                severity = str(severity)
+
+            cwe = issue.get("cwe") or "CWE-Unknown"
+            if isinstance(cwe, (list, tuple)):
+                cwe = ", ".join(str(item) for item in cwe if item)
+            else:
+                cwe = str(cwe)
+
+            cwe_match = re.search(r"(\d+)", cwe)
+            cwe_link = (
+                f"https://cwe.mitre.org/data/definitions/{cwe_match.group(1)}.html"
+                if cwe_match
+                else ""
+            )
+
+            folder = file_name.split("/", 1)[0] if "/" in file_name else file_name
+            issues.append(
+                {
+                    "file": file_name,
+                    "line": str(issue.get("line_number") or ""),
+                    "severity": severity,
+                    "cwe": cwe,
+                    "cweLink": cwe_link,
+                    "issue": _coerce_to_string(issue.get("issue")),
+                    "reasoning": _coerce_to_string(issue.get("reasoning")),
+                    "mitigation": _coerce_to_string(issue.get("mitigation")),
+                    "confidence": _coerce_to_string(issue.get("confidence")),
+                    "snippet": _coerce_to_string(issue.get("code_snippet")),
+                    "folder": folder,
+                }
+            )
+
+    return issues
+
+
+def _coerce_to_string(value):
+    if value is None:
+        return ""
+    try:
+        return str(value)
+    except Exception:  # pragma: no cover - defensive
+        return ""

--- a/src/metis/cli/report_template.html
+++ b/src/metis/cli/report_template.html
@@ -1,0 +1,1041 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>__TITLE__</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 2rem; background: #081229; color: #f4f5f7; }
+        h1 { margin-bottom: 0.25rem; color: #ffffff; }
+        .meta { color: #9ca3c7; margin-bottom: 1.5rem; }
+        .mode-toggle { position: fixed; top: 1.25rem; right: 1.5rem; z-index: 10000; display: inline-flex; align-items: center; justify-content: center; width: 38px; height: 38px; border-radius: 999px; border: 1px solid rgba(148, 163, 184, 0.35); background: rgba(8, 18, 41, 0.85); color: #f4f5f7; cursor: pointer; transition: background 0.2s ease, transform 0.2s ease; }
+        .mode-toggle:hover { background: rgba(59, 130, 246, 0.25); transform: translateY(-1px); }
+        body.light-theme { background: #f5f7fb; color: #101828; }
+        body.light-theme h1 { color: #0b1120; }
+        body.light-theme .meta { color: #4b5565; }
+        body.light-theme .chart-card { background: #ffffff; border-color: #d0d5e0; box-shadow: 0 12px 30px -18px rgba(15, 23, 42, 0.15); }
+        body.light-theme .chart-card.selected { border-color: #2563eb; box-shadow: 0 18px 38px -18px rgba(37, 99, 235, 0.35); }
+        body.light-theme .chart-card.selected { border-color: #2563eb; box-shadow: 0 18px 38px -18px rgba(37, 99, 235, 0.35); }
+        body.light-theme .chart-card h2 { color: #111827; }
+        body.light-theme .chart-card .echart { cursor: pointer; }
+        body.light-theme .chart-button { color: #1e293b; border-color: rgba(148, 163, 184, 0.4); background: rgba(148, 163, 184, 0.18); }
+        body.light-theme .chart-button:hover { background: rgba(59, 130, 246, 0.2); }
+        body.light-theme #no-issues { background: #fdf2d0; color: #92400e; }
+        body.light-theme .counts { color: #364152; }
+        body.light-theme .chart-empty { color: #4a5565; }
+        body.light-theme .filters label { color: #1f2a3d; }
+        body.light-theme .filters select { background: #ffffff; color: #1f2a3d; border-color: #c5cfe3; }
+        body.light-theme details.issue { background: #ffffff; border-color: #d0d7e4; box-shadow: 0 12px 28px -20px rgba(15, 23, 42, 0.18); }
+        body.light-theme details.issue summary { color: #111827; }
+        body.light-theme details.issue[open] summary { background: linear-gradient(90deg, rgba(37,99,235,0.15), rgba(37,99,235,0.05)); color: #0b1120; }
+        body.light-theme .summary-file { color: #334155; }
+        body.light-theme .issue-body { background: #f6f8fc; border-top-color: #d0d7e4; color: #1f2a3d; }
+        body.light-theme .issue-body h3 { color: #1d4ed8; }
+        body.light-theme .code-snippet { background: #1f2937; color: #f8fafc; border-color: #1e293b; }
+        body.light-theme .chart-card.maximized { background: #ffffff; }
+        body.light-theme .mode-toggle { background: rgba(248, 250, 252, 0.9); color: #111827; border-color: rgba(71, 85, 105, 0.3); }
+        body.light-theme .mode-toggle:hover { background: rgba(59, 130, 246, 0.18); }
+        .filters { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem; }
+        .filters label { font-weight: 600; font-size: 0.95rem; color: #d1d5f0; }
+        .filters select { margin-left: 0.35rem; padding: 0.35rem 0.5rem; border: 1px solid #314170; border-radius: 6px; background: #0f1e3a; color: #f4f5f7; }
+        .filters select:focus { outline: 2px solid #3b82f6; }
+        .counts { margin-bottom: 1rem; font-weight: 600; color: #cbd5ff; }
+        #no-issues { padding: 1.5rem; background: #102345; color: #facc15; border-radius: 8px; display: none; }
+        .charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.5rem; margin-bottom: 2rem; }
+        .charts.maximized-active { grid-template-columns: 1fr; }
+        .charts.maximized-active .chart-card:not(.maximized) { display: none; }
+        .chart-card { position: relative; background: #0d1a33; border: 1px solid #1f2c4d; border-radius: 12px; padding: 1rem 1.25rem 1.5rem; box-shadow: 0 10px 30px -15px rgba(15, 23, 42, 0.8); min-height: 320px; display: flex; flex-direction: column; transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease; }
+        .chart-card.selected { border-color: #3b82f6; box-shadow: 0 20px 45px -18px rgba(59, 130, 246, 0.45); }
+        .chart-card.selected { border-color: #3b82f6; box-shadow: 0 20px 45px -18px rgba(59, 130, 246, 0.45); }
+        .chart-card h2 { font-size: 1.05rem; margin-bottom: 0.75rem; color: #f4f5f7; display: flex; justify-content: space-between; align-items: center; gap: 0.75rem; }
+        .chart-actions { display: inline-flex; gap: 0.5rem; }
+        .chart-button { background: rgba(148, 163, 184, 0.15); border: 1px solid rgba(148, 163, 184, 0.3); color: #cbd5ff; padding: 0.25rem 0.55rem; border-radius: 6px; font-size: 0.75rem; cursor: pointer; transition: background 0.2s ease, transform 0.2s ease; }
+        .chart-button:hover { background: rgba(59, 130, 246, 0.35); transform: translateY(-1px); }
+        .chart-card.maximized { margin: 0; border-radius: 16px; padding: 1.5rem 1.75rem 2rem; box-shadow: 0 20px 50px -20px rgba(8, 11, 31, 0.6); min-height: 420px; }
+        .chart-card.maximized canvas,
+        .chart-card.maximized .echart { height: 380px !important; }
+        .chart-card canvas,
+        .chart-card .echart { flex: 1 1 auto; height: 260px !important; cursor: pointer; }
+        .chart-empty { margin-top: 1rem; text-align: center; color: #94a3de; font-size: 0.9rem; display: none; }
+        #results { display: flex; flex-direction: column; gap: 1rem; margin-top: 1.5rem; }
+        .report-footer { margin-top: 2rem; text-align: center; font-size: 0.85rem; color: #94a3de; }
+        body.light-theme .report-footer { color: #4a5565; }
+
+        details.issue { background: #0d1b36; border: 1px solid #1d2a4b; border-radius: 10px; overflow: hidden; box-shadow: 0 10px 25px -20px rgba(8, 15, 35, 0.9); }
+        details.issue summary { cursor: pointer; padding: 0.85rem 1.1rem; display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: baseline; font-weight: 600; color: #e2e8f8; }
+        details.issue[open] summary { background: linear-gradient(90deg, rgba(59,130,246,0.2), rgba(59,130,246,0.05)); }
+        .summary-pill { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.15rem 0.65rem; border-radius: 999px; font-size: 0.78rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.02em; }
+        .summary-pill a { color: inherit; text-decoration: none; }
+        .summary-pill a:hover { text-decoration: underline; }
+        .severity-Critical { background: rgba(185, 28, 28, 0.25); color: #fda4af; border: 1px solid rgba(185, 28, 28, 0.35); }
+        .severity-High { background: rgba(239, 68, 68, 0.22); color: #f87171; border: 1px solid rgba(239, 68, 68, 0.32); }
+        .severity-Medium { background: rgba(249, 115, 22, 0.2); color: #fb923c; border: 1px solid rgba(249, 115, 22, 0.3); }
+        .severity-Low { background: rgba(250, 204, 21, 0.18); color: #facc15; border: 1px solid rgba(250, 204, 21, 0.3); }
+        .severity-Unknown { background: rgba(148, 163, 184, 0.2); color: #cbd5f5; border: 1px solid rgba(148, 163, 184, 0.3); }
+        .summary-file { color: #94a3de; font-size: 0.9rem; }
+        .summary-meta { color: #cbd5ff; font-size: 0.8rem; }
+        body.light-theme .severity-Critical { background: #fee2e2; color: #b91c1c; border: 1px solid #fecaca; }
+        body.light-theme .severity-High { background: #fecaca; color: #c2410c; border: 1px solid #fca5a5; }
+        body.light-theme .severity-Medium { background: #fed7aa; color: #b45309; border: 1px solid #fdba74; }
+        body.light-theme .severity-Low { background: #fef08a; color: #a16207; border: 1px solid #fde047; }
+        body.light-theme .severity-Unknown { background: #e2e8f0; color: #475569; border: 1px solid #cbd5f5; }
+        body.light-theme .summary-meta { color: #2563eb; }
+        .issue-body { padding: 1rem 1.1rem 1.25rem; border-top: 1px solid #1d2a4b; display: grid; gap: 0.75rem; background: #09132a; }
+        .issue-body section { display: grid; gap: 0.35rem; }
+        .issue-body h3 { margin: 0; font-size: 0.9rem; color: #94a3de; text-transform: uppercase; letter-spacing: 0.08em; }
+        .code-snippet { background: #071024; border: 1px solid #1f2c4d; padding: 0.75rem; border-radius: 8px; font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 0.85rem; color: #cbd5f5; overflow-x: auto; white-space: pre-wrap; }
+        @media (max-width: 900px) {
+            body { margin: 1rem; }
+            details.issue summary { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+            .chart-card { min-height: 260px; }
+            .chart-card canvas,
+            .chart-card .echart { min-height: 200px; }
+        }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+</head>
+<body>
+    <button id="modeToggle" class="mode-toggle" aria-label="Toggle color mode" title="Toggle color mode">&#9788;</button>
+    <div class="header">
+        <div class="title-block">
+            <h1>__TITLE__</h1>
+            <div class="meta">Generated at __GENERATED_AT__</div>
+        </div>
+    </div>
+    <div class="charts">
+        <div class="chart-card" id="severityCard">
+            <h2>
+                Issues by Severity
+                <span class="chart-actions">
+                    <button class="chart-button chart-toggle" data-chart="severityChart" aria-label="Toggle full size" title="View full size">&#x26F6;</button>
+                </span>
+            </h2>
+            <div id="severityChart" class="echart"></div>
+            <div class="chart-empty">No data available.</div>
+        </div>
+        <div class="chart-card" id="cweCard">
+            <h2>
+                Top CWEs
+                <span class="chart-actions">
+                    <button class="chart-button chart-toggle" data-chart="cweChart" aria-label="Toggle full size" title="View full size">&#x26F6;</button>
+                </span>
+            </h2>
+            <div id="cweChart" class="echart"></div>
+            <div class="chart-empty">No data available.</div>
+        </div>
+        <div class="chart-card" id="treemapCard">
+            <h2>
+                File Treemap
+                <span class="chart-actions">
+                    <button class="chart-button chart-toggle" data-chart="treemapChart" aria-label="Toggle full size" title="View full size">&#x26F6;</button>
+                </span>
+            </h2>
+            <div id="treemapChart" class="echart"></div>
+            <div class="chart-empty">No data available.</div>
+        </div>
+    </div>
+    <div class="filters">
+        <label>Severity
+            <select id="severityFilter">
+                <option value="">All</option>
+            </select>
+        </label>
+        <label>CWE
+            <select id="cweFilter">
+                <option value="">All</option>
+            </select>
+        </label>
+        <label>Folder
+            <select id="folderFilter">
+                <option value="">All</option>
+            </select>
+        </label>
+        <label>File
+            <select id="fileFilter">
+                <option value="">All</option>
+            </select>
+        </label>
+        <label>Sort
+            <select id="sortFilter">
+                <option value="severity-desc">Severity (Critical→Low)</option>
+                <option value="severity-asc">Severity (Low→Critical)</option>
+            </select>
+        </label>
+    </div>
+    <div class="counts">Showing <span id="resultsCount">0</span> issues</div>
+    <div id="no-issues">No issues match the current filters.</div>
+    <div id="results"></div>
+
+    <script id="report-data" type="application/json">__DATA_JSON__</script>
+    <footer class="report-footer">Generated by Metis v__METIS_VERSION__</footer>
+    <script>
+        const payload = JSON.parse(document.getElementById('report-data').textContent || '{}');
+        const issues = payload.issues || [];
+        const severityCounts = payload.severityCounts || {};
+        const cweCounts = payload.cweCounts || {};
+        const fileStats = payload.fileStats || {};
+        const severityFilter = document.getElementById('severityFilter');
+        const cweFilter = document.getElementById('cweFilter');
+        const folderFilter = document.getElementById('folderFilter');
+        const fileFilter = document.getElementById('fileFilter');
+        const sortFilter = document.getElementById('sortFilter');
+        const chartsContainer = document.querySelector('.charts');
+        let treemapEntries = [];
+        const chartCards = {
+            severity: document.getElementById('severityCard'),
+            cwe: document.getElementById('cweCard'),
+            treemap: document.getElementById('treemapCard')
+        };
+        const resultsContainer = document.getElementById('results');
+        const resultsCount = document.getElementById('resultsCount');
+        const noIssues = document.getElementById('no-issues');
+
+        const severityColors = {
+            'Critical': '#b91c1c',
+            'High': '#f87171',
+            'Medium': '#fb923c',
+            'Low': '#facc15',
+            'Unknown': '#94a3b8'
+        };
+
+        const severityRank = {
+            'Critical': 5,
+            'High': 4,
+            'Medium': 3,
+            'Low': 2,
+            'Unknown': 1
+        };
+
+        let severityChartInstance = null;
+        let cweChartInstance = null;
+        let treemapChartInstance = null;
+
+        function toggleFilter(select, value) {
+            if (!select) return;
+            if (select.value === value) {
+                select.value = '';
+            } else {
+                select.value = value;
+            }
+            applyFilters();
+        }
+
+        function updateToggleButtonState(button, expanded) {
+            if (!button) return;
+            button.setAttribute('aria-pressed', expanded ? 'true' : 'false');
+            button.innerHTML = expanded ? '&#x2715;' : '&#x26F6;';
+            button.title = expanded ? 'Exit full size' : 'View full size';
+        }
+
+        function normalizePath(path) {
+            return (path || '')
+                .replace(/\\/g, '/')
+                .replace(/^\/+/, '')
+                .replace(/\/+$/, '');
+        }
+
+        function collectFolderOptions() {
+            const folders = new Set();
+            issues.forEach(issue => {
+                const filePath = normalizePath(issue.file || '');
+                if (filePath) {
+                    const parts = filePath.split('/');
+                    if (parts.length > 1) {
+                        parts.pop();
+                        let prefix = '';
+                        parts.forEach(part => {
+                            if (!part) return;
+                            prefix = prefix ? prefix + '/' + part : part;
+                            folders.add(prefix);
+                        });
+                    } else if (issue.folder) {
+                        folders.add(issue.folder);
+                    }
+                } else if (issue.folder) {
+                    folders.add(issue.folder);
+                }
+            });
+            return Array.from(folders).sort((a, b) => a.localeCompare(b));
+        }
+
+        function matchesFolder(issue, folderValue) {
+            if (!folderValue) return true;
+            const normalizedValue = normalizePath(folderValue);
+            const filePath = normalizePath(issue.file || '');
+            if (filePath) {
+                if (filePath === normalizedValue) return true;
+                if (filePath.startsWith(normalizedValue + '/')) return true;
+            }
+            const issueFolder = normalizePath(issue.folder || '');
+            if (issueFolder === normalizedValue) return true;
+            return false;
+        }
+
+        function uniqueValues(key) {
+            const values = new Set();
+            issues.forEach(issue => {
+                const value = issue[key] || '';
+                if (value) {
+                    values.add(value);
+                }
+            });
+            return Array.from(values).sort((a, b) => a.localeCompare(b));
+        }
+
+        function populateFilters() {
+            const severityOrder = ['Critical', 'High', 'Medium', 'Low', 'Unknown'];
+            const severities = uniqueValues('severity');
+            const sortedSeverities = severityOrder.filter(value => severities.includes(value));
+            const remainingSeverities = severities.filter(value => !severityOrder.includes(value)).sort((a, b) => a.localeCompare(b));
+            fillSelect(severityFilter, [...sortedSeverities, ...remainingSeverities]);
+            fillSelect(cweFilter, uniqueValues('cwe'));
+            fillSelect(folderFilter, collectFolderOptions());
+            fillSelect(fileFilter, uniqueValues('file'));
+        }
+
+        function fillSelect(select, values) {
+            if (!select) return;
+            select.innerHTML = '';
+
+            const defaultOption = document.createElement('option');
+            defaultOption.value = '';
+            defaultOption.textContent = 'All';
+            select.appendChild(defaultOption);
+
+            values.forEach(rawValue => {
+                const value = String(rawValue);
+                const option = document.createElement('option');
+                option.value = value;
+                option.textContent = value;
+                select.appendChild(option);
+            });
+        }
+
+        function applyFilters() {
+            const severityValue = severityFilter.value;
+            const cweValue = cweFilter.value;
+            const folderValue = folderFilter.value;
+            const fileValue = fileFilter.value;
+
+            const filtered = issues.filter(issue => (
+                (!severityValue || issue.severity === severityValue) &&
+                (!cweValue || issue.cwe === cweValue) &&
+                matchesFolder(issue, folderValue) &&
+                (!fileValue || issue.file === fileValue)
+            ));
+
+            const sorted = sortIssues(filtered.slice());
+            renderIssues(sorted);
+            resultsCount.textContent = filtered.length;
+            noIssues.style.display = filtered.length ? 'none' : 'block';
+            updateChartHighlights();
+        }
+
+        function sortIssues(rows) {
+            if (!rows || !rows.length) {
+                return rows;
+            }
+
+            const sortValue = (sortFilter && sortFilter.value) || 'severity-desc';
+
+            const compareSeverity = (a, b, direction = 'desc') => {
+                const rankA = severityRank[a.severity] || 0;
+                const rankB = severityRank[b.severity] || 0;
+                return direction === 'asc' ? rankA - rankB : rankB - rankA;
+            };
+
+            const comparators = {
+                'severity-desc': (a, b) => compareSeverity(a, b, 'desc'),
+                'severity-asc': (a, b) => compareSeverity(a, b, 'asc'),
+            };
+
+            const comparator = comparators[sortValue] || comparators['severity-desc'];
+            return rows.sort((a, b) => {
+                const primary = comparator(a, b);
+                if (primary !== 0) return primary;
+                // tie-breaker: keep deterministic order by file name
+                const fileA = (a.file || '').toString().toLowerCase();
+                const fileB = (b.file || '').toString().toLowerCase();
+                if (fileA === fileB) return 0;
+                return fileA < fileB ? -1 : 1;
+            });
+        }
+
+        function updateChartHighlights() {
+            if (chartCards.severity) {
+                chartCards.severity.classList.toggle('selected', Boolean(severityFilter.value));
+            }
+            if (chartCards.cwe) {
+                chartCards.cwe.classList.toggle('selected', Boolean(cweFilter.value));
+            }
+            if (chartCards.treemap) {
+                const active = Boolean(folderFilter.value || fileFilter.value);
+                chartCards.treemap.classList.toggle('selected', active);
+            }
+            highlightSeveritySlice(severityFilter.value);
+            highlightCweBar(cweFilter.value);
+            highlightTreemapSelection(folderFilter.value, fileFilter.value);
+        }
+
+        function highlightSeveritySlice(selectedValue) {
+            if (!severityChartInstance) return;
+            const option = severityChartInstance.getOption();
+            if (!option.series || !option.series.length) return;
+            const isLight = document.body.classList.contains('light-theme');
+            const baseBorder = isLight ? '#e2e8f0' : '#0d1a33';
+            const data = (option.series[0].data || []).map(item => {
+                const name = item.name;
+                const selected = Boolean(selectedValue && name === selectedValue);
+                return {
+                    ...item,
+                    selected,
+                    itemStyle: {
+                        ...(item.itemStyle || {}),
+                        color: severityColors[name] || severityColors.Unknown,
+                        borderColor: selected ? '#3b82f6' : baseBorder,
+                        borderWidth: selected ? 3 : 1
+                    }
+                };
+            });
+            severityChartInstance.setOption({ series: [{ data }] }, false, false);
+            severityChartInstance.dispatchAction({ type: 'downplay', seriesIndex: 0 });
+            if (selectedValue) {
+                const index = data.findIndex(item => item.name === selectedValue);
+                if (index >= 0) {
+                    severityChartInstance.dispatchAction({ type: 'highlight', seriesIndex: 0, dataIndex: index });
+                }
+            }
+        }
+
+        function highlightCweBar(selectedValue) {
+            if (!cweChartInstance) return;
+            const option = cweChartInstance.getOption();
+            if (!option.series || !option.series.length || !option.xAxis || !option.xAxis.length) return;
+            const labels = option.xAxis[0].data || [];
+            const seriesData = option.series[0].data || [];
+            const isLight = document.body.classList.contains('light-theme');
+            const baseColor = isLight ? '#ea580c' : '#f97316';
+            const borderColor = isLight ? '#1d4ed8' : '#bfdbfe';
+            const newData = labels.map((label, idx) => {
+                const raw = seriesData[idx];
+                const value = typeof raw === 'object' && raw !== null ? raw.value : raw;
+                const selected = Boolean(selectedValue && label === selectedValue);
+                return {
+                    value,
+                    itemStyle: {
+                        color: baseColor,
+                        borderColor: selected ? borderColor : 'transparent',
+                        borderWidth: selected ? 2 : 0
+                    }
+                };
+            });
+            cweChartInstance.setOption({ series: [{ data: newData }] }, false, false);
+            cweChartInstance.dispatchAction({ type: 'downplay', seriesIndex: 0 });
+            if (selectedValue) {
+                const index = labels.indexOf(selectedValue);
+                if (index >= 0) {
+                    cweChartInstance.dispatchAction({ type: 'highlight', seriesIndex: 0, dataIndex: index });
+                }
+            }
+        }
+
+        function highlightTreemapSelection(selectedFolderValue, selectedFileValue) {
+            if (!treemapChartInstance || !treemapEntries.length) return;
+            const focusPath = selectedFileValue || selectedFolderValue || '';
+            const isLight = document.body.classList.contains('light-theme');
+            const data = buildTreemapHierarchy(treemapEntries, focusPath, isLight);
+            treemapChartInstance.setOption({ series: [{ data }] }, false, false);
+        }
+
+        function renderIssues(rows) {
+            resultsContainer.innerHTML = '';
+            rows.forEach(row => {
+                const detailsEl = document.createElement('details');
+                detailsEl.className = 'issue';
+
+                const summary = document.createElement('summary');
+                const severityClass = 'summary-pill severity-' + (row.severity || 'Unknown').replace(/[\s]+/g, '-');
+                const severitySpan = document.createElement('span');
+                severitySpan.className = severityClass;
+                severitySpan.textContent = row.severity || 'Unknown';
+
+                const cweSpan = document.createElement('span');
+                cweSpan.className = 'summary-pill';
+                const cweValue = row.cwe || 'CWE-Unknown';
+                const cweLink = row.cweLink || '';
+                if (cweLink) {
+                    const anchor = document.createElement('a');
+                    anchor.href = cweLink;
+                    anchor.target = '_blank';
+                    anchor.rel = 'noopener noreferrer';
+                    anchor.textContent = cweValue;
+                    cweSpan.appendChild(anchor);
+                } else {
+                    cweSpan.textContent = cweValue;
+                }
+
+                const fileSpan = document.createElement('span');
+                fileSpan.className = 'summary-file';
+                fileSpan.textContent = (row.file || 'Unknown') + (row.line ? ' • line ' + row.line : '');
+
+                const issueTitle = document.createElement('span');
+                issueTitle.textContent = row.issue || 'Issue';
+
+                const confidenceSpan = document.createElement('span');
+                confidenceSpan.className = 'summary-meta';
+                confidenceSpan.textContent = row.confidence ? 'Confidence: ' + row.confidence : '';
+
+                summary.appendChild(severitySpan);
+                summary.appendChild(cweSpan);
+                summary.appendChild(issueTitle);
+                summary.appendChild(fileSpan);
+                if (confidenceSpan.textContent) {
+                    summary.appendChild(confidenceSpan);
+                }
+
+                const body = document.createElement('div');
+                body.className = 'issue-body';
+
+                appendSection(body, 'Reasoning', row.reasoning);
+                appendSection(body, 'Mitigation', row.mitigation);
+                appendSnippet(body, row.snippet);
+                if (row.line) {
+                    appendSection(body, 'Location', row.file + ' • line ' + row.line);
+                }
+
+                detailsEl.appendChild(summary);
+                detailsEl.appendChild(body);
+                resultsContainer.appendChild(detailsEl);
+            });
+        }
+
+        function appendSection(parent, heading, content) {
+            if (!content) return;
+            const section = document.createElement('section');
+            const title = document.createElement('h3');
+            title.textContent = heading;
+            const paragraph = document.createElement('p');
+            paragraph.textContent = content;
+            section.appendChild(title);
+            section.appendChild(paragraph);
+            parent.appendChild(section);
+        }
+
+        function appendSnippet(parent, snippet) {
+            if (!snippet) return;
+            const section = document.createElement('section');
+            const title = document.createElement('h3');
+            title.textContent = 'Code Snippet';
+            const pre = document.createElement('pre');
+            pre.className = 'code-snippet';
+            pre.textContent = snippet;
+            section.appendChild(title);
+            section.appendChild(pre);
+            parent.appendChild(section);
+        }
+
+        populateFilters();
+        if (sortFilter) {
+            sortFilter.value = 'severity-desc';
+        }
+        applyFilters();
+        [severityFilter, cweFilter, folderFilter, fileFilter, sortFilter]
+            .filter(Boolean)
+            .forEach(select => select.addEventListener('change', applyFilters));
+
+        renderCharts();
+        setupChartControls();
+
+        function renderCharts() {
+            renderSeverityChart();
+            renderCweChart();
+            renderTreemapChart();
+            resizeCharts();
+            updateChartHighlights();
+        }
+
+        function setTheme(theme) {
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+                modeToggle.innerHTML = '&#9790;';
+                modeToggle.setAttribute('data-mode', 'light');
+                localStorage.setItem('metis-report-theme', 'light');
+            } else {
+                document.body.classList.remove('light-theme');
+                modeToggle.innerHTML = '&#9788;';
+                modeToggle.setAttribute('data-mode', 'dark');
+                localStorage.setItem('metis-report-theme', 'dark');
+            }
+            renderCharts();
+            requestAnimationFrame(() => {
+                applyFilters();
+                resizeCharts();
+            });
+        }
+
+        const modeToggle = document.getElementById('modeToggle');
+        const storedTheme = localStorage.getItem('metis-report-theme');
+        const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+        setTheme(storedTheme || (prefersLight ? 'light' : 'dark'));
+
+        modeToggle.addEventListener('click', () => {
+            const current = modeToggle.getAttribute('data-mode');
+            setTheme(current === 'light' ? 'dark' : 'light');
+        });
+
+        function setupChartControls() {
+            const buttons = document.querySelectorAll('.chart-toggle');
+            buttons.forEach(button => {
+                updateToggleButtonState(button, false);
+                button.addEventListener('click', () => {
+                    const card = button.closest('.chart-card');
+                    if (!card) return;
+
+                    const alreadyMaximized = card.classList.contains('maximized');
+                    if (!alreadyMaximized && chartsContainer) {
+                        chartsContainer.classList.add('maximized-active');
+                    }
+                    document.querySelectorAll('.chart-card.maximized').forEach(el => {
+                        el.classList.remove('maximized');
+                        updateToggleButtonState(el.querySelector('.chart-toggle'), false);
+                    });
+
+                    if (!alreadyMaximized) {
+                        card.classList.add('maximized');
+                    } else if (chartsContainer) {
+                        chartsContainer.classList.remove('maximized-active');
+                    }
+
+                    updateToggleButtonState(button, !alreadyMaximized);
+                    requestAnimationFrame(resizeCharts);
+                });
+            });
+
+            document.addEventListener('keydown', event => {
+                if (event.key === 'Escape') {
+                    document.querySelectorAll('.chart-card.maximized').forEach(el => {
+                        el.classList.remove('maximized');
+                        updateToggleButtonState(el.querySelector('.chart-toggle'), false);
+                    });
+                    if (chartsContainer) {
+                        chartsContainer.classList.remove('maximized-active');
+                    }
+                    requestAnimationFrame(resizeCharts);
+                }
+            });
+        }
+
+        function clearAllFilters(exceptSelect = null) {
+            [severityFilter, cweFilter, folderFilter, fileFilter]
+                .filter(select => select && select !== exceptSelect)
+                .forEach(select => {
+                    select.value = '';
+                });
+            updateChartHighlights();
+        }
+
+        function renderSeverityChart() {
+            const container = document.getElementById('severityChart');
+            if (!container || typeof echarts === 'undefined') return;
+            const empty = container.parentElement ? container.parentElement.querySelector('.chart-empty') : null;
+            const severityOrder = ['Critical', 'High', 'Medium', 'Low', 'Unknown'];
+            const orderedEntries = severityOrder
+                .map(name => ({ name, value: severityCounts[name] || 0 }))
+                .filter(entry => entry.value > 0);
+            const additionalEntries = Object.entries(severityCounts)
+                .filter(([name, value]) => value > 0 && !severityOrder.includes(name))
+                .map(([name, value]) => ({ name, value }))
+                .sort((a, b) => a.name.localeCompare(b.name));
+            const entries = [...orderedEntries, ...additionalEntries];
+
+            if (!entries.length) {
+                if (empty) empty.style.display = 'block';
+                if (severityChartInstance) {
+                    severityChartInstance.dispose();
+                    severityChartInstance = null;
+                }
+                return;
+            }
+
+            if (empty) empty.style.display = 'none';
+
+            if (severityChartInstance) {
+                severityChartInstance.dispose();
+            }
+
+            severityChartInstance = echarts.init(container);
+            const isLight = document.body.classList.contains('light-theme');
+            severityChartInstance.setOption({
+                backgroundColor: 'transparent',
+                tooltip: {
+                    trigger: 'item',
+                    formatter: params => `${params.name}: ${params.value}`
+                },
+                legend: {
+                    orient: 'vertical',
+                    left: 0,
+                    top: 'middle',
+                    textStyle: { color: isLight ? '#1f2937' : '#e2e8f0' }
+                },
+                series: [{
+                    name: 'Severity',
+                    type: 'pie',
+                    radius: ['45%', '70%'],
+                    center: ['60%', '50%'],
+                    avoidLabelOverlap: false,
+                    itemStyle: {
+                        borderColor: isLight ? '#e2e8f0' : '#0d1a33',
+                        borderWidth: 1
+                    },
+                    label: {
+                        color: isLight ? '#1f2937' : '#e2e8f0'
+                    },
+                    labelLine: {
+                        length: 15,
+                        length2: 10
+                    },
+                    data: entries.map(entry => ({
+                        value: entry.value,
+                        name: entry.name,
+                        itemStyle: { color: severityColors[entry.name] || severityColors.Unknown }
+                    }))
+                }]
+            });
+
+            severityChartInstance.off('click');
+            severityChartInstance.on('click', params => {
+                if (!params || !params.name) return;
+                clearAllFilters(severityFilter);
+                toggleFilter(severityFilter, params.name);
+            });
+
+            highlightSeveritySlice(severityFilter.value);
+        }
+
+        function renderTreemapChart() {
+            const container = document.getElementById('treemapChart');
+            if (!container || typeof echarts === 'undefined') return;
+            const empty = container.parentElement ? container.parentElement.querySelector('.chart-empty') : null;
+            const entries = Object.entries(fileStats || {});
+            const isLight = document.body.classList.contains('light-theme');
+            const activeTreemapPath = (fileFilter && fileFilter.value) || (folderFilter && folderFilter.value) || '';
+            treemapEntries = entries;
+
+            if (!entries.length) {
+                if (empty) empty.style.display = 'block';
+                if (treemapChartInstance) {
+                    treemapChartInstance.dispose();
+                    treemapChartInstance = null;
+                }
+                return;
+            }
+
+            if (empty) empty.style.display = 'none';
+
+            const data = buildTreemapHierarchy(entries, activeTreemapPath, isLight);
+
+            if (treemapChartInstance) {
+                treemapChartInstance.dispose();
+            }
+
+            treemapChartInstance = echarts.init(container);
+            treemapChartInstance.setOption({
+                backgroundColor: 'transparent',
+                tooltip: {
+                    trigger: 'item',
+                    textStyle: { color: isLight ? '#1f2937' : '#f8fafc' },
+                    backgroundColor: isLight ? 'rgba(248, 250, 252, 0.95)' : 'rgba(11, 23, 42, 0.95)',
+                    borderColor: isLight ? '#d0d7e4' : '#1f2c4d',
+                    borderWidth: 1,
+                    formatter: info => {
+                        const data = info.data || {};
+                        const counts = data.severityCounts || {};
+                        const total = Object.values(counts).reduce((sum, value) => sum + value, 0);
+                        const severityLines = Object.entries(counts)
+                            .filter(([, value]) => value > 0)
+                            .sort((a, b) => (severityRank[b[0]] || 0) - (severityRank[a[0]] || 0))
+                            .map(([severity, value]) => `${severity}: ${value}`);
+                        const path = data.isFile ? data.fullPath : data.fullPath || data.name;
+                        const severity = data.severity || 'Unknown';
+                        const details = [
+                            `<strong>${path}</strong>`,
+                            `Severity: ${severity}`,
+                            `Total issues: ${total}`
+                        ];
+                        if (severityLines.length) {
+                            details.push(severityLines.join('<br/>'));
+                        }
+                        if (data.filterType === 'file') {
+                            details.push('Click to filter by file');
+                        } else if (data.filterType === 'folder') {
+                            details.push('Click to filter by folder');
+                        }
+                        return details.join('<br/>');
+                    }
+                },
+                series: [{
+                    type: 'treemap',
+                    data,
+                    roam: true,
+                    nodeClick: false,
+                    visibleMin: 1,
+                   label: {
+                        color: isLight ? '#1f2937' : '#f4f5f7',
+                        formatter: params => params.name
+                    },
+                    upperLabel: {
+                        show: true,
+                        color: isLight ? '#1f2937' : '#f4f5f7',
+                        height: 24
+                    },
+                    breadcrumb: {
+                        show: false
+                    },
+                    itemStyle: {
+                        borderColor: isLight ? '#d0d7e4' : '#0d1a33',
+                        borderWidth: 1,
+                        gapWidth: 2
+                    },
+                    levels: [
+                        {
+                            itemStyle: {
+                                borderWidth: 1,
+                                borderColor: isLight ? '#e2e8f0' : '#1f2c4d',
+                                gapWidth: 4
+                            }
+                        },
+                        {
+                            itemStyle: {
+                                borderWidth: 1,
+                                borderColor: isLight ? '#e2e8f0' : '#1f2c4d',
+                                gapWidth: 2
+                            }
+                        }
+                    ]
+                }]
+            });
+
+            treemapChartInstance.off('click');
+            treemapChartInstance.on('click', params => {
+                const dataPoint = params && params.data;
+                if (!dataPoint) return;
+                if (dataPoint.filterType === 'file' && dataPoint.filterValue) {
+                    clearAllFilters(fileFilter);
+                    toggleFilter(fileFilter, dataPoint.filterValue);
+                } else if (dataPoint.filterType === 'folder' && dataPoint.filterValue) {
+                    clearAllFilters(folderFilter);
+                    toggleFilter(folderFilter, dataPoint.filterValue);
+                }
+            });
+
+            highlightTreemapSelection(folderFilter.value, fileFilter.value);
+
+            resizeCharts();
+        }
+
+        function buildTreemapHierarchy(entries, activePath = '', isLightTheme = false) {
+            const root = { name: 'root', children: [] };
+
+            entries.forEach(([filePath, info]) => {
+                const parts = filePath.split(/[\\/]/).filter(Boolean);
+                if (!parts.length) return;
+                let current = root;
+                let accumulatedPath = '';
+
+                parts.forEach((part, index) => {
+                    accumulatedPath = accumulatedPath ? accumulatedPath + '/' + part : part;
+                    let child = (current.children || []).find(node => node.name === part);
+                    if (!child) {
+                        child = {
+                            name: part,
+                            id: accumulatedPath,
+                            children: [],
+                            severityCounts: {},
+                            severity: 'Unknown',
+                            value: 0,
+                            fullPath: accumulatedPath
+                        };
+                        child.filterType = 'folder';
+                        child.filterValue = accumulatedPath;
+                        current.children = current.children || [];
+                        current.children.push(child);
+                    } else if (child.filterType !== 'file') {
+                        child.filterType = 'folder';
+                        child.filterValue = accumulatedPath;
+                        child.fullPath = accumulatedPath;
+                    }
+
+                    if (index === parts.length - 1) {
+                        child.isFile = true;
+                        child.filterType = 'file';
+                        child.filterValue = filePath;
+                        child.fullPath = filePath;
+                        child.id = filePath;
+                        child.value = (info && typeof info.count === 'number') ? info.count : 0;
+                        const counts = Object.assign({}, (info && info.severityCounts) || {});
+                        child.severityCounts = counts;
+                        const declaredSeverity = info && info.maxSeverity;
+                        child.severity = declaredSeverity || deriveMaxSeverityFromCounts(counts);
+                    }
+
+                    current = child;
+                });
+            });
+
+            const finalizeNode = node => {
+                const isMatch = activePath && node.fullPath === activePath;
+                const baseBorder = isLightTheme ? '#d0d7e4' : '#0d1a33';
+                const highlightBorder = '#3b82f6';
+                if (node.children && node.children.length) {
+                    let total = 0;
+                    const counts = {};
+                    node.children.forEach(child => {
+                        finalizeNode(child);
+                        total += child.value || 0;
+                        const childCounts = child.severityCounts || {};
+                        Object.keys(childCounts).forEach(key => {
+                            counts[key] = (counts[key] || 0) + childCounts[key];
+                        });
+                    });
+                    node.value = total;
+                    node.severityCounts = counts;
+                    const derivedSeverity = deriveMaxSeverityFromCounts(counts);
+                    if (derivedSeverity) {
+                        node.severity = derivedSeverity;
+                    }
+                }
+
+                if (!node.severityCounts) {
+                    node.severityCounts = {};
+                }
+
+                const colorKey = node.severity && severityColors[node.severity] ? node.severity : 'Unknown';
+                node.itemStyle = node.itemStyle || {};
+                node.itemStyle.color = severityColors[colorKey] || severityColors.Unknown;
+                node.itemStyle.borderColor = isMatch ? highlightBorder : baseBorder;
+                node.itemStyle.borderWidth = isMatch ? 3 : 1;
+                node.emphasis = node.emphasis || {};
+                node.emphasis.itemStyle = Object.assign({}, node.emphasis.itemStyle, {
+                    borderColor: highlightBorder,
+                    borderWidth: 4
+                });
+            };
+
+            (root.children || []).forEach(finalizeNode);
+            return root.children || [];
+        }
+
+        function deriveMaxSeverityFromCounts(counts) {
+            if (!counts) return 'Unknown';
+            let maxSeverity = 'Unknown';
+            let maxRank = 0;
+            Object.entries(counts).forEach(([severity, value]) => {
+                if (!value) return;
+                const rank = severityRank[severity] || 0;
+                if (rank > maxRank) {
+                    maxRank = rank;
+                    maxSeverity = severity;
+                }
+            });
+            return maxSeverity;
+        }
+
+        function resizeCharts() {
+            if (severityChartInstance) {
+                severityChartInstance.resize();
+            }
+            if (cweChartInstance) {
+                cweChartInstance.resize();
+            }
+            if (treemapChartInstance) {
+                treemapChartInstance.resize();
+            }
+        }
+
+        window.addEventListener('resize', resizeCharts);
+
+        function renderCweChart() {
+            const container = document.getElementById('cweChart');
+            if (!container || typeof echarts === 'undefined') return;
+            const empty = container.parentElement ? container.parentElement.querySelector('.chart-empty') : null;
+            const entries = Object.entries(cweCounts)
+                .filter(([, value]) => value > 0)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 10);
+
+            if (!entries.length) {
+                if (empty) empty.style.display = 'block';
+                if (cweChartInstance) {
+                    cweChartInstance.dispose();
+                    cweChartInstance = null;
+                }
+                return;
+            }
+
+            if (empty) empty.style.display = 'none';
+
+            const labels = entries.map(([label]) => label);
+            const data = entries.map(([, value]) => value);
+
+            if (cweChartInstance) {
+                cweChartInstance.dispose();
+            }
+
+            cweChartInstance = echarts.init(container);
+            const isLight = document.body.classList.contains('light-theme');
+            cweChartInstance.setOption({
+                backgroundColor: 'transparent',
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: { type: 'shadow' }
+                },
+                grid: {
+                    left: '6%',
+                    right: '4%',
+                    bottom: '12%',
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    data: labels,
+                    axisLabel: {
+                        color: isLight ? '#1f2937' : '#e2e8f0',
+                        interval: 0,
+                        rotate: labels.length > 5 ? 30 : 0
+                    },
+                    axisLine: { lineStyle: { color: isLight ? 'rgba(100, 116, 139, 0.35)' : 'rgba(148, 163, 184, 0.35)' } },
+                    axisTick: { alignWithLabel: true }
+                },
+                yAxis: {
+                    type: 'value',
+                    minInterval: 1,
+                    axisLabel: { color: isLight ? '#1f2937' : '#e2e8f0' },
+                    axisLine: { lineStyle: { color: isLight ? 'rgba(100, 116, 139, 0.35)' : 'rgba(148, 163, 184, 0.35)' } },
+                    splitLine: { lineStyle: { color: isLight ? 'rgba(148, 163, 184, 0.25)' : 'rgba(148, 163, 184, 0.15)' } }
+                },
+                series: [{
+                    name: 'Findings',
+                    type: 'bar',
+                    barWidth: '55%',
+                    itemStyle: {
+                        color: isLight ? '#ea580c' : '#f97316',
+                        borderRadius: [6, 6, 0, 0]
+                    },
+                    data
+                }]
+            });
+
+            cweChartInstance.off('click');
+            cweChartInstance.on('click', params => {
+                if (!params || !params.name) return;
+                const value = params.name;
+                clearAllFilters(cweFilter);
+                toggleFilter(cweFilter, value);
+            });
+
+            highlightCweBar(cweFilter.value);
+        }
+
+    </script>
+</body>
+</html>

--- a/src/metis/cli/report_template.html
+++ b/src/metis/cli/report_template.html
@@ -92,7 +92,7 @@
             .chart-card .echart { min-height: 200px; }
         }
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js" integrity="sha384-o5uz97et3bErHvpKfD4Jz4n0JfhJDWABFuF4NP+iEEDxE1VwMWJ19QGR0lqFZnr6" crossorigin="anonymous"></script>
 </head>
 <body>
     <button id="modeToggle" class="mode-toggle" aria-label="Toggle color mode" title="Toggle color mode">&#9788;</button>

--- a/src/metis/cli/report_template.html
+++ b/src/metis/cli/report_template.html
@@ -125,7 +125,7 @@
         </div>
         <div class="chart-card" id="treemapCard">
             <h2>
-                File Treemap
+                Issues by File
                 <span class="chart-actions">
                     <button class="chart-button chart-toggle" data-chart="treemapChart" aria-label="Toggle full size" title="View full size">&#x26F6;</button>
                 </span>

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -240,7 +240,8 @@ def _coerce_to_string(value):
 
 def _build_html_document(issues, source_name):
     generated_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
-    title = f"Metis Security Report - {source_name}"
+    display_name = Path(source_name).stem if source_name else source_name
+    title = f"Metis Security Report - {display_name}"
     severity_counts = Counter()
     cwe_counts = Counter()
     severity_priority = {

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -77,7 +77,7 @@ def with_spinner(task_description, fn, *args, **kwargs):
     return result
 
 
-def save_output(output_files, data, quiet=False, sarif=False):
+def save_output(output_files, data, quiet=False):
     if not output_files:
         return
 
@@ -151,9 +151,7 @@ def save_output(output_files, data, quiet=False, sarif=False):
             continue
 
         # default to JSON
-        payload = generate_sarif(data) if sarif else json_payload
-        label = "SARIF results" if sarif else "Results"
-        _write_payload(output_path, payload, label)
+        _write_payload(output_path, json_payload, "Results")
 
 
 def _generate_html_report(output_path: Path, report_data, quiet=False):

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -1,9 +1,16 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import csv
 import json
+import html
 import logging
+import importlib.metadata
+import re
+from collections import Counter
+from datetime import datetime
 from pathlib import Path
+from importlib.resources import files
 
 from rich.console import Console
 from rich.markup import escape
@@ -11,7 +18,15 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from metis.sarif.writer import generate_sarif
 
+try:
+    METIS_VERSION = importlib.metadata.version('metis')
+except importlib.metadata.PackageNotFoundError:
+    METIS_VERSION = 'unknown'
+
+
 console = Console()
+logger = logging.getLogger("metis")
+REPORT_TEMPLATE = files("metis.cli").joinpath("report_template.html").read_text(encoding="utf-8")
 
 try:
     from metis.vector_store.pgvector_store import PGVectorStoreImpl
@@ -62,16 +77,244 @@ def with_spinner(task_description, fn, *args, **kwargs):
     return result
 
 
-def save_output(output_file, data, quiet=False, sarif=False):
+def save_output(output_files, data, quiet=False, sarif=False):
+    if not output_files:
+        return
 
-    dump_data = data
-    if sarif:
-        dump_data = generate_sarif(data)
+    if isinstance(output_files, (str, Path)):
+        files = [output_files]
+    else:
+        files = list(output_files)
+    json_payload = data
+    sarif_payload = None
 
-    if output_file:
-        with open(output_file, "w") as f:
-            json.dump(dump_data, f, indent=4)
-        print_console(f"[blue]Results saved to {escape(output_file)}[/blue]", quiet)
+    def _write_payload(path: Path, payload, label: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=4)
+        print_console(
+            f"[blue]{label} saved to {escape(str(path))}[/blue]",
+            quiet,
+        )
+
+    for file_entry in files:
+        output_path = Path(file_entry)
+        suffix = output_path.suffix.lower()
+
+        if suffix == ".html":
+            _generate_html_report(output_path, data, quiet)
+            continue
+
+        if suffix == ".sarif":
+            if sarif_payload is None:
+                sarif_payload = generate_sarif(data)
+            _write_payload(output_path, sarif_payload, "SARIF report")
+            continue
+
+        if suffix == ".csv":
+            try:
+                issues = _flatten_issues(data)
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                with output_path.open("w", encoding="utf-8", newline="") as csv_file:
+                    writer = csv.writer(csv_file)
+                    writer.writerow([
+                        "File",
+                        "Line",
+                        "Severity",
+                        "CWE",
+                        "Issue",
+                        "Reasoning",
+                        "Mitigation",
+                        "Confidence",
+                    ])
+                    for issue in issues:
+                        writer.writerow([
+                            issue.get("file", ""),
+                            issue.get("line", ""),
+                            issue.get("severity", ""),
+                            issue.get("cwe", ""),
+                            issue.get("issue", ""),
+                            issue.get("reasoning", ""),
+                            issue.get("mitigation", ""),
+                            issue.get("confidence", ""),
+                        ])
+                print_console(
+                    f"[blue]CSV report saved to {escape(str(output_path))}[/blue]",
+                    quiet,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to generate CSV report: %s", exc)
+                print_console(
+                    f"[red]Failed to generate CSV report at {escape(str(output_path))}[/red]",
+                    quiet,
+                )
+            continue
+
+        # default to JSON
+        payload = generate_sarif(data) if sarif else json_payload
+        label = "SARIF results" if sarif else "Results"
+        _write_payload(output_path, payload, label)
+
+
+def _generate_html_report(output_path: Path, report_data, quiet=False):
+    html_path = output_path.with_suffix(".html")
+    try:
+        issues = _flatten_issues(report_data)
+        html_path.parent.mkdir(parents=True, exist_ok=True)
+        document = _build_html_document(issues, output_path.name)
+        html_path.write_text(document, encoding="utf-8")
+        print_console(
+            f"[blue]HTML report saved to {escape(str(html_path))}[/blue]",
+            quiet,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to generate HTML report: %s", exc)
+        print_console("[red]Failed to generate HTML report.[/red]", quiet)
+
+
+def _flatten_issues(report_data):
+    issues = []
+    if not isinstance(report_data, dict):
+        return issues
+
+    reviews = report_data.get("reviews", [])
+    for file_entry in reviews:
+        file_name = file_entry.get("file") or file_entry.get("file_path") or "Unknown"
+        try:
+            file_name = str(file_name)
+        except Exception:  # pragma: no cover - defensive
+            file_name = "Unknown"
+
+        for issue in file_entry.get("reviews", []):
+            severity = issue.get("severity") or "Unknown"
+            if isinstance(severity, str):
+                severity = severity.strip() or "Unknown"
+            else:
+                severity = str(severity)
+
+            cwe = issue.get("cwe") or "CWE-Unknown"
+            if isinstance(cwe, (list, tuple)):
+                cwe = ", ".join(str(item) for item in cwe if item)
+            else:
+                cwe = str(cwe)
+
+            cwe_match = re.search(r"(\d+)", cwe)
+            cwe_link = (
+                f"https://cwe.mitre.org/data/definitions/{cwe_match.group(1)}.html"
+                if cwe_match
+                else ""
+            )
+
+            folder = file_name.split("/", 1)[0] if "/" in file_name else file_name
+            issues.append(
+                {
+                    "file": file_name,
+                    "line": str(issue.get("line_number") or ""),
+                    "severity": severity,
+                    "cwe": cwe,
+                    "cweLink": cwe_link,
+                    "issue": _coerce_to_string(issue.get("issue")),
+                    "reasoning": _coerce_to_string(issue.get("reasoning")),
+                    "mitigation": _coerce_to_string(issue.get("mitigation")),
+                    "confidence": _coerce_to_string(issue.get("confidence")),
+                    "snippet": _coerce_to_string(issue.get("code_snippet")),
+                    "folder": folder,
+                }
+            )
+
+    return issues
+
+
+def _coerce_to_string(value):
+    if value is None:
+        return ""
+    try:
+        return str(value)
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+def _build_html_document(issues, source_name):
+    generated_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    title = f"Metis Security Report - {source_name}"
+    severity_counts = Counter()
+    cwe_counts = Counter()
+    severity_priority = {
+        "Critical": 4,
+        "High": 3,
+        "Medium": 2,
+        "Low": 1,
+        "Unknown": 0,
+    }
+    file_stats: dict[str, dict[str, object]] = {}
+    folder_stats: dict[str, dict[str, object]] = {}
+    for issue in issues:
+        severity = issue.get("severity") or "Unknown"
+        cwe = issue.get("cwe") or "CWE-Unknown"
+        severity_counts[severity] += 1
+        cwe_counts[cwe] += 1
+
+        file_name = issue.get("file") or "Unknown"
+        folder_name = issue.get("folder") or (
+            file_name.split("/", 1)[0] if "/" in file_name else file_name
+        ) or "Unknown"
+        stats = file_stats.setdefault(
+            file_name,
+            {
+                "count": 0,
+                "severityCounts": Counter(),
+                "maxSeverity": "Unknown",
+            },
+        )
+        stats["count"] = int(stats["count"]) + 1
+        stats["severityCounts"][severity] += 1
+        current_max = stats["maxSeverity"]
+        if severity_priority.get(severity, 0) > severity_priority.get(current_max, 0):
+            stats["maxSeverity"] = severity
+
+        folder_entry = folder_stats.setdefault(
+            folder_name,
+            {
+                "count": 0,
+                "severityCounts": Counter(),
+            },
+        )
+        folder_entry["count"] = int(folder_entry["count"]) + 1
+        folder_entry["severityCounts"][severity] += 1
+
+    file_stats_serialized = {
+        file_name: {
+            "count": details["count"],
+            "severityCounts": dict(details["severityCounts"]),
+            "maxSeverity": details["maxSeverity"],
+        }
+        for file_name, details in file_stats.items()
+    }
+
+    folder_stats_serialized = {
+        folder_name: {
+            "count": details["count"],
+            "severityCounts": dict(details["severityCounts"]),
+        }
+        for folder_name, details in folder_stats.items()
+    }
+
+    payload = {
+        "issues": issues,
+        "severityCounts": dict(severity_counts),
+        "cweCounts": dict(cwe_counts),
+        "fileStats": file_stats_serialized,
+        "folderStats": folder_stats_serialized,
+    }
+    data_json = json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
+    template = REPORT_TEMPLATE
+    return (
+        template
+        .replace("__TITLE__", html.escape(title))
+        .replace("__GENERATED_AT__", html.escape(generated_at))
+        .replace("__DATA_JSON__", data_json)
+        .replace("__METIS_VERSION__", html.escape(METIS_VERSION))
+    )
 
 
 def check_file_exists(file_path, quiet=False):
@@ -107,7 +350,19 @@ def pretty_print_reviews(results, quiet=False):
                         quiet,
                     )
                 if r.get("cwe"):
-                    print_console(f"    [red]CWE:[/red] {r['cwe']}", quiet)
+                    cwe_text = str(r["cwe"])
+                    match = re.search(r"(\d+)", cwe_text)
+                    if match:
+                        cwe_url = f"https://cwe.mitre.org/data/definitions/{match.group(1)}.html"
+                        print_console(
+                            f"    [red]CWE:[/red] [link={cwe_url}]{escape(cwe_text)}[/link]",
+                            quiet,
+                        )
+                    else:
+                        print_console(
+                            f"    [red]CWE:[/red] {escape(cwe_text)}",
+                            quiet,
+                        )
                 if severity := r.get("severity"):
                     severity_color = {
                         "Low": "green",

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -101,7 +101,9 @@ def save_output(output_files, data, quiet=False):
 
         if suffix == ".html":
             try:
-                html_path = export_html(data, output_path, REPORT_TEMPLATE, METIS_VERSION)
+                html_path = export_html(
+                    data, output_path, REPORT_TEMPLATE, METIS_VERSION
+                )
                 print_console(
                     f"[blue]HTML report saved to {escape(str(html_path))}[/blue]",
                     quiet,

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -19,14 +19,16 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from metis.sarif.writer import generate_sarif
 
 try:
-    METIS_VERSION = importlib.metadata.version('metis')
+    METIS_VERSION = importlib.metadata.version("metis")
 except importlib.metadata.PackageNotFoundError:
-    METIS_VERSION = 'unknown'
+    METIS_VERSION = "unknown"
 
 
 console = Console()
 logger = logging.getLogger("metis")
-REPORT_TEMPLATE = files("metis.cli").joinpath("report_template.html").read_text(encoding="utf-8")
+REPORT_TEMPLATE = (
+    files("metis.cli").joinpath("report_template.html").read_text(encoding="utf-8")
+)
 
 try:
     from metis.vector_store.pgvector_store import PGVectorStoreImpl
@@ -117,27 +119,31 @@ def save_output(output_files, data, quiet=False):
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 with output_path.open("w", encoding="utf-8", newline="") as csv_file:
                     writer = csv.writer(csv_file)
-                    writer.writerow([
-                        "File",
-                        "Line",
-                        "Severity",
-                        "CWE",
-                        "Issue",
-                        "Reasoning",
-                        "Mitigation",
-                        "Confidence",
-                    ])
+                    writer.writerow(
+                        [
+                            "File",
+                            "Line",
+                            "Severity",
+                            "CWE",
+                            "Issue",
+                            "Reasoning",
+                            "Mitigation",
+                            "Confidence",
+                        ]
+                    )
                     for issue in issues:
-                        writer.writerow([
-                            issue.get("file", ""),
-                            issue.get("line", ""),
-                            issue.get("severity", ""),
-                            issue.get("cwe", ""),
-                            issue.get("issue", ""),
-                            issue.get("reasoning", ""),
-                            issue.get("mitigation", ""),
-                            issue.get("confidence", ""),
-                        ])
+                        writer.writerow(
+                            [
+                                issue.get("file", ""),
+                                issue.get("line", ""),
+                                issue.get("severity", ""),
+                                issue.get("cwe", ""),
+                                issue.get("issue", ""),
+                                issue.get("reasoning", ""),
+                                issue.get("mitigation", ""),
+                                issue.get("confidence", ""),
+                            ]
+                        )
                 print_console(
                     f"[blue]CSV report saved to {escape(str(output_path))}[/blue]",
                     quiet,
@@ -253,9 +259,11 @@ def _build_html_document(issues, source_name):
         cwe_counts[cwe] += 1
 
         file_name = issue.get("file") or "Unknown"
-        folder_name = issue.get("folder") or (
-            file_name.split("/", 1)[0] if "/" in file_name else file_name
-        ) or "Unknown"
+        folder_name = (
+            issue.get("folder")
+            or (file_name.split("/", 1)[0] if "/" in file_name else file_name)
+            or "Unknown"
+        )
         stats = file_stats.setdefault(
             file_name,
             {
@@ -307,8 +315,7 @@ def _build_html_document(issues, source_name):
     data_json = json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
     template = REPORT_TEMPLATE
     return (
-        template
-        .replace("__TITLE__", html.escape(title))
+        template.replace("__TITLE__", html.escape(title))
         .replace("__GENERATED_AT__", html.escape(generated_at))
         .replace("__DATA_JSON__", data_json)
         .replace("__METIS_VERSION__", html.escape(METIS_VERSION))

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -1,14 +1,10 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import csv
 import json
-import html
 import logging
 import importlib.metadata
 import re
-from collections import Counter
-from datetime import datetime
 from pathlib import Path
 from importlib.resources import files
 
@@ -16,7 +12,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
-from metis.sarif.writer import generate_sarif
+from .exporters import export_csv, export_html, export_sarif
 
 try:
     METIS_VERSION = importlib.metadata.version("metis")
@@ -104,48 +100,39 @@ def save_output(output_files, data, quiet=False):
         suffix = output_path.suffix.lower()
 
         if suffix == ".html":
-            _generate_html_report(output_path, data, quiet)
+            try:
+                html_path = export_html(data, output_path, REPORT_TEMPLATE, METIS_VERSION)
+                print_console(
+                    f"[blue]HTML report saved to {escape(str(html_path))}[/blue]",
+                    quiet,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to generate HTML report: %s", exc)
+                print_console("[red]Failed to generate HTML report.[/red]", quiet)
             continue
 
         if suffix == ".sarif":
-            if sarif_payload is None:
-                sarif_payload = generate_sarif(data)
-            _write_payload(output_path, sarif_payload, "SARIF report")
+            try:
+                sarif_path, sarif_payload = export_sarif(
+                    data, output_path, sarif_payload
+                )
+                print_console(
+                    f"[blue]SARIF report saved to {escape(str(sarif_path))}[/blue]",
+                    quiet,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to generate SARIF report: %s", exc)
+                print_console(
+                    f"[red]Failed to generate SARIF report at {escape(str(output_path))}[/red]",
+                    quiet,
+                )
             continue
 
         if suffix == ".csv":
             try:
-                issues = _flatten_issues(data)
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                with output_path.open("w", encoding="utf-8", newline="") as csv_file:
-                    writer = csv.writer(csv_file)
-                    writer.writerow(
-                        [
-                            "File",
-                            "Line",
-                            "Severity",
-                            "CWE",
-                            "Issue",
-                            "Reasoning",
-                            "Mitigation",
-                            "Confidence",
-                        ]
-                    )
-                    for issue in issues:
-                        writer.writerow(
-                            [
-                                issue.get("file", ""),
-                                issue.get("line", ""),
-                                issue.get("severity", ""),
-                                issue.get("cwe", ""),
-                                issue.get("issue", ""),
-                                issue.get("reasoning", ""),
-                                issue.get("mitigation", ""),
-                                issue.get("confidence", ""),
-                            ]
-                        )
+                csv_path = export_csv(data, output_path)
                 print_console(
-                    f"[blue]CSV report saved to {escape(str(output_path))}[/blue]",
+                    f"[blue]CSV report saved to {escape(str(csv_path))}[/blue]",
                     quiet,
                 )
             except Exception as exc:  # pragma: no cover - defensive
@@ -158,169 +145,6 @@ def save_output(output_files, data, quiet=False):
 
         # default to JSON
         _write_payload(output_path, json_payload, "Results")
-
-
-def _generate_html_report(output_path: Path, report_data, quiet=False):
-    html_path = output_path.with_suffix(".html")
-    try:
-        issues = _flatten_issues(report_data)
-        html_path.parent.mkdir(parents=True, exist_ok=True)
-        document = _build_html_document(issues, output_path.name)
-        html_path.write_text(document, encoding="utf-8")
-        print_console(
-            f"[blue]HTML report saved to {escape(str(html_path))}[/blue]",
-            quiet,
-        )
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Failed to generate HTML report: %s", exc)
-        print_console("[red]Failed to generate HTML report.[/red]", quiet)
-
-
-def _flatten_issues(report_data):
-    issues = []
-    if not isinstance(report_data, dict):
-        return issues
-
-    reviews = report_data.get("reviews", [])
-    for file_entry in reviews:
-        file_name = file_entry.get("file") or file_entry.get("file_path") or "Unknown"
-        try:
-            file_name = str(file_name)
-        except Exception:  # pragma: no cover - defensive
-            file_name = "Unknown"
-
-        for issue in file_entry.get("reviews", []):
-            severity = issue.get("severity") or "Unknown"
-            if isinstance(severity, str):
-                severity = severity.strip() or "Unknown"
-            else:
-                severity = str(severity)
-
-            cwe = issue.get("cwe") or "CWE-Unknown"
-            if isinstance(cwe, (list, tuple)):
-                cwe = ", ".join(str(item) for item in cwe if item)
-            else:
-                cwe = str(cwe)
-
-            cwe_match = re.search(r"(\d+)", cwe)
-            cwe_link = (
-                f"https://cwe.mitre.org/data/definitions/{cwe_match.group(1)}.html"
-                if cwe_match
-                else ""
-            )
-
-            folder = file_name.split("/", 1)[0] if "/" in file_name else file_name
-            issues.append(
-                {
-                    "file": file_name,
-                    "line": str(issue.get("line_number") or ""),
-                    "severity": severity,
-                    "cwe": cwe,
-                    "cweLink": cwe_link,
-                    "issue": _coerce_to_string(issue.get("issue")),
-                    "reasoning": _coerce_to_string(issue.get("reasoning")),
-                    "mitigation": _coerce_to_string(issue.get("mitigation")),
-                    "confidence": _coerce_to_string(issue.get("confidence")),
-                    "snippet": _coerce_to_string(issue.get("code_snippet")),
-                    "folder": folder,
-                }
-            )
-
-    return issues
-
-
-def _coerce_to_string(value):
-    if value is None:
-        return ""
-    try:
-        return str(value)
-    except Exception:  # pragma: no cover - defensive
-        return ""
-
-
-def _build_html_document(issues, source_name):
-    generated_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
-    display_name = Path(source_name).stem if source_name else source_name
-    title = f"Metis Security Report - {display_name}"
-    severity_counts = Counter()
-    cwe_counts = Counter()
-    severity_priority = {
-        "Critical": 4,
-        "High": 3,
-        "Medium": 2,
-        "Low": 1,
-        "Unknown": 0,
-    }
-    file_stats: dict[str, dict[str, object]] = {}
-    folder_stats: dict[str, dict[str, object]] = {}
-    for issue in issues:
-        severity = issue.get("severity") or "Unknown"
-        cwe = issue.get("cwe") or "CWE-Unknown"
-        severity_counts[severity] += 1
-        cwe_counts[cwe] += 1
-
-        file_name = issue.get("file") or "Unknown"
-        folder_name = (
-            issue.get("folder")
-            or (file_name.split("/", 1)[0] if "/" in file_name else file_name)
-            or "Unknown"
-        )
-        stats = file_stats.setdefault(
-            file_name,
-            {
-                "count": 0,
-                "severityCounts": Counter(),
-                "maxSeverity": "Unknown",
-            },
-        )
-        stats["count"] = int(stats["count"]) + 1
-        stats["severityCounts"][severity] += 1
-        current_max = stats["maxSeverity"]
-        if severity_priority.get(severity, 0) > severity_priority.get(current_max, 0):
-            stats["maxSeverity"] = severity
-
-        folder_entry = folder_stats.setdefault(
-            folder_name,
-            {
-                "count": 0,
-                "severityCounts": Counter(),
-            },
-        )
-        folder_entry["count"] = int(folder_entry["count"]) + 1
-        folder_entry["severityCounts"][severity] += 1
-
-    file_stats_serialized = {
-        file_name: {
-            "count": details["count"],
-            "severityCounts": dict(details["severityCounts"]),
-            "maxSeverity": details["maxSeverity"],
-        }
-        for file_name, details in file_stats.items()
-    }
-
-    folder_stats_serialized = {
-        folder_name: {
-            "count": details["count"],
-            "severityCounts": dict(details["severityCounts"]),
-        }
-        for folder_name, details in folder_stats.items()
-    }
-
-    payload = {
-        "issues": issues,
-        "severityCounts": dict(severity_counts),
-        "cweCounts": dict(cwe_counts),
-        "fileStats": file_stats_serialized,
-        "folderStats": folder_stats_serialized,
-    }
-    data_json = json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
-    template = REPORT_TEMPLATE
-    return (
-        template.replace("__TITLE__", html.escape(title))
-        .replace("__GENERATED_AT__", html.escape(generated_at))
-        .replace("__DATA_JSON__", data_json)
-        .replace("__METIS_VERSION__", html.escape(METIS_VERSION))
-    )
 
 
 def check_file_exists(file_path, quiet=False):


### PR DESCRIPTION
This extension adds the following:
- Ability to create a HTML and CSV report showing issues identified in a scan
- A new command flag "--output-files" which allows for multiple output files to be generated per run
- Removed --sarif flag, this is implied by the file extension