### PR TITLE
fix(ollama): add default api_key for ollama langchain

### DIFF
--- a/src/metis/providers/ollama.py
+++ b/src/metis/providers/ollama.py
@@ -26,7 +26,10 @@ class OllamaProvider(OpenAICompatibleProvider):
             logger.debug("Force-enabling OpenAI-like mode for Ollama provider")
             self.config["force_openai_like"] = True
         if not config.get("llm_api_key"):
-            logger.warning("Langchain Ollama integration requires an non-empty api_key, using a default.")
+            logger.warning(
+                "Langchain Ollama integration requires an non-empty api_key, using a default."
+            )
             self.api_key = "default-key"
+
 
 register_provider("ollama", OllamaProvider)


### PR DESCRIPTION
Installing metis in a new project and running review_code may result in errors like:
`Unable to create review runnable; OpenAI-based provider required.`

After some research, found that langchain (used by the ollama), requires a non-empty api_key with any value.

Non working metis.yaml
```
llm_provider:
  name: "ollama"
  model: "phi3"
  code_embedding_model: "all-minilm"
  docs_embedding_model: "all-minilm"
  # api_key = "1234a"
```

The change adds a warning and add an api_key="default-key"

2025-11-28 17:42:41,799 - WARNING - Langchain Ollama integration requires an non-empty api_key, using a default.

