### PR TITLE
fix: Save output to file for ask command in non-interactive mode

### DIFF
--- a/src/metis/cli/commands.py
+++ b/src/metis/cli/commands.py
@@ -126,7 +126,7 @@ def run_update(engine, patch_file, args):
     print_console("[green]Index update completed.[/green]", args.quiet)
 
 
-def run_ask(engine, question):
+def run_ask(engine, question, args):
     answer = with_spinner("Thinking...", engine.ask_question, question)
     print_console("[bold magenta]Metis Answer:[/bold magenta]\n")
     if isinstance(answer, dict):
@@ -140,3 +140,4 @@ def run_ask(engine, question):
             )
     else:
         print_console(escape(str(answer)))
+    save_output(args.output_file, answer, args.quiet)

--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -108,7 +108,7 @@ def execute_command(engine, cmd, cmd_args, args):
     if cmd in ("review_patch", "review_file", "update"):
         func(engine, cmd_args[0], args)
     elif cmd == "ask":
-        func(engine, " ".join(cmd_args))
+        func(engine, " ".join(cmd_args), args)
     elif cmd == "index":
         func(engine, args.verbose, args.quiet)
     elif cmd == "review_code":


### PR DESCRIPTION
Fixes #95

Passes pre-commit and tests.

Tested with `--output-file 'results/ask.json' --non-interactive --command 'ask do you work?'`.