### PR TITLE
fix: resolve review_code chroma init race

### DIFF
--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -5,6 +5,7 @@ import logging
 import os
 import unidiff
 import pathspec
+from threading import Lock
 
 from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
 from llama_index.core.node_parser import SentenceSplitter
@@ -94,6 +95,7 @@ class MetisEngine:
         self._ask_graph = None
         self._qe_code = None
         self._qe_docs = None
+        self._qe_init_lock = Lock()
         self.metisignore_file = kwargs.get("metisignore_file") or ".metisignore"
         self.review_code_include_paths = kwargs.get("review_code_include_paths", [])
         self.review_code_exclude_paths = kwargs.get("review_code_exclude_paths", [])
@@ -557,23 +559,25 @@ class MetisEngine:
         logger.info("Index update complete based on the provided patch diff.")
 
     def _init_and_get_query_engines(self):
-        if self._qe_code is not None and self._qe_docs is not None:
-            return self._qe_code, self._qe_docs
-        self.vector_backend.init()
-        qe_code, qe_docs = self.vector_backend.get_query_engines(
-            self.llm_provider,
-            self.similarity_top_k,
-            self.response_mode,
-        )
-        if not qe_code or not qe_docs:
-            raise QueryEngineInitError()
-        self._qe_code = qe_code
-        self._qe_docs = qe_docs
-        return qe_code, qe_docs
+        with self._qe_init_lock:
+            if self._qe_code is not None and self._qe_docs is not None:
+                return self._qe_code, self._qe_docs
+            self.vector_backend.init()
+            qe_code, qe_docs = self.vector_backend.get_query_engines(
+                self.llm_provider,
+                self.similarity_top_k,
+                self.response_mode,
+            )
+            if not qe_code or not qe_docs:
+                raise QueryEngineInitError()
+            self._qe_code = qe_code
+            self._qe_docs = qe_docs
+            return qe_code, qe_docs
 
     def close(self):
-        self._qe_code = None
-        self._qe_docs = None
-        close_fn = getattr(self.vector_backend, "close", None)
-        if callable(close_fn):
-            close_fn()
+        with self._qe_init_lock:
+            self._qe_code = None
+            self._qe_docs = None
+            close_fn = getattr(self.vector_backend, "close", None)
+            if callable(close_fn):
+                close_fn()

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -5,7 +5,7 @@ import logging
 import os
 import unidiff
 import pathspec
-from threading import Lock
+from threading import Lock, Condition
 
 from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
 from llama_index.core.node_parser import SentenceSplitter
@@ -96,6 +96,9 @@ class MetisEngine:
         self._qe_code = None
         self._qe_docs = None
         self._qe_init_lock = Lock()
+        self._qe_close_condition = Condition(self._qe_init_lock)
+        self._qe_close_in_progress = False
+        self._qe_init_in_progress = False
         self.metisignore_file = kwargs.get("metisignore_file") or ".metisignore"
         self.review_code_include_paths = kwargs.get("review_code_include_paths", [])
         self.review_code_exclude_paths = kwargs.get("review_code_exclude_paths", [])
@@ -559,9 +562,18 @@ class MetisEngine:
         logger.info("Index update complete based on the provided patch diff.")
 
     def _init_and_get_query_engines(self):
-        with self._qe_init_lock:
-            if self._qe_code is not None and self._qe_docs is not None:
-                return self._qe_code, self._qe_docs
+        while True:
+            with self._qe_close_condition:
+                while self._qe_close_in_progress:
+                    self._qe_close_condition.wait()
+                if self._qe_code is not None and self._qe_docs is not None:
+                    return self._qe_code, self._qe_docs
+                if self._qe_init_in_progress:
+                    self._qe_close_condition.wait()
+                    continue
+                self._qe_init_in_progress = True
+                break
+        try:
             self.vector_backend.init()
             qe_code, qe_docs = self.vector_backend.get_query_engines(
                 self.llm_provider,
@@ -570,14 +582,32 @@ class MetisEngine:
             )
             if not qe_code or not qe_docs:
                 raise QueryEngineInitError()
+        except BaseException:
+            with self._qe_close_condition:
+                self._qe_init_in_progress = False
+                self._qe_close_condition.notify_all()
+            raise
+
+        with self._qe_close_condition:
             self._qe_code = qe_code
             self._qe_docs = qe_docs
+            self._qe_init_in_progress = False
+            self._qe_close_condition.notify_all()
             return qe_code, qe_docs
 
     def close(self):
-        with self._qe_init_lock:
-            self._qe_code = None
-            self._qe_docs = None
-            close_fn = getattr(self.vector_backend, "close", None)
+        try:
+            with self._qe_close_condition:
+                while self._qe_close_in_progress or self._qe_init_in_progress:
+                    self._qe_close_condition.wait()
+                self._qe_close_in_progress = True
+                self._qe_code = None
+                self._qe_docs = None
+                close_fn = getattr(self.vector_backend, "close", None)
             if callable(close_fn):
                 close_fn()
+        finally:
+            with self._qe_close_condition:
+                if self._qe_close_in_progress:
+                    self._qe_close_in_progress = False
+                    self._qe_close_condition.notify_all()

--- a/src/metis/vector_store/chroma_store.py
+++ b/src/metis/vector_store/chroma_store.py
@@ -24,7 +24,9 @@ class ChromaStore(BaseVectorStore):
         self._initialized = False
         self._init_lock = Lock()
 
-    def _clear_state(self):
+    def _detach_state(self, client=None):
+        # Drop shared state under _init_lock so other threads can re-init immediately.
+        detached_client = self._client if client is None else client
         self._client = None
         self._initialized = False
         for attr in (
@@ -35,16 +37,35 @@ class ChromaStore(BaseVectorStore):
         ):
             if hasattr(self, attr):
                 delattr(self, attr)
+        return detached_client
 
     def _stop_client(self, client):
+        # Chroma shutdown can block; callers decide whether lock must be held.
         if client is None:
             return
         try:
-            client._system.stop()
+            close_fn = getattr(client, "close", None)
+            if callable(close_fn):
+                # close() is refcount-aware for shared PersistentClient systems.
+                close_fn()
+                return
+            stop_fn = getattr(getattr(client, "_system", None), "stop", None)
+            if callable(stop_fn):
+                stop_fn()
         except Exception as e:
             logger.warning(f"Error closing ChromaStore: {e}")
 
+    def _stop_client_legacy_path_under_lock(self, client):
+        # client._system.stop() is not refcount-aware on older chromadb clients.
+        close_fn = getattr(client, "close", None)
+        if callable(close_fn):
+            return client
+        self._stop_client(client)
+        return None
+
     def init(self):
+        client_to_stop = None
+        init_error = None
         with self._init_lock:
             if self._initialized:
                 return
@@ -76,9 +97,16 @@ class ChromaStore(BaseVectorStore):
 
             except Exception as e:
                 logger.error(f"Error initializing ChromaStore: {e}")
