### PR TITLE
fix(plugin): added restrictive prompt definitions for the return type

### DIFF
--- a/src/metis/plugins/plugins.yaml
+++ b/src/metis/plugins/plugins.yaml
@@ -14,10 +14,12 @@ general_prompts:
     FILE: {file_path}
   security_review_report: |-
     3. How to Report
-        - List all identified security issues in a JSON array.
+        - Return a JSON object with a single key "reviews" mapping to a list of identified security issues.
         - Each element must strictly follow this structure:
           [[REVIEW_SCHEMA_FIELDS]]
-        - IMPORTANT: If no identified security issues are found, return: {\"reviews\": []}
+        - If no identified security issues are found, return: {\"reviews\": []}
+        - If no CWE identified, does not guess a number.
+        - Ensure the json is valid, without any additional commentary or text outside the json structure.
 
 plugins:
   c:


### PR DESCRIPTION
FIX: Added restrictive prompt definitions for the return type.

Depending on the engine or model, the LLM may add footnotes to the output and sometimes include comments on CWE lines, which can make the JSON invalid.

**Code analyzed (python):**
```
def do_nasty_things(senha:str):
    print(senha)

if __name__ == "__main__":
    PASSWORD = "secret password"
    do_nasty_things(PASSWORD)
```


**Example of incorrect output:**
```
2025-12-04 20:05:44,436 - WARNING - LLM fallback returned non-JSON response: {
  "reviews": []
}


No identified security issues were found within the provided source code snippet based on the given context and changes. The file appears not to contain any 
hardcoded secrets, insecure use of libraries that could lead directly to known vulnerabilities (such as those listed in OWASP Top 10), or other common sources for 
immediate concern regarding its current state.

The script is a simple demonstration with no apparent malicious intent; it reads data from an external table and displays part of the dataset. The hardcoded 
password within this context seems benign, but it's worth noting that best practices dictate avoiding such patterns in production code due to security concerns 
related to secret management as mentioned earlier.
```

**After the fix:**
```
File: dabtest/main.py
 Identified issue 1: Hardcoded sensitive data
    Snippet: "PASSWORD = "secret password""
    Line number: 26
    CWE: CWE-287
    Severity: High
    Why: The hardcoded password is a significant security risk as it can be easily extracted from the source code, leading to unauthorized access.
    Mitigation: Use environment variables or secret management systems like HashiCorp Vault for storing sensitive data. Avoid embedding secrets directly in the 
application code.
    Confidence: 1.0
```

I'll keep reviewing the prompt structure to check any inconsistencies.