-                self._stop_client(client)
-                self._clear_state()
-                raise VectorStoreInitError() from e
+                client_to_stop = self._detach_state(client)
+                if client_to_stop is not None:
+                    client_to_stop = self._stop_client_legacy_path_under_lock(
+                        client_to_stop
+                    )
+                init_error = e
+
+        self._stop_client(client_to_stop)
+        if init_error is not None:
+            raise VectorStoreInitError() from init_error
 
     def get_query_engines(
         self, llm_provider, similarity_top_k=None, response_mode=None
@@ -117,6 +145,8 @@ class ChromaStore(BaseVectorStore):
 
     def close(self):
         with self._init_lock:
-            client = self._client
-            self._clear_state()
-            self._stop_client(client)
+            client = self._detach_state()
+            if client is not None:
+                client = self._stop_client_legacy_path_under_lock(client)
+
+        self._stop_client(client)

--- a/src/metis/vector_store/chroma_store.py
+++ b/src/metis/vector_store/chroma_store.py
@@ -7,6 +7,7 @@ from chromadb import PersistentClient
 from metis.exceptions import VectorStoreInitError, QueryEngineInitError
 from metis.vector_store.base import BaseVectorStore, QueryEngineRetriever
 from chromadb.config import Settings
+from threading import Lock
 
 import logging
 
@@ -21,38 +22,63 @@ class ChromaStore(BaseVectorStore):
         self.query_config = query_config
         self._client = None
         self._initialized = False
+        self._init_lock = Lock()
 
-    def init(self):
-        if self._initialized:
+    def _clear_state(self):
+        self._client = None
+        self._initialized = False
+        for attr in (
+            "vector_store_code",
+            "vector_store_docs",
+            "storage_context_code",
+            "storage_context_docs",
+        ):
+            if hasattr(self, attr):
+                delattr(self, attr)
+
+    def _stop_client(self, client):
+        if client is None:
             return
         try:
-            client = PersistentClient(
-                path=self.persist_dir, settings=Settings(anonymized_telemetry=False)
-            )
-            code_collection = client.get_or_create_collection("code")
-            docs_collection = client.get_or_create_collection("docs")
-
-            self.vector_store_code = ChromaVectorStore(
-                chroma_collection=code_collection,
-                embed_model=self.embed_model_code,
-            )
-            self.vector_store_docs = ChromaVectorStore(
-                chroma_collection=docs_collection,
-                embed_model=self.embed_model_docs,
-            )
-            self.storage_context_code = StorageContext.from_defaults(
-                vector_store=self.vector_store_code
-            )
-            self.storage_context_docs = StorageContext.from_defaults(
-                vector_store=self.vector_store_docs
-            )
-            self._client = client
-            self._initialized = True
-            logger.info("Chroma vector components initialized.")
-
+            client._system.stop()
         except Exception as e:
-            logger.error(f"Error initializing ChromaStore: {e}")
-            raise VectorStoreInitError()
+            logger.warning(f"Error closing ChromaStore: {e}")
+
+    def init(self):
+        with self._init_lock:
+            if self._initialized:
+                return
+            client = None
+            try:
+                client = PersistentClient(
+                    path=self.persist_dir, settings=Settings(anonymized_telemetry=False)
+                )
+                code_collection = client.get_or_create_collection("code")
+                docs_collection = client.get_or_create_collection("docs")
+
+                self.vector_store_code = ChromaVectorStore(
+                    chroma_collection=code_collection,
+                    embed_model=self.embed_model_code,
+                )
+                self.vector_store_docs = ChromaVectorStore(
+                    chroma_collection=docs_collection,
+                    embed_model=self.embed_model_docs,
+                )
+                self.storage_context_code = StorageContext.from_defaults(
+                    vector_store=self.vector_store_code
+                )
+                self.storage_context_docs = StorageContext.from_defaults(
+                    vector_store=self.vector_store_docs
+                )
+                self._client = client
+                self._initialized = True
+                logger.info("Chroma vector components initialized.")
+
+            except Exception as e:
+                logger.error(f"Error initializing ChromaStore: {e}")
+                self._stop_client(client)
+                self._clear_state()
+                raise VectorStoreInitError() from e
 
     def get_query_engines(
         self, llm_provider, similarity_top_k=None, response_mode=None
@@ -90,19 +116,7 @@ class ChromaStore(BaseVectorStore):
         return self.storage_context_code, self.storage_context_docs
 
     def close(self):
-        client = self._client
-        if client is not None:
-            try:
-                client._system.stop()
-            except Exception as e:
-                logger.warning(f"Error closing ChromaStore: {e}")
-        self._client = None
-        self._initialized = False
-        for attr in (
-            "vector_store_code",
-            "vector_store_docs",
-            "storage_context_code",
-            "storage_context_docs",
-        ):
-            if hasattr(self, attr):
-                delattr(self, attr)
+        with self._init_lock:
+            client = self._client
+            self._clear_state()
+            self._stop_client(client)

--- a/src/metis/vector_store/pgvector_store.py
+++ b/src/metis/vector_store/pgvector_store.py
@@ -38,10 +38,25 @@ class PGVectorStoreImpl(BaseVectorStore):
         self._initialized = False
         self._init_lock = Lock()
 
-    def _cleanup_vector_components(self):
+    def _detach_vector_components(self):
+        # Detach shared store/context refs while holding _init_lock.
         self._initialized = False
+        detached_stores = []
         for attr in ("vector_store_code", "vector_store_docs"):
             store = getattr(self, attr, None)
+            if store is not None:
+                detached_stores.append((attr, store))
+            if hasattr(self, attr):
+                delattr(self, attr)
+        for attr in ("storage_context_code", "storage_context_docs"):
+            if hasattr(self, attr):
+                delattr(self, attr)
+        return detached_stores
+
+    def _dispose_vector_components(self, detached_stores):
+        # Disposal may block on I/O, so it runs after lock-protected detachment.
+        disposed_engines = set()
+        for attr, store in detached_stores:
             if store is None:
                 continue
             close_fn = getattr(store, "close", None)
@@ -52,6 +67,12 @@ class PGVectorStoreImpl(BaseVectorStore):
                     logger.warning(f"Error closing PG vector store '{attr}': {e}")
             for engine_attr in ("_engine", "engine"):
                 candidate_engine = getattr(store, engine_attr, None)
+                if candidate_engine is None:
+                    continue
+                engine_id = id(candidate_engine)
+                if engine_id in disposed_engines:
+                    continue
+                disposed_engines.add(engine_id)
                 dispose_fn = getattr(candidate_engine, "dispose", None)
                 if callable(dispose_fn):
                     try:
@@ -60,13 +81,10 @@ class PGVectorStoreImpl(BaseVectorStore):
                         logger.warning(
                             f"Error disposing engine for PG vector store '{attr}': {e}"
                         )
-            if hasattr(self, attr):
-                delattr(self, attr)
-        for attr in ("storage_context_code", "storage_context_docs"):
-            if hasattr(self, attr):
-                delattr(self, attr)
 
     def init(self):
+        detached_stores = []
+        init_error = None
         with self._init_lock:
             if self._initialized:
                 return
@@ -109,8 +127,12 @@ class PGVectorStoreImpl(BaseVectorStore):
 
             except Exception as e:
                 logger.error(f"Error initializing PGVectorStore: {e}")
-                self._cleanup_vector_components()
-                raise VectorStoreInitError() from e
+                detached_stores = self._detach_vector_components()
+                init_error = e
+
+        self._dispose_vector_components(detached_stores)
+        if init_error is not None:
+            raise VectorStoreInitError() from init_error
 
     def get_query_engines(self, llm_provider, similarity_top_k, response_mode):
         try:
@@ -172,4 +194,6 @@ class PGVectorStoreImpl(BaseVectorStore):
 
     def close(self):
         with self._init_lock:
-            self._cleanup_vector_components()
+            detached_stores = self._detach_vector_components()
+
+        self._dispose_vector_components(detached_stores)

--- a/src/metis/vector_store/pgvector_store.py
+++ b/src/metis/vector_store/pgvector_store.py
@@ -11,6 +11,7 @@ from metis.exceptions import (
 from metis.vector_store.base import BaseVectorStore, QueryEngineRetriever
 from llama_index.vector_stores.postgres import PGVectorStore
 from sqlalchemy.engine.url import make_url
+from threading import Lock
 
 
 import logging
@@ -35,50 +36,81 @@ class PGVectorStoreImpl(BaseVectorStore):
         self.embed_dim = embed_dim
         self.hnsw_kwargs = hnsw_kwargs or {}
         self._initialized = False
+        self._init_lock = Lock()
+
+    def _cleanup_vector_components(self):
+        self._initialized = False
+        for attr in ("vector_store_code", "vector_store_docs"):
+            store = getattr(self, attr, None)
+            if store is None:
+                continue
+            close_fn = getattr(store, "close", None)
+            if callable(close_fn):
+                try:
+                    close_fn()
+                except Exception as e:
+                    logger.warning(f"Error closing PG vector store '{attr}': {e}")
+            for engine_attr in ("_engine", "engine"):
+                candidate_engine = getattr(store, engine_attr, None)
+                dispose_fn = getattr(candidate_engine, "dispose", None)
+                if callable(dispose_fn):
+                    try:
+                        dispose_fn()
+                    except Exception as e:
+                        logger.warning(
+                            f"Error disposing engine for PG vector store '{attr}': {e}"
+                        )
+            if hasattr(self, attr):
+                delattr(self, attr)
+        for attr in ("storage_context_code", "storage_context_docs"):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
     def init(self):
-        if self._initialized:
-            return
-        try:
-            url = make_url(self.connection_string)
-            db_name = url.database
+        with self._init_lock:
+            if self._initialized:
+                return
+            try:
+                url = make_url(self.connection_string)
+                db_name = url.database
 
-            self.vector_store_code = PGVectorStore.from_params(
-                database=db_name,
-                host=url.host,
-                password=url.password,
-                port=url.port,
-                user=url.username,
-                table_name="code",
-                schema_name=self.project_schema,
-                embed_dim=self.embed_dim,
-                hnsw_kwargs=self.hnsw_kwargs.copy(),
-            )
-            self.vector_store_docs = PGVectorStore.from_params(
-                database=db_name,
-                host=url.host,
-                password=url.password,
-                port=url.port,
-                user=url.username,
-                table_name="docs",
-                schema_name=self.project_schema,
-                embed_dim=self.embed_dim,
-                hnsw_kwargs=self.hnsw_kwargs.copy(),
-            )
+                self.vector_store_code = PGVectorStore.from_params(
+                    database=db_name,
+                    host=url.host,
+                    password=url.password,
+                    port=url.port,
+                    user=url.username,
+                    table_name="code",
+                    schema_name=self.project_schema,
+                    embed_dim=self.embed_dim,
+                    hnsw_kwargs=self.hnsw_kwargs.copy(),
+                )
+                self.vector_store_docs = PGVectorStore.from_params(
+                    database=db_name,
+                    host=url.host,
+                    password=url.password,
+                    port=url.port,
+                    user=url.username,
+                    table_name="docs",
+                    schema_name=self.project_schema,
+                    embed_dim=self.embed_dim,
+                    hnsw_kwargs=self.hnsw_kwargs.copy(),
+                )
 
-            self.storage_context_code = StorageContext.from_defaults(
-                vector_store=self.vector_store_code
-            )
-            self.storage_context_docs = StorageContext.from_defaults(
-                vector_store=self.vector_store_docs
-            )
+                self.storage_context_code = StorageContext.from_defaults(
+                    vector_store=self.vector_store_code
+                )
+                self.storage_context_docs = StorageContext.from_defaults(
+                    vector_store=self.vector_store_docs
+                )
 
-            self._initialized = True
-            logger.info("Postgres vector components initialized.")
+                self._initialized = True
+                logger.info("Postgres vector components initialized.")
 
-        except Exception as e:
-            logger.error(f"Error initializing PGVectorStore: {e}")
-            raise VectorStoreInitError()
+            except Exception as e:
+                logger.error(f"Error initializing PGVectorStore: {e}")
+                self._cleanup_vector_components()
+                raise VectorStoreInitError() from e
 
     def get_query_engines(self, llm_provider, similarity_top_k, response_mode):
         try:
@@ -139,29 +171,5 @@ class PGVectorStoreImpl(BaseVectorStore):
                 engine.dispose()
 
     def close(self):
-        self._initialized = False
-        for attr in ("vector_store_code", "vector_store_docs"):
-            store = getattr(self, attr, None)
-            if store is None:
-                continue
-            close_fn = getattr(store, "close", None)
-            if callable(close_fn):
-                try:
-                    close_fn()
-                except Exception as e:
-                    logger.warning(f"Error closing PG vector store '{attr}': {e}")
-            for engine_attr in ("_engine", "engine"):
-                candidate_engine = getattr(store, engine_attr, None)
-                dispose_fn = getattr(candidate_engine, "dispose", None)
-                if callable(dispose_fn):
-                    try:
-                        dispose_fn()
-                    except Exception as e:
-                        logger.warning(
-                            f"Error disposing engine for PG vector store '{attr}': {e}"
-                        )
-            if hasattr(self, attr):
-                delattr(self, attr)
-        for attr in ("storage_context_code", "storage_context_docs"):
-            if hasattr(self, attr):
-                delattr(self, attr)
+        with self._init_lock:
+            self._cleanup_vector_components()

--- a/tests/test_engine_chroma.py
+++ b/tests/test_engine_chroma.py
@@ -13,9 +13,10 @@ from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 
 
 @pytest.mark.chroma
-def test_chroma_backend_indexing(tmp_path):
-    original_embed_model = getattr(Settings, "_embed_model", None)
-    Settings.embed_model = MockEmbedding(embed_dim=8)
+def test_chroma_backend_indexing(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        Settings, "_embed_model", MockEmbedding(embed_dim=8), raising=False
+    )
 
     chroma_dir = tmp_path / "chroma_test"
     os.makedirs(chroma_dir, exist_ok=True)
@@ -54,10 +55,12 @@ def test_chroma_backend_indexing(tmp_path):
         **runtime,
     )
 
-    try:
-        engine.index_codebase()
-    finally:
-        Settings._embed_model = original_embed_model
+    engine.index_codebase()
+    assert backend._initialized is True
+    code_ctx, docs_ctx = backend.get_storage_contexts()
+    assert code_ctx is not None
+    assert docs_ctx is not None
+    engine.close()
 
 
 @pytest.mark.chroma
@@ -75,6 +78,7 @@ def test_chroma_store_init_is_thread_safe_and_reinitializable(monkeypatch, tmp_p
             del path, settings
             nonlocal client_init_calls
             client_init_calls += 1
+            self.close = Mock()
             self._system = Mock(stop=Mock())
             if client_init_calls == 1:
                 init_started.set()
@@ -142,7 +146,7 @@ def test_chroma_store_init_is_thread_safe_and_reinitializable(monkeypatch, tmp_p
 
     first_client = store._client
     store.close()
-    assert first_client._system.stop.call_count == 1
+    assert first_client.close.call_count == 1
     assert store._initialized is False
     assert not hasattr(store, "vector_store_code")
     assert not hasattr(store, "vector_store_docs")
@@ -169,6 +173,7 @@ def test_chroma_store_init_failure_is_retryable(monkeypatch, tmp_path):
             del path, settings
             nonlocal client_init_calls
             client_init_calls += 1
+            self.close = Mock()
             self._system = Mock(stop=Mock())
             client_instances.append(self)
 
@@ -208,7 +213,7 @@ def test_chroma_store_init_failure_is_retryable(monkeypatch, tmp_path):
         store.init()
     assert client_init_calls == 1
     assert len(client_instances) == 1
-    assert client_instances[0]._system.stop.call_count == 1
+    assert client_instances[0].close.call_count == 1
     assert store._initialized is False
     assert store._client is None
     assert not hasattr(store, "vector_store_code")
@@ -221,3 +226,318 @@ def test_chroma_store_init_failure_is_retryable(monkeypatch, tmp_path):
     assert vector_store_inits == 2
     assert storage_context_inits == 2
     assert store._initialized is True
+
+
+@pytest.mark.chroma
+def test_chroma_store_close_handles_client_close_error(tmp_path):
+    close_mock = Mock(side_effect=RuntimeError("close failed"))
+    client = Mock()
+    client.close = close_mock
+    store = ChromaStore(
+        persist_dir=str(tmp_path / "chroma-test"),
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        query_config={},
+    )
+    store._client = client
+    store._initialized = True
+    store.vector_store_code = object()
+    store.vector_store_docs = object()
+    store.storage_context_code = object()
+    store.storage_context_docs = object()
+
+    store.close()
+
+    assert close_mock.call_count == 1
+    assert store._initialized is False
+    assert store._client is None
+    assert not hasattr(store, "vector_store_code")
+    assert not hasattr(store, "vector_store_docs")
+    assert not hasattr(store, "storage_context_code")
+    assert not hasattr(store, "storage_context_docs")
+
+
+@pytest.mark.chroma
+def test_chroma_store_prefers_client_close_over_system_stop(tmp_path):
+    close_mock = Mock()
+    stop_mock = Mock()
+    client = Mock()
+    client.close = close_mock
+    client._system = Mock(stop=stop_mock)
+    store = ChromaStore(
+        persist_dir=str(tmp_path / "chroma-test"),
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        query_config={},
+    )
+
+    store._stop_client(client)
+
+    assert close_mock.call_count == 1
+    assert stop_mock.call_count == 0
+
+
+@pytest.mark.chroma
+def test_chroma_store_falls_back_to_system_stop_when_close_unavailable(tmp_path):
+    stop_mock = Mock()
+    client = type("_ClientWithoutClose", (), {})()
+    client._system = type("_System", (), {"stop": stop_mock})()
+    store = ChromaStore(
+        persist_dir=str(tmp_path / "chroma-test"),
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        query_config={},
+    )
+
+    store._stop_client(client)
+
+    assert stop_mock.call_count == 1
+
+
+@pytest.mark.chroma
+def test_chroma_store_init_failure_cleanup_handles_client_close_error(
+    monkeypatch, tmp_path
+):
+    from metis.vector_store import chroma_store as chroma_store_module
+
+    client_instances = []
+
+    class _FailingClient:
+        def __init__(self, path, settings):
+            del path, settings
+            self.close = Mock(side_effect=RuntimeError("close failed"))
+            client_instances.append(self)
+
+        def get_or_create_collection(self, name):
+            if name == "docs":
+                raise RuntimeError("boom")
+            return {"name": name}
+
+    monkeypatch.setattr(chroma_store_module, "PersistentClient", _FailingClient)
+    store = ChromaStore(
+        persist_dir=str(tmp_path / "chroma_test"),
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        query_config={},
+    )
+
+    with pytest.raises(VectorStoreInitError):
+        store.init()
+
+    assert len(client_instances) == 1
+    assert client_instances[0].close.call_count == 1
+    assert store._initialized is False
+    assert store._client is None
+    assert not hasattr(store, "vector_store_code")
+    assert not hasattr(store, "vector_store_docs")
+    assert not hasattr(store, "storage_context_code")
+    assert not hasattr(store, "storage_context_docs")
+
+
+@pytest.mark.chroma
+def test_chroma_store_close_allows_reinit_while_client_close_is_slow(
+    monkeypatch, tmp_path
+):
+    from metis.vector_store import chroma_store as chroma_store_module
+
+    close_started = threading.Event()
+    release_close = threading.Event()
+    client_init_calls = 0
+    client_instances = []
+
+    class _FakeClient:
+        def __init__(self, path, settings):
+            del path, settings
+            nonlocal client_init_calls
+            client_init_calls += 1
+            self.client_id = client_init_calls
+            self.close_calls = 0
+            client_instances.append(self)
+
+        def get_or_create_collection(self, name):
+            return {"name": name}
+
+        def close(self):
+            self.close_calls += 1
+            if self.client_id == 1:
+                close_started.set()
+                release_close.wait(timeout=2)
+
+    class _FakeChromaVectorStore:
+        def __init__(self, chroma_collection, embed_model):
+            self.chroma_collection = chroma_collection
+            self.embed_model = embed_model
+
+    class _FakeStorageContext:
+        @staticmethod
+        def from_defaults(vector_store):
+            del vector_store
+            return object()
+
+    monkeypatch.setattr(chroma_store_module, "PersistentClient", _FakeClient)
+    monkeypatch.setattr(
+        chroma_store_module, "ChromaVectorStore", _FakeChromaVectorStore
+    )
+    monkeypatch.setattr(chroma_store_module, "StorageContext", _FakeStorageContext)
+
+    store = ChromaStore(
+        persist_dir=str(tmp_path / "chroma_test"),
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        query_config={},
+    )
+
+    store.init()
+    assert client_init_calls == 1
+
+    errors = []
+
+    def _call_close():
+        try:
+            store.close()
+        except Exception as exc:
+            errors.append(exc)
+
+    close_thread = threading.Thread(target=_call_close)
+    close_thread.start()
+    assert close_started.wait(timeout=2)
+
+    init_completed = threading.Event()
+
+    def _call_init():
+        try:
+            store.init()
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            init_completed.set()
+
+    init_thread = threading.Thread(target=_call_init)
+    init_thread.start()
+    assert init_completed.wait(timeout=2)
+    init_thread.join(timeout=2)
+
+    assert not init_thread.is_alive()
+    assert not errors
+    assert client_init_calls == 2
+    assert store._initialized is True
+    assert store._client is client_instances[1]
+    assert client_instances[1].close_calls == 0
+
+    release_close.set()
+    close_thread.join(timeout=2)
+
+    assert not close_thread.is_alive()
+    assert not errors
+    assert client_instances[0].close_calls == 1
+
+    store.close()
+    store.close()
+    assert client_instances[1].close_calls == 1
+    assert store._initialized is False
+
+
+@pytest.mark.chroma
+def test_chroma_store_close_blocks_reinit_while_legacy_system_stop_is_slow(
+    monkeypatch, tmp_path
+):
+    from metis.vector_store import chroma_store as chroma_store_module
+
+    stop_started = threading.Event()
+    release_stop = threading.Event()
+    init_completed = threading.Event()
+    client_init_calls = 0
+    client_instances = []
+
+    class _System:
+        def __init__(self, client):
+            self._client = client
+
+        def stop(self):
+            self._client.stop_calls += 1
+            if self._client.client_id == 1:
+                stop_started.set()
+                release_stop.wait(timeout=2)
+
+    class _FakeClient:
+        def __init__(self, path, settings):
+            del path, settings
+            nonlocal client_init_calls
+            client_init_calls += 1
+            self.client_id = client_init_calls
+            self.stop_calls = 0
+            self._system = _System(self)
+            client_instances.append(self)
+
+        def get_or_create_collection(self, name):
+            return {"name": name}
+
+    class _FakeChromaVectorStore:
+        def __init__(self, chroma_collection, embed_model):
+            self.chroma_collection = chroma_collection
+            self.embed_model = embed_model
+
+    class _FakeStorageContext:
+        @staticmethod
+        def from_defaults(vector_store):
+            del vector_store
+            return object()
+
+    monkeypatch.setattr(chroma_store_module, "PersistentClient", _FakeClient)
+    monkeypatch.setattr(
+        chroma_store_module, "ChromaVectorStore", _FakeChromaVectorStore
+    )
+    monkeypatch.setattr(chroma_store_module, "StorageContext", _FakeStorageContext)
+
+    store = ChromaStore(
+        persist_dir=str(tmp_path / "chroma_test"),
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        query_config={},
+    )
+
+    store.init()
+    assert client_init_calls == 1
+
+    errors = []
+
+    def _call_close():
+        try:
+            store.close()
+        except Exception as exc:
+            errors.append(exc)
+
+    close_thread = threading.Thread(target=_call_close)
+    close_thread.start()
+    assert stop_started.wait(timeout=2)
+
+    def _call_init():
+        try:
+            store.init()
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            init_completed.set()
+
+    init_thread = threading.Thread(target=_call_init)
+    init_thread.start()
+    assert not init_completed.wait(timeout=0.2)
+
+    release_stop.set()
+    assert init_completed.wait(timeout=2)
+    init_thread.join(timeout=2)
+    close_thread.join(timeout=2)
+
+    assert not init_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert not errors
+    assert client_init_calls == 2
+    assert store._initialized is True
+    assert store._client is client_instances[1]
+    assert client_instances[0].stop_calls == 1
+    assert client_instances[1].stop_calls == 0
+
+    store.close()
+    store.close()
+    assert client_instances[1].stop_calls == 1
+    assert store._initialized is False

--- a/tests/test_engine_chroma.py
+++ b/tests/test_engine_chroma.py
@@ -3,7 +3,10 @@
 
 import pytest
 import os
+import threading
+from unittest.mock import Mock
 from metis.engine import MetisEngine
+from metis.exceptions import VectorStoreInitError
 from metis.vector_store.chroma_store import ChromaStore
 from llama_index.core.settings import Settings
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
@@ -11,7 +14,7 @@ from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 
 @pytest.mark.chroma
 def test_chroma_backend_indexing(tmp_path):
-
+    original_embed_model = getattr(Settings, "_embed_model", None)
     Settings.embed_model = MockEmbedding(embed_dim=8)
 
     chroma_dir = tmp_path / "chroma_test"
@@ -51,4 +54,170 @@ def test_chroma_backend_indexing(tmp_path):
         **runtime,
     )
 
-    engine.index_codebase()
+    try:
+        engine.index_codebase()
+    finally:
+        Settings._embed_model = original_embed_model
+
+
+@pytest.mark.chroma
+def test_chroma_store_init_is_thread_safe_and_reinitializable(monkeypatch, tmp_path):
+    from metis.vector_store import chroma_store as chroma_store_module
+
+    init_started = threading.Event()
+    release_init = threading.Event()
+    client_init_calls = 0
+    vector_store_inits = 0
+    storage_context_inits = 0
+
+    class _FakeClient:
+        def __init__(self, path, settings):
+            del path, settings
+            nonlocal client_init_calls
+            client_init_calls += 1
+            self._system = Mock(stop=Mock())
+            if client_init_calls == 1:
+                init_started.set()
+                release_init.wait(timeout=2)
+
+        def get_or_create_collection(self, name):
+            return {"name": name}
+
+    class _FakeChromaVectorStore:
+        def __init__(self, chroma_collection, embed_model):
+            nonlocal vector_store_inits
+            vector_store_inits += 1
+            self.collection = chroma_collection
+            self.embed_model = embed_model
+
+    class _FakeStorageContext:
+        @staticmethod
+        def from_defaults(vector_store):
+            del vector_store
+            nonlocal storage_context_inits
+            storage_context_inits += 1
+            return object()
+
+    monkeypatch.setattr(chroma_store_module, "PersistentClient", _FakeClient)
+    monkeypatch.setattr(
+        chroma_store_module, "ChromaVectorStore", _FakeChromaVectorStore
+    )
+    monkeypatch.setattr(chroma_store_module, "StorageContext", _FakeStorageContext)
+
+    store = ChromaStore(
+        persist_dir=str(tmp_path / "chroma_test"),
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        query_config={},
+    )
+
+    errors = []
+
+    def _call_init():
+        try:
+            store.init()
+        except Exception as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=_call_init)
+    second = threading.Thread(target=_call_init)
+    first.start()
+    assert init_started.wait(timeout=2)
+    second.start()
+    release_init.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert not errors
+    assert client_init_calls == 1
+    assert vector_store_inits == 2
+    assert storage_context_inits == 2
+
+    store.init()
+    assert client_init_calls == 1
+    assert vector_store_inits == 2
+    assert storage_context_inits == 2
+
+    first_client = store._client
+    store.close()
+    assert first_client._system.stop.call_count == 1
+    assert store._initialized is False
+    assert not hasattr(store, "vector_store_code")
+    assert not hasattr(store, "vector_store_docs")
+    assert not hasattr(store, "storage_context_code")
+    assert not hasattr(store, "storage_context_docs")
+
+    store.init()
+    assert client_init_calls == 2
+    assert vector_store_inits == 4
+    assert storage_context_inits == 4
+
+
+@pytest.mark.chroma
+def test_chroma_store_init_failure_is_retryable(monkeypatch, tmp_path):
+    from metis.vector_store import chroma_store as chroma_store_module
+
+    client_init_calls = 0
+    client_instances = []
+    vector_store_inits = 0
+    storage_context_inits = 0
+
+    class _FakeClient:
+        def __init__(self, path, settings):
+            del path, settings
+            nonlocal client_init_calls
+            client_init_calls += 1
+            self._system = Mock(stop=Mock())
+            client_instances.append(self)
+
+        def get_or_create_collection(self, name):
+            if client_init_calls == 1 and name == "docs":
+                raise RuntimeError("boom")
+            return {"name": name}
+
+    class _FakeChromaVectorStore:
+        def __init__(self, chroma_collection, embed_model):
+            del chroma_collection, embed_model
+            nonlocal vector_store_inits
+            vector_store_inits += 1
+
+    class _FakeStorageContext:
+        @staticmethod
+        def from_defaults(vector_store):
+            del vector_store
+            nonlocal storage_context_inits
+            storage_context_inits += 1
+            return object()
+
+    monkeypatch.setattr(chroma_store_module, "PersistentClient", _FakeClient)
+    monkeypatch.setattr(
+        chroma_store_module, "ChromaVectorStore", _FakeChromaVectorStore
+    )
+    monkeypatch.setattr(chroma_store_module, "StorageContext", _FakeStorageContext)
+
+    store = ChromaStore(
+        persist_dir=str(tmp_path / "chroma_test"),
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        query_config={},
+    )
+
+    with pytest.raises(VectorStoreInitError):
+        store.init()
+    assert client_init_calls == 1
+    assert len(client_instances) == 1
+    assert client_instances[0]._system.stop.call_count == 1
+    assert store._initialized is False
+    assert store._client is None
+    assert not hasattr(store, "vector_store_code")
+    assert not hasattr(store, "vector_store_docs")
+    assert not hasattr(store, "storage_context_code")
+    assert not hasattr(store, "storage_context_docs")
+
+    store.init()
+    assert client_init_calls == 2
+    assert vector_store_inits == 2
+    assert storage_context_inits == 2
+    assert store._initialized is True

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -3,6 +3,7 @@
 
 import pytest
 import tempfile
+import threading
 from unittest.mock import Mock
 from metis.engine import MetisEngine
 from metis.exceptions import PluginNotFoundError, QueryEngineInitError
@@ -41,6 +42,45 @@ def test_init_and_get_query_engines_raises_on_missing_backend():
     )
     with pytest.raises(QueryEngineInitError):
         engine._init_and_get_query_engines()
+
+
+def test_init_and_get_query_engines_propagates_backend_init_error():
+    bad_backend = Mock()
+    bad_backend.init = Mock(side_effect=RuntimeError("boom"))
+    bad_backend.get_query_engines = Mock(return_value=(object(), object()))
+    engine = MetisEngine(
+        vector_backend=bad_backend,
+        llm_provider=Mock(),
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        engine._init_and_get_query_engines()
+    assert engine._qe_code is None
+    assert engine._qe_docs is None
+
+
+@pytest.mark.parametrize("query_engines", [(None, object()), (object(), None)])
+def test_init_and_get_query_engines_raises_on_partial_query_engines(query_engines):
+    bad_backend = Mock()
+    bad_backend.init = Mock()
+    bad_backend.get_query_engines = Mock(return_value=query_engines)
+    engine = MetisEngine(
+        vector_backend=bad_backend,
+        llm_provider=Mock(),
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+    with pytest.raises(QueryEngineInitError):
+        engine._init_and_get_query_engines()
+    assert engine._qe_code is None
+    assert engine._qe_docs is None
 
 
 def test_init_and_get_default_unavailable_metisignore():
@@ -82,3 +122,133 @@ def test_init_and_get_default_available_metisignore():
         assert engine.load_metisignore() is not None
         assert engine.metisignore_file == temp_file.name
     assert engine is not None
+
+
+def test_review_code_parallel_init_invokes_backend_init_once_per_engine_lifecycle(
+    dummy_llm, monkeypatch
+):
+    parallel_calls = 4
+
+    class _CountingBackend:
+        def __init__(self):
+            self.init_call_count = 0
+            self.get_query_engines_call_count = 0
+            self._init_barrier = threading.Barrier(parallel_calls)
+
+        def init(self):
+            self.init_call_count += 1
+            try:
+                self._init_barrier.wait(timeout=2)
+            except threading.BrokenBarrierError:
+                pass
+
+        def get_query_engines(self, *_args, **_kwargs):
+            self.get_query_engines_call_count += 1
+            return (object(), object())
+
+    backend = _CountingBackend()
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=backend,
+        llm_provider=dummy_llm,
+        max_workers=parallel_calls,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    monkeypatch.setattr(
+        engine,
+        "get_code_files",
+        lambda: [f"/tmp/file_{i}.c" for i in range(parallel_calls)],
+    )
+
+    def _review_file(_path):
+        engine._init_and_get_query_engines()
+        return {"reviews": ["ok"]}
+
+    monkeypatch.setattr(engine, "review_file", _review_file)
+
+    results = list(engine.review_code())
+    assert len(results) == parallel_calls
+    assert backend.init_call_count == 1
+    assert backend.get_query_engines_call_count == 1
+
+
+def test_close_clears_cached_query_engines_after_concurrent_init(dummy_llm):
+    init_started = threading.Event()
+    release_init = threading.Event()
+
+    class _Backend:
+        def init(self):
+            init_started.set()
+            release_init.wait(timeout=2)
+
+        def get_query_engines(self, *_args, **_kwargs):
+            return (object(), object())
+
+        def close(self):
+            return None
+
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=_Backend(),
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    init_thread = threading.Thread(target=engine._init_and_get_query_engines)
+    close_thread = threading.Thread(target=engine.close)
+
+    init_thread.start()
+    assert init_started.wait(timeout=2)
+    close_thread.start()
+    release_init.set()
+    init_thread.join(timeout=2)
+    close_thread.join(timeout=2)
+
+    assert not init_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert engine._qe_code is None
+    assert engine._qe_docs is None
+
+
+def test_close_clears_cached_query_engines_when_backend_close_fails(dummy_llm):
+    qe_code = object()
+    qe_docs = object()
+
+    class _Backend:
+        def init(self):
+            return None
+
+        def get_query_engines(self, *_args, **_kwargs):
+            return (qe_code, qe_docs)
+
+        def close(self):
+            raise RuntimeError("close failed")
+
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=_Backend(),
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    assert engine._init_and_get_query_engines() == (qe_code, qe_docs)
+    assert engine._qe_code is qe_code
+    assert engine._qe_docs is qe_docs
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        engine.close()
+
+    assert engine._qe_code is None
+    assert engine._qe_docs is None

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -218,6 +218,47 @@ def test_close_clears_cached_query_engines_after_concurrent_init(dummy_llm):
     assert engine._qe_docs is None
 
 
+def test_init_releases_query_engine_lock_while_backend_init_runs(dummy_llm):
+    init_started = threading.Event()
+    release_init = threading.Event()
+
+    class _Backend:
+        def init(self):
+            init_started.set()
+            release_init.wait(timeout=2)
+
+        def get_query_engines(self, *_args, **_kwargs):
+            return (object(), object())
+
+        def close(self):
+            return None
+
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=_Backend(),
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    init_thread = threading.Thread(target=engine._init_and_get_query_engines)
+    init_thread.start()
+    assert init_started.wait(timeout=2)
+
+    lock_was_released = engine._qe_init_lock.acquire(blocking=False)
+    if lock_was_released:
+        engine._qe_init_lock.release()
+
+    release_init.set()
+    init_thread.join(timeout=2)
+
+    assert not init_thread.is_alive()
+    assert lock_was_released is True
+
+
 def test_close_clears_cached_query_engines_when_backend_close_fails(dummy_llm):
     qe_code = object()
     qe_docs = object()
@@ -252,3 +293,213 @@ def test_close_clears_cached_query_engines_when_backend_close_fails(dummy_llm):
 
     assert engine._qe_code is None
     assert engine._qe_docs is None
+
+
+def test_close_invalidates_cached_query_engines_and_reinits_on_next_access(dummy_llm):
+    first_qe_code = object()
+    first_qe_docs = object()
+    second_qe_code = object()
+    second_qe_docs = object()
+
+    class _Backend:
+        def __init__(self):
+            self.init_call_count = 0
+            self.close_call_count = 0
+            self._next_engines = [
+                (first_qe_code, first_qe_docs),
+                (second_qe_code, second_qe_docs),
+            ]
+
+        def init(self):
+            self.init_call_count += 1
+
+        def get_query_engines(self, *_args, **_kwargs):
+            return self._next_engines.pop(0)
+
+        def close(self):
+            self.close_call_count += 1
+
+    backend = _Backend()
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=backend,
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    assert engine._init_and_get_query_engines() == (first_qe_code, first_qe_docs)
+    assert engine._init_and_get_query_engines() == (first_qe_code, first_qe_docs)
+    assert backend.init_call_count == 1
+
+    engine.close()
+    assert backend.close_call_count == 1
+    assert engine._qe_code is None
+    assert engine._qe_docs is None
+
+    assert engine._init_and_get_query_engines() == (second_qe_code, second_qe_docs)
+    assert backend.init_call_count == 2
+
+
+def test_close_blocks_reinit_until_backend_close_completes(dummy_llm):
+    close_started = threading.Event()
+    release_close = threading.Event()
+    init_completed = threading.Event()
+
+    class _Backend:
+        def __init__(self):
+            self.init_call_count = 0
+
+        def init(self):
+            self.init_call_count += 1
+
+        def get_query_engines(self, *_args, **_kwargs):
+            return (object(), object())
+
+        def close(self):
+            close_started.set()
+            release_close.wait(timeout=2)
+
+    backend = _Backend()
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=backend,
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    engine._init_and_get_query_engines()
+    assert backend.init_call_count == 1
+
+    close_errors = []
+    init_errors = []
+
+    def _call_close():
+        try:
+            engine.close()
+        except Exception as exc:
+            close_errors.append(exc)
+
+    def _call_init():
+        try:
+            engine._init_and_get_query_engines()
+        except Exception as exc:
+            init_errors.append(exc)
+        finally:
+            init_completed.set()
+
+    close_thread = threading.Thread(target=_call_close)
+    close_thread.start()
+    assert close_started.wait(timeout=2)
+
+    init_thread = threading.Thread(target=_call_init)
+    init_thread.start()
+    assert not init_completed.wait(timeout=0.2)
+
+    release_close.set()
+    assert init_completed.wait(timeout=2)
+
+    assert not close_errors
+    assert not init_errors
+    assert backend.init_call_count == 2
+
+    close_thread.join(timeout=2)
+    init_thread.join(timeout=2)
+    assert not close_thread.is_alive()
+    assert not init_thread.is_alive()
+
+
+def test_init_clears_in_progress_flag_on_base_exception(dummy_llm):
+    first_qe_code = object()
+    first_qe_docs = object()
+
+    class _FatalInitError(BaseException):
+        pass
+
+    class _Backend:
+        def __init__(self):
+            self.init_call_count = 0
+
+        def init(self):
+            self.init_call_count += 1
+            if self.init_call_count == 1:
+                raise _FatalInitError("fatal init interruption")
+
+        def get_query_engines(self, *_args, **_kwargs):
+            return (first_qe_code, first_qe_docs)
+
+    backend = _Backend()
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=backend,
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    with pytest.raises(_FatalInitError, match="fatal init interruption"):
+        engine._init_and_get_query_engines()
+
+    assert engine._qe_init_in_progress is False
+    assert engine._init_and_get_query_engines() == (first_qe_code, first_qe_docs)
+    assert backend.init_call_count == 2
+
+
+def test_close_resets_close_state_when_close_lookup_fails(dummy_llm):
+    first_qe_code = object()
+    first_qe_docs = object()
+    second_qe_code = object()
+    second_qe_docs = object()
+
+    class _Backend:
+        def __init__(self):
+            self.init_call_count = 0
+            self._engines = [
+                (first_qe_code, first_qe_docs),
+                (second_qe_code, second_qe_docs),
+            ]
+
+        def __getattribute__(self, name):
+            if name == "close":
+                raise RuntimeError("close lookup failed")
+            return object.__getattribute__(self, name)
+
+        def init(self):
+            self.init_call_count += 1
+
+        def get_query_engines(self, *_args, **_kwargs):
+            return self._engines.pop(0)
+
+    backend = _Backend()
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=backend,
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    assert engine._init_and_get_query_engines() == (first_qe_code, first_qe_docs)
+
+    with pytest.raises(RuntimeError, match="close lookup failed"):
+        engine.close()
+
+    assert engine._qe_close_in_progress is False
+    assert engine._qe_code is None
+    assert engine._qe_docs is None
+
+    assert engine._init_and_get_query_engines() == (second_qe_code, second_qe_docs)
+    assert backend.init_call_count == 2

--- a/tests/test_engine_review.py
+++ b/tests/test_engine_review.py
@@ -1,7 +1,15 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import threading
+from types import SimpleNamespace
 from unittest.mock import Mock
+
+import pytest
+
+from metis.cli.commands import run_review_code
+from metis.cli.commands import run_index
+from metis.engine import MetisEngine
 
 
 def test_ask_question(engine):
@@ -52,3 +60,88 @@ def test_review_patch_handles_parse_error(engine, tmp_path):
     result = engine.review_patch(str(bad_patch_file))
     assert "reviews" in result
     assert result["reviews"] == []
+
+
+@pytest.mark.parametrize("max_workers", [1, 10])
+def test_index_then_non_interactive_review_code_avoids_chroma_init_race(
+    dummy_llm, monkeypatch, max_workers
+):
+    shared_state = {"indexed": False}
+    init_guard_lock = threading.Lock()
+    init_started = threading.Event()
+    release_init = threading.Event()
+    init_call_count = 0
+
+    index_backend = Mock()
+    index_engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=index_backend,
+        llm_provider=dummy_llm,
+        max_workers=1,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    def _mark_indexed():
+        shared_state["indexed"] = True
+
+    monkeypatch.setattr(index_engine, "index_codebase", _mark_indexed)
+    run_index(index_engine, verbose=False, quiet=True)
+    assert shared_state["indexed"] is True
+
+    review_backend = Mock()
+    review_backend.get_query_engines = Mock(return_value=(object(), object()))
+    review_engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=review_backend,
+        llm_provider=dummy_llm,
+        max_workers=max_workers,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    def _init_with_single_call_guard():
+        nonlocal init_call_count
+        if not shared_state["indexed"]:
+            raise RuntimeError("default_tenant connection error")
+        with init_guard_lock:
+            init_call_count += 1
+            current_call_count = init_call_count
+        if current_call_count == 1:
+            init_started.set()
+            release_init.wait(timeout=2)
+            return
+        raise RuntimeError("default_tenant connection error")
+
+    class _DummyReviewGraph:
+        def review(self, req):
+            return {"file": req["relative_file"], "reviews": [{"issue": "Issue"}]}
+
+    captured_results: dict[str, dict[str, list[dict[str, object]]]] = {}
+    file_path = "./tests/data/test.c"
+    review_files = [file_path for _ in range(max_workers)]
+
+    monkeypatch.setattr(review_backend, "init", _init_with_single_call_guard)
+    monkeypatch.setattr(review_engine, "get_code_files", lambda: review_files)
+    monkeypatch.setattr(review_engine, "_get_review_graph", lambda: _DummyReviewGraph())
+    monkeypatch.setattr(
+        "metis.cli.commands.pretty_print_reviews",
+        lambda results, _quiet: captured_results.setdefault("value", results),
+    )
+    monkeypatch.setattr(
+        "metis.cli.commands.save_output", lambda *_args, **_kwargs: None
+    )
+
+    args = SimpleNamespace(verbose=False, quiet=True, output_file=[])
+    release_timer = threading.Timer(0.05, release_init.set)
+    release_timer.start()
+    run_review_code(review_engine, args)
+    release_timer.cancel()
+
+    assert init_started.is_set()
+    assert init_call_count == 1
+    assert len(captured_results["value"]["reviews"]) == max_workers

--- a/tests/test_engine_review.py
+++ b/tests/test_engine_review.py
@@ -137,11 +137,17 @@ def test_index_then_non_interactive_review_code_avoids_chroma_init_race(
     )
 
     args = SimpleNamespace(verbose=False, quiet=True, output_file=[])
-    release_timer = threading.Timer(0.05, release_init.set)
-    release_timer.start()
+
+    def _release_after_init_starts():
+        init_started.wait(timeout=2)
+        release_init.set()
+
+    release_thread = threading.Thread(target=_release_after_init_starts)
+    release_thread.start()
     run_review_code(review_engine, args)
-    release_timer.cancel()
+    release_thread.join(timeout=2)
 
     assert init_started.is_set()
+    assert not release_thread.is_alive()
     assert init_call_count == 1
     assert len(captured_results["value"]["reviews"]) == max_workers

--- a/tests/test_pg_backend_mocked_unit.py
+++ b/tests/test_pg_backend_mocked_unit.py
@@ -12,25 +12,64 @@ from metis.exceptions import VectorStoreInitError
 
 @pytest.mark.postgres
 def test_pg_vectorstore_mocked_init(monkeypatch):
-
+    from metis.vector_store import pgvector_store as pgvector_store_module
     from metis.vector_store.pgvector_store import PGVectorStoreImpl
 
+    from_params_calls = []
+    storage_context_calls = []
+    created_stores = []
+
+    class _FakeStore:
+        def __init__(self, name):
+            self.name = name
+
+    class _FakePGVectorStore:
+        @staticmethod
+        def from_params(**kwargs):
+            from_params_calls.append(kwargs)
+            store = _FakeStore(kwargs["table_name"])
+            created_stores.append(store)
+            return store
+
+    class _FakeStorageContext:
+        @staticmethod
+        def from_defaults(vector_store):
+            storage_context_calls.append(vector_store)
+            return f"context-{vector_store.name}"
+
     pg = PGVectorStoreImpl(
-        connection_string="postgresql://...",
+        connection_string="postgresql://metis_user:metis_password@localhost:5432/metis_db",
         project_schema="test_schema",
         embed_model_code=Mock(),
         embed_model_docs=Mock(),
         embed_dim=1536,
     )
 
-    monkeypatch.setattr(pg, "check_project_schema_exists", lambda: True)
-    pg.vector_store_code = Mock(add=Mock(return_value=["mock_id"]))
-    pg.vector_store_docs = Mock(add=Mock(return_value=["mock_id"]))
-    pg.get_storage_contexts = lambda: ("code_ctx", "doc_ctx")
+    monkeypatch.setattr(pgvector_store_module, "PGVectorStore", _FakePGVectorStore)
+    monkeypatch.setattr(pgvector_store_module, "StorageContext", _FakeStorageContext)
+    monkeypatch.setattr(
+        pgvector_store_module,
+        "make_url",
+        lambda _url: SimpleNamespace(
+            database="metis_db",
+            host="localhost",
+            password="metis_password",
+            port=5432,
+            username="metis_user",
+        ),
+    )
 
     pg.init()
-    ctx = pg.get_storage_contexts()
-    assert ctx == ("code_ctx", "doc_ctx")
+    assert pg._initialized is True
+    assert len(from_params_calls) == 2
+    assert from_params_calls[0]["table_name"] == "code"
+    assert from_params_calls[1]["table_name"] == "docs"
+    assert from_params_calls[0]["schema_name"] == "test_schema"
+    assert from_params_calls[1]["schema_name"] == "test_schema"
+    assert pg.vector_store_code is created_stores[0]
+    assert pg.vector_store_docs is created_stores[1]
+    assert storage_context_calls == [created_stores[0], created_stores[1]]
+    assert pg.get_storage_contexts() == ("context-code", "context-docs")
 
 
 def test_pg_vectorstore_init_is_thread_safe_and_reinitializable(monkeypatch):
@@ -216,3 +255,235 @@ def test_pg_vectorstore_init_failure_is_retryable(monkeypatch):
     assert pg._initialized is True
     assert hasattr(pg, "vector_store_code")
     assert hasattr(pg, "vector_store_docs")
+
+
+def test_pg_vectorstore_close_allows_reinit_while_dispose_is_slow(monkeypatch):
+    dispose_started = threading.Event()
+    release_dispose = threading.Event()
+    from_params_calls = 0
+    created_stores = []
+
+    class _FakeEngine:
+        def __init__(self, store_id):
+            self.store_id = store_id
+            self.dispose_calls = 0
+
+        def dispose(self):
+            self.dispose_calls += 1
+            if self.store_id == 1:
+                dispose_started.set()
+                release_dispose.wait(timeout=2)
+
+    class _FakeStore:
+        def __init__(self, store_id):
+            self.store_id = store_id
+            self.close_calls = 0
+            self._engine = _FakeEngine(store_id)
+
+        def close(self):
+            self.close_calls += 1
+
+    class _FakePGVectorStore:
+        @staticmethod
+        def from_params(**kwargs):
+            del kwargs
+            nonlocal from_params_calls
+            from_params_calls += 1
+            store = _FakeStore(from_params_calls)
+            created_stores.append(store)
+            return store
+
+    fake_pgvector_module = ModuleType("llama_index.vector_stores.postgres")
+    fake_pgvector_module.PGVectorStore = _FakePGVectorStore
+    monkeypatch.setitem(
+        sys.modules, "llama_index.vector_stores.postgres", fake_pgvector_module
+    )
+    monkeypatch.delitem(sys.modules, "metis.vector_store.pgvector_store", raising=False)
+
+    from metis.vector_store import pgvector_store as pgvector_store_module
+    from metis.vector_store.pgvector_store import PGVectorStoreImpl
+
+    class _FakeStorageContext:
+        @staticmethod
+        def from_defaults(vector_store):
+            del vector_store
+            return object()
+
+    monkeypatch.setattr(
+        pgvector_store_module,
+        "make_url",
+        lambda _url: SimpleNamespace(
+            database="metis_db",
+            host="localhost",
+            password="password",
+            port=5432,
+            username="metis_user",
+        ),
+    )
+    monkeypatch.setattr(pgvector_store_module, "StorageContext", _FakeStorageContext)
+
+    pg = PGVectorStoreImpl(
+        connection_string="postgresql://metis_user:metis_password@localhost:5432/metis_db",
+        project_schema="test_schema",
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        embed_dim=1536,
+    )
+
+    pg.init()
+    assert from_params_calls == 2
+
+    errors = []
+
+    def _call_close():
+        try:
+            pg.close()
+        except Exception as exc:
+            errors.append(exc)
+
+    close_thread = threading.Thread(target=_call_close)
+    close_thread.start()
+    assert dispose_started.wait(timeout=2)
+
+    def _call_init():
+        try:
+            pg.init()
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            init_completed.set()
+
+    init_thread = threading.Thread(target=_call_init)
+    init_completed = threading.Event()
+    init_thread.start()
+    assert init_completed.wait(timeout=2)
+    init_thread.join(timeout=2)
+
+    assert not init_thread.is_alive()
+    assert not errors
+    assert from_params_calls == 4
+    assert pg._initialized is True
+    assert pg.vector_store_code is created_stores[2]
+    assert pg.vector_store_docs is created_stores[3]
+
+    release_dispose.set()
+    close_thread.join(timeout=2)
+
+    assert not close_thread.is_alive()
+    assert not errors
+    assert created_stores[0].close_calls == 1
+    assert created_stores[1].close_calls == 1
+    assert created_stores[0]._engine.dispose_calls == 1
+    assert created_stores[1]._engine.dispose_calls == 1
+
+    pg.close()
+    pg.close()
+
+    assert created_stores[2].close_calls == 1
+    assert created_stores[3].close_calls == 1
+    assert created_stores[2]._engine.dispose_calls == 1
+    assert created_stores[3]._engine.dispose_calls == 1
+    assert pg._initialized is False
+
+
+def test_pg_vectorstore_close_tolerates_store_cleanup_errors():
+    from metis.vector_store.pgvector_store import PGVectorStoreImpl
+
+    def _raise_close():
+        raise RuntimeError("close boom")
+
+    def _raise_dispose():
+        raise RuntimeError("dispose boom")
+
+    code_store = SimpleNamespace(
+        close=_raise_close, _engine=SimpleNamespace(dispose=Mock())
+    )
+    docs_store = SimpleNamespace(
+        close=Mock(), _engine=SimpleNamespace(dispose=_raise_dispose)
+    )
+
+    pg = PGVectorStoreImpl(
+        connection_string="postgresql://...",
+        project_schema="test_schema",
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        embed_dim=1536,
+    )
+    pg._initialized = True
+    pg.vector_store_code = code_store
+    pg.vector_store_docs = docs_store
+    pg.storage_context_code = object()
+    pg.storage_context_docs = object()
+
+    pg.close()
+
+    assert pg._initialized is False
+    assert not hasattr(pg, "vector_store_code")
+    assert not hasattr(pg, "vector_store_docs")
+    assert not hasattr(pg, "storage_context_code")
+    assert not hasattr(pg, "storage_context_docs")
+
+
+def test_pg_vectorstore_close_deduplicates_shared_engine_dispose():
+    from metis.vector_store.pgvector_store import PGVectorStoreImpl
+
+    shared_engine = Mock(dispose=Mock())
+    code_store = SimpleNamespace(close=Mock(), _engine=shared_engine)
+    docs_store = SimpleNamespace(close=Mock(), engine=shared_engine)
+
+    pg = PGVectorStoreImpl(
+        connection_string="postgresql://...",
+        project_schema="test_schema",
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        embed_dim=1536,
+    )
+    pg._initialized = True
+    pg.vector_store_code = code_store
+    pg.vector_store_docs = docs_store
+    pg.storage_context_code = object()
+    pg.storage_context_docs = object()
+
+    pg.close()
+
+    assert code_store.close.call_count == 1
+    assert docs_store.close.call_count == 1
+    assert shared_engine.dispose.call_count == 1
+
+
+def test_pg_vectorstore_close_disposes_engine_attribute_variants():
+    from metis.vector_store.pgvector_store import PGVectorStoreImpl
+
+    code_engine = Mock(dispose=Mock())
+    docs_engine = Mock(dispose=Mock())
+    code_store = SimpleNamespace(close=Mock(), _engine=code_engine, engine=code_engine)
+    docs_store = SimpleNamespace(close=Mock(), engine=docs_engine)
+
+    pg = PGVectorStoreImpl(
+        connection_string="postgresql://...",
+        project_schema="test_schema",
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        embed_dim=1536,
+    )
+    pg._initialized = True
+    pg.vector_store_code = code_store
+    pg.vector_store_docs = docs_store
+    pg.storage_context_code = object()
+    pg.storage_context_docs = object()
+
+    pg.close()
+
+    assert pg._initialized is False
+    assert code_store.close.call_count == 1
+    assert docs_store.close.call_count == 1
+    assert code_engine.dispose.call_count == 1
+    assert docs_engine.dispose.call_count == 1
+    assert not hasattr(pg, "vector_store_code")
+    assert not hasattr(pg, "vector_store_docs")
+    assert not hasattr(pg, "storage_context_code")
+    assert not hasattr(pg, "storage_context_docs")
+
+    pg.close()
+    assert code_engine.dispose.call_count == 1
+    assert docs_engine.dispose.call_count == 1

--- a/tests/test_pg_backend_mocked_unit.py
+++ b/tests/test_pg_backend_mocked_unit.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import threading
+import sys
 from unittest.mock import Mock
+from types import SimpleNamespace
+from types import ModuleType
+from metis.exceptions import VectorStoreInitError
 
 
 @pytest.mark.postgres
@@ -16,7 +21,6 @@ def test_pg_vectorstore_mocked_init(monkeypatch):
         embed_model_code=Mock(),
         embed_model_docs=Mock(),
         embed_dim=1536,
-        logger=None,
     )
 
     monkeypatch.setattr(pg, "check_project_schema_exists", lambda: True)
@@ -27,3 +31,188 @@ def test_pg_vectorstore_mocked_init(monkeypatch):
     pg.init()
     ctx = pg.get_storage_contexts()
     assert ctx == ("code_ctx", "doc_ctx")
+
+
+def test_pg_vectorstore_init_is_thread_safe_and_reinitializable(monkeypatch):
+    init_started = threading.Event()
+    release_init = threading.Event()
+    from_params_calls = 0
+    storage_context_inits = 0
+
+    class _FakeStore:
+        def __init__(self):
+            self.close = Mock()
+            self._engine = Mock(dispose=Mock())
+
+    class _FakePGVectorStore:
+        @staticmethod
+        def from_params(**kwargs):
+            nonlocal from_params_calls
+            from_params_calls += 1
+            if from_params_calls == 1:
+                init_started.set()
+                release_init.wait(timeout=2)
+            return _FakeStore()
+
+    fake_pgvector_module = ModuleType("llama_index.vector_stores.postgres")
+    fake_pgvector_module.PGVectorStore = _FakePGVectorStore
+    monkeypatch.setitem(
+        sys.modules, "llama_index.vector_stores.postgres", fake_pgvector_module
+    )
+    monkeypatch.delitem(sys.modules, "metis.vector_store.pgvector_store", raising=False)
+
+    from metis.vector_store import pgvector_store as pgvector_store_module
+    from metis.vector_store.pgvector_store import PGVectorStoreImpl
+
+    class _FakeStorageContext:
+        @staticmethod
+        def from_defaults(vector_store):
+            del vector_store
+            nonlocal storage_context_inits
+            storage_context_inits += 1
+            return object()
+
+    monkeypatch.setattr(
+        pgvector_store_module,
+        "make_url",
+        lambda _url: SimpleNamespace(
+            database="metis_db",
+            host="localhost",
+            password="password",
+            port=5432,
+            username="metis_user",
+        ),
+    )
+    monkeypatch.setattr(pgvector_store_module, "StorageContext", _FakeStorageContext)
+
+    pg = PGVectorStoreImpl(
+        connection_string="postgresql://metis_user:metis_password@localhost:5432/metis_db",
+        project_schema="test_schema",
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        embed_dim=1536,
+    )
+
+    errors = []
+
+    def _call_init():
+        try:
+            pg.init()
+        except Exception as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=_call_init)
+    second = threading.Thread(target=_call_init)
+    first.start()
+    assert init_started.wait(timeout=2)
+    second.start()
+    release_init.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert not errors
+    assert from_params_calls == 2
+    assert storage_context_inits == 2
+
+    pg.init()
+    assert from_params_calls == 2
+    assert storage_context_inits == 2
+
+    first_code_store = pg.vector_store_code
+    first_docs_store = pg.vector_store_docs
+    pg.close()
+    assert pg._initialized is False
+    assert first_code_store.close.call_count == 1
+    assert first_docs_store.close.call_count == 1
+    assert first_code_store._engine.dispose.call_count == 1
+    assert first_docs_store._engine.dispose.call_count == 1
+    assert not hasattr(pg, "vector_store_code")
+    assert not hasattr(pg, "vector_store_docs")
+    assert not hasattr(pg, "storage_context_code")
+    assert not hasattr(pg, "storage_context_docs")
+
+    pg.init()
+    assert from_params_calls == 4
+    assert storage_context_inits == 4
+
+
+def test_pg_vectorstore_init_failure_is_retryable(monkeypatch):
+    from_params_calls = 0
+    storage_context_inits = 0
+    created_stores = []
+
+    class _FakeStore:
+        def __init__(self):
+            self.close = Mock()
+            self._engine = Mock(dispose=Mock())
+
+    class _FakePGVectorStore:
+        @staticmethod
+        def from_params(**kwargs):
+            del kwargs
+            nonlocal from_params_calls
+            from_params_calls += 1
+            if from_params_calls == 2:
+                raise RuntimeError("boom")
+            store = _FakeStore()
+            created_stores.append(store)
+            return store
+
+    fake_pgvector_module = ModuleType("llama_index.vector_stores.postgres")
+    fake_pgvector_module.PGVectorStore = _FakePGVectorStore
+    monkeypatch.setitem(
+        sys.modules, "llama_index.vector_stores.postgres", fake_pgvector_module
+    )
+    monkeypatch.delitem(sys.modules, "metis.vector_store.pgvector_store", raising=False)
+
+    from metis.vector_store import pgvector_store as pgvector_store_module
+    from metis.vector_store.pgvector_store import PGVectorStoreImpl
+
+    class _FakeStorageContext:
+        @staticmethod
+        def from_defaults(vector_store):
+            del vector_store
+            nonlocal storage_context_inits
+            storage_context_inits += 1
+            return object()
+
+    monkeypatch.setattr(
+        pgvector_store_module,
+        "make_url",
+        lambda _url: SimpleNamespace(
+            database="metis_db",
+            host="localhost",
+            password="password",
+            port=5432,
+            username="metis_user",
+        ),
+    )
+    monkeypatch.setattr(pgvector_store_module, "StorageContext", _FakeStorageContext)
+
+    pg = PGVectorStoreImpl(
+        connection_string="postgresql://metis_user:metis_password@localhost:5432/metis_db",
+        project_schema="test_schema",
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        embed_dim=1536,
+    )
+
+    with pytest.raises(VectorStoreInitError):
+        pg.init()
+    assert from_params_calls == 2
+    assert storage_context_inits == 0
+    assert pg._initialized is False
+    assert not hasattr(pg, "vector_store_code")
+    assert not hasattr(pg, "vector_store_docs")
+    assert not hasattr(pg, "storage_context_code")
+    assert not hasattr(pg, "storage_context_docs")
+    assert created_stores[0].close.call_count == 1
+    assert created_stores[0]._engine.dispose.call_count == 1
+
+    pg.init()
+    assert from_params_calls == 4
+    assert pg._initialized is True
+    assert hasattr(pg, "vector_store_code")
+    assert hasattr(pg, "vector_store_docs")


### PR DESCRIPTION
## Summary

  This PR fixes a race condition during review_code query-engine initialization, especially with Chroma in non-interactive flows after indexing.
  The issue could trigger initialization conflicts (including default_tenant connection errors) under parallel review workers.

  ## Root Cause

  MetisEngine._init_and_get_query_engines() and vector-store init/close paths were not serialized, so concurrent workers could race through
  backend init and teardown.

  ## Changes

  - Added engine-level synchronization:
      - MetisEngine now uses a lock (_qe_init_lock) around query-engine init and close().
      - Ensures backend init/query-engine creation happens once per lifecycle.
  - Hardened Chroma backend lifecycle:
      - Added lock-protected init()/close().
      - Added explicit state reset helper and client shutdown helper.
      - On init failure, stops partially created client, clears state, and raises VectorStoreInitError with exception chaining.
  - Hardened PGVector backend lifecycle:
      - Added lock-protected init()/close().
      - Centralized cleanup to close stores, dispose engines, and clear storage contexts.
      - On partial init failure, performs cleanup and raises VectorStoreInitError with exception chaining.
  - Expanded test coverage:
      - Thread-safe single-init behavior for engine/chroma/pgvector.
      - Retryability after init failures.
      - Correct cache clearing on close (including backend close failure path).
      - Repro/guard test for index -> non-interactive review_code race.

  ## Validation

  Executed:

  UV_CACHE_DIR=$PWD/.uv-cache uv run pytest tests/test_engine_chroma.py tests/test_engine_core.py tests/test_engine_review.py tests/
  test_pg_backend_mocked_unit.py

  Result:

  - 23 passed, 1 skipped in 3.54s
  - Skipped test is Postgres-gated (--postgres not enabled).