### PR TITLE
feat(refactor): decouple engine workflows and centralize tool policies

### DIFF
--- a/src/metis/cli/commands.py
+++ b/src/metis/cli/commands.py
@@ -64,7 +64,7 @@ def run_review(engine, patch_file, args):
         return
     results = with_spinner(
         "Reviewing patch...",
-        engine.review_patch,
+        engine.review.review_patch,
         patch_file=patch_file,
         quiet=args.quiet,
     )
@@ -76,7 +76,7 @@ def run_file_review(engine, file_path, args):
         return
     raw_result = with_spinner(
         f"Reviewing file {file_path}...",
-        engine.review_file,
+        engine.review.review_file,
         file_path=file_path,
         quiet=args.quiet,
     )
@@ -92,8 +92,8 @@ def run_file_review(engine, file_path, args):
 def run_review_code(engine, args):
     if args.verbose:
         print_console("[cyan]Reviewing codebase...[/cyan]", args.quiet)
-        total = len(engine.get_code_files())
-        file_reviews = iterate_with_progress(total, engine.review_code())
+        total = len(engine.review.get_code_files())
+        file_reviews = iterate_with_progress(total, engine.review.review_code())
         results = {"reviews": file_reviews}
     else:
         results = with_spinner(
@@ -107,14 +107,16 @@ def run_index(engine, verbose=False, quiet=False):
         print_console("[cyan]Indexing codebase...[/cyan]", quiet)
         total = count_index_items(engine)
         if total > 0:
-            iterate_with_progress(total, engine.index_prepare_nodes_iter())
+            iterate_with_progress(total, engine.indexing.index_prepare_nodes_iter())
             with_timer(
-                "Embedding indexes...", engine.index_finalize_embeddings, quiet=quiet
+                "Embedding indexes...",
+                engine.indexing.index_finalize_embeddings,
+                quiet=quiet,
             )
             print_console("[green]Indexing completed successfully.[/green]", quiet)
             return
 
-    with_spinner("Indexing codebase...", engine.index_codebase, quiet=quiet)
+    with_spinner("Indexing codebase...", engine.indexing.index_codebase, quiet=quiet)
     print_console("[green]Indexing completed successfully.[/green]", quiet)
 
 
@@ -122,7 +124,12 @@ def run_update(engine, patch_file, args):
     if not check_file_exists(patch_file):
         return
     file_diff = read_file_content(patch_file)
-    with_spinner("Updating index...", engine.update_index, file_diff, quiet=args.quiet)
+    with_spinner(
+        "Updating index...",
+        engine.indexing.update_index,
+        file_diff,
+        quiet=args.quiet,
+    )
     print_console("[green]Index update completed.[/green]", args.quiet)
 
 

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -4,7 +4,6 @@
 import importlib.metadata
 import json
 import logging
-import os
 import re
 import warnings
 from pathlib import Path
@@ -232,7 +231,7 @@ def with_timer(task_description, fn, *args, quiet=False, **kwargs):
 
 
 def collect_reviews(engine):
-    return {"reviews": [r for r in engine.review_code() if r]}
+    return {"reviews": [r for r in engine.review.review_code() if r]}
 
 
 def iterate_with_progress(total, iterable):
@@ -269,22 +268,8 @@ def build_standard_progress(*, transient: bool):
 
 
 def count_index_items(engine):
-    """
-    Count total items to index (code + docs files).
-    Used to size the progress bar for verbose indexing.
-    """
-
-    docs_exts = engine.plugin_config.get("docs", {})
-    code_count = len(engine.get_code_files())
-
-    doc_count = 0
-    base_path = os.path.abspath(engine.codebase_path)
-    for _, _, _files in os.walk(base_path):
-        for f in _files:
-            if os.path.splitext(f)[1].lower() in docs_exts:
-                doc_count += 1
-
-    return code_count + doc_count
+    """Count total items to index via the indexing domain surface."""
+    return engine.indexing.count_index_items()
 
 
 def save_output(output_files, data, quiet=False, sarif_payload=None):

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -1,41 +1,35 @@
 # SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
-import os
-import pathspec
-from threading import Lock
-import unidiff
+from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
-from llama_index.core.node_parser import SentenceSplitter
-from llama_index.core.schema import Document
+import logging
 
 from metis.configuration import load_plugin_config
-from metis.exceptions import (
-    ParsingError,
-    PluginNotFoundError,
-    QueryEngineInitError,
-)
-from metis.plugin_loader import load_plugins, discover_supported_language_names
-from metis.usage import UsageRuntime, submit_with_current_context
-from metis.utils import read_file_content
+from metis.exceptions import PluginNotFoundError, QueryEngineInitError
+from metis.plugin_loader import discover_supported_language_names, load_plugins
+from metis.usage import UsageRuntime
 from metis.vector_store.base import BaseVectorStore
 
-from .diff_utils import extract_content_from_diff, process_diff_file
-from .graphs.types import AskRequest, ReviewRequest
-from .helpers import apply_custom_guidance, prepare_nodes_iter, summarize_changes
+from .graphs import AskGraph, ReviewGraph
+from .indexing_service import IndexingService
+from .repository import EngineRepository
+from .review_service import ReviewService
+from .runtime import EngineConfig, EngineState
 from .triage_constants import DEFAULT_TRIAGE_SIMILARITY_TOP_K
 from .triage_service import TriageService
-from metis.engine.graphs import AskGraph, ReviewGraph
 
 logger = logging.getLogger("metis")
 
 
 class MetisEngine:
-
     _SUPPORTED_LANGUAGES = None
+
+    max_workers: int
+    max_token_length: int
+    llama_query_model: str
+    similarity_top_k: int
+    response_mode: str
 
     def __init__(
         self,
@@ -73,37 +67,63 @@ class MetisEngine:
         self.triage_tool_timeout_seconds = int(
             kwargs.get("triage_tool_timeout_seconds", 12)
         )
-        # Optional user-provided guidance to be appended to system prompts
         self.custom_prompt_text = kwargs.get("custom_prompt_text")
-        self.plugin_config = load_plugin_config()
+        self.metisignore_file = kwargs.get("metisignore_file") or ".metisignore"
+        self.review_code_include_paths = kwargs.get("review_code_include_paths", [])
+        self.review_code_exclude_paths = kwargs.get("review_code_exclude_paths", [])
 
-        # Load precedence note from general prompts
+        self.plugin_config = load_plugin_config()
         self.custom_guidance_precedence = self.plugin_config.get(
             "general_prompts", {}
         ).get("custom_guidance_precedence", "")
         self.plugins = load_plugins(self.plugin_config)
 
-        # Cache splitters and extension/plugin lookups
-        self._splitter_cache = {}
         self.code_exts = set()
         self.ext_plugin_map = {}
-
         for plugin in self.plugins:
-            for e in plugin.get_supported_extensions():
-                e_lower = e.lower()
-                self.code_exts.add(e_lower)
-                self.ext_plugin_map[e_lower] = plugin
+            for extension in plugin.get_supported_extensions():
+                lowered = extension.lower()
+                self.code_exts.add(lowered)
+                self.ext_plugin_map[lowered] = plugin
 
-        # Graphs are built lazily on first use
-        self._review_graph = None
-        self._ask_graph = None
-        self._qe_code = None
-        self._qe_docs = None
-        self._query_engine_lock = Lock()
-        self.metisignore_file = kwargs.get("metisignore_file") or ".metisignore"
-        self.review_code_include_paths = kwargs.get("review_code_include_paths", [])
-        self.review_code_exclude_paths = kwargs.get("review_code_exclude_paths", [])
         self._init_embed_models(injected_usage_runtime)
+
+        self._config = EngineConfig(
+            codebase_path=self.codebase_path,
+            vector_backend=self.vector_backend,
+            llm_provider=self.llm_provider,
+            usage_runtime=self.usage_runtime,
+            plugin_config=self.plugin_config,
+            custom_prompt_text=self.custom_prompt_text,
+            custom_guidance_precedence=self.custom_guidance_precedence,
+            embed_model_code=self.get_embed_model_code(),
+            embed_model_docs=self.get_embed_model_docs(),
+            max_workers=self.max_workers,
+            max_token_length=self.max_token_length,
+            llama_query_model=self.llama_query_model,
+            similarity_top_k=self.similarity_top_k,
+            response_mode=self.response_mode,
+            doc_chunk_size=self.doc_chunk_size,
+            doc_chunk_overlap=self.doc_chunk_overlap,
+            metisignore_file=self.metisignore_file,
+            review_code_include_paths=list(self.review_code_include_paths),
+            review_code_exclude_paths=list(self.review_code_exclude_paths),
+            code_exts=self.code_exts,
+            ext_plugin_map=self.ext_plugin_map,
+        )
+        self._state = EngineState()
+        self.repository = EngineRepository(self._config, self._state)
+        self.indexing = IndexingService(
+            self._config,
+            self._state,
+            self.repository,
+        )
+        self.review = ReviewService(
+            self._config,
+            self.repository,
+            get_query_engines=lambda: self._init_and_get_query_engines(),
+            review_graph_factory=lambda: self._get_review_graph(),
+        )
         self._triage_service = self._build_triage_service()
 
     def _init_usage_runtime(self, kwargs) -> UsageRuntime:
@@ -192,31 +212,9 @@ class MetisEngine:
             usage_hooks=self.usage_runtime.hooks,
         )
 
-    def load_metisignore(self) -> pathspec.GitIgnoreSpec | None:
-        """
-        Load metisignore file and return a GitIgnoreSpec matcher.
-
-        Args:
-            metisignore: Path to a file that have the ignore regex ( use the .gitignore syntax )
-
-        Returns:
-            pathspec.GitIgnoreSpec object or None if file doesn't exist
-        """
-        try:
-            if not self.metisignore_file:
-                logger.info("No MetisIgnore file provided")
-                return None
-            with open(self.metisignore_file, "r") as f:
-                spec = pathspec.GitIgnoreSpec.from_lines(f)
-                logger.info(f"MetisIgnore file loaded: {self.metisignore_file}")
-            return spec
-        except FileNotFoundError:
-            logger.info(f"MetisIgnore file not loaded {self.metisignore_file}")
-            return None
-
     def _get_review_graph(self):
-        if self._review_graph is None:
-            self._review_graph = ReviewGraph(
+        if self._state.review_graph is None:
+            self._state.review_graph = ReviewGraph(
                 llm_provider=self.llm_provider,
                 plugin_config=self.plugin_config,
                 custom_prompt_text=self.custom_prompt_text,
@@ -225,22 +223,18 @@ class MetisEngine:
                 max_token_length=self.max_token_length,
                 chat_model_kwargs=self.usage_runtime.hooks.chat_model_kwargs(),
             )
-        return self._review_graph
+        return self._state.review_graph
 
     def _get_ask_graph(self):
-        if self._ask_graph is None:
-            self._ask_graph = AskGraph(
+        if self._state.ask_graph is None:
+            self._state.ask_graph = AskGraph(
                 llm_provider=self.llm_provider,
                 llama_query_model=self.llama_query_model,
             )
-        return self._ask_graph
+        return self._state.ask_graph
 
     @classmethod
     def supported_languages(cls):
-        """
-        Returns the list of supported languages by the Metis engine.
-        """
-        # Cache to avoid repeated plugin instantiation in repeated calls
         if cls._SUPPORTED_LANGUAGES is None:
             plugin_config = load_plugin_config()
             cls._SUPPORTED_LANGUAGES = discover_supported_language_names(plugin_config)
@@ -257,408 +251,29 @@ class MetisEngine:
         raise PluginNotFoundError(name)
 
     def _get_plugin_for_extension(self, extension):
-        return self.ext_plugin_map.get(extension.lower())
+        return self.repository.get_plugin_for_extension(extension)
 
     def _get_all_supported_code_extensions(self):
-        return sorted(self.code_exts)
+        return self.repository.get_all_supported_code_extensions()
 
     def _get_splitter_cached(self, plugin):
-        key = plugin.get_name()
-        if key in self._splitter_cache:
-            return self._splitter_cache[key]
-        splitter = plugin.get_splitter()
-        self._splitter_cache[key] = splitter
-        return splitter
+        return self.repository.get_splitter_cached(plugin)
 
     def _get_doc_splitter(self):
-        if not hasattr(self, "_doc_splitter") or self._doc_splitter is None:
-            self._doc_splitter = SentenceSplitter(
-                chunk_size=self.doc_chunk_size,
-                chunk_overlap=self.doc_chunk_overlap,
-            )
-        return self._doc_splitter
+        return self.repository.get_doc_splitter()
 
     def _rel_to_base(self, path):
-        base_path = os.path.abspath(self.codebase_path)
-        return base_path, os.path.relpath(path, base_path)
+        return self.repository.rel_to_base(path)
 
     def ask_question(self, question):
-        """
-        Loads the indexes and queries them for an answer using the AskGraph.
-        """
         qe_code, qe_docs = self._init_and_get_query_engines()
         logger.info("Querying codebase for your question...")
-        req: AskRequest = {
+        req = {
             "question": question,
             "retriever_code": qe_code,
             "retriever_docs": qe_docs,
         }
         return self._get_ask_graph().ask(req)
-
-    def index_codebase(self):
-        """
-        Reads files from the codebase, splits documents using language-specific
-        splitters, builds vector indexes for code and documentation, and persists them.
-        """
-
-        self.index_prepare_nodes()
-        self.index_finalize_embeddings()
-
-    def index_prepare_nodes_iter(self):
-        """
-        Parse documents and prepare nodes for indexing, yielding one step per file.
-        Stores prepared nodes internally for a subsequent call to
-        `index_finalize_embeddings`.
-        """
-        # Read docs and code supported extensions from config
-        docs_supported_exts = self.plugin_config.get("docs", {}).get(
-            "supported_extensions", [".md"]
-        )
-        code_supported_exts = self._get_all_supported_code_extensions()
-
-        logger.info(f"Indexing codebase at: {self.codebase_path}")
-        reader = SimpleDirectoryReader(
-            input_dir=self.codebase_path,
-            recursive=True,
-            required_exts=code_supported_exts + docs_supported_exts,
-            filename_as_id=True,
-        )
-        documents = reader.load_data()
-        logger.info(f"Loaded {len(documents)} documents from {self.codebase_path}")
-
-        self.vector_backend.init()
-        doc_splitter = self._get_doc_splitter()
-        metisignore_spec = self.load_metisignore()
-        base_path = os.path.abspath(self.codebase_path)
-        parent_dir = os.path.dirname(base_path)
-        code_docs = []
-        doc_docs = []
-        for doc in documents:
-            ext = os.path.splitext(doc.id_)[1].lower()
-            new_id = os.path.relpath(doc.id_, parent_dir)
-            doc.doc_id = new_id
-            doc.id_ = new_id
-
-            if metisignore_spec and metisignore_spec.match_file(
-                os.path.join(parent_dir, new_id)
-            ):
-                continue
-
-            if ext in docs_supported_exts:
-                doc_docs.append(doc)
-            elif ext in code_supported_exts:
-                code_docs.append(doc)
-
-        nodes_code, nodes_docs = yield from prepare_nodes_iter(
-            code_docs,
-            doc_docs,
-            self._get_plugin_for_extension,
-            self._get_splitter_cached,
-            doc_splitter,
-        )
-
-        # Store nodes for embedding phase
-        self._pending_nodes = (nodes_code, nodes_docs)
-        return
-
-    def index_prepare_nodes(self):
-        """
-        Prepare nodes without exposing an iterator.
-        Consumes the iterator so non-verbose callers avoid a no-op loop.
-        """
-        for _ in self.index_prepare_nodes_iter():
-            pass
-
-    def index_finalize_embeddings(self):
-        """Build vector indexes from previously prepared nodes."""
-        pending = getattr(self, "_pending_nodes", None)
-        if not pending:
-            # Nothing to do
-            return
-        nodes_code, nodes_docs = pending
-        storage_context_code, storage_context_docs = (
-            self.vector_backend.get_storage_contexts()
-        )
-        VectorStoreIndex(
-            nodes_code,
-            storage_context=storage_context_code,
-            embed_model=self.get_embed_model_code(),
-            **self.usage_runtime.hooks.embed_model_kwargs(),
-        )
-
-        VectorStoreIndex(
-            nodes_docs,
-            storage_context=storage_context_docs,
-            embed_model=self.get_embed_model_docs(),
-            **self.usage_runtime.hooks.embed_model_kwargs(),
-        )
-        # Clear pending nodes
-        self._pending_nodes = None
-
-    def review_file(self, file_path):
-        """
-        Review a single source file. Detects plugin by extension, retrieves
-        relevant context from code/docs indexes, runs the security review,
-        and returns a result dict or None
-        if the file is unsupported or empty.
-        """
-        qe_code, qe_docs = self._init_and_get_query_engines()
-        base_path = os.path.abspath(self.codebase_path)
-        snippet = read_file_content(file_path)
-        if not snippet:
-            return None
-
-        ext = os.path.splitext(file_path)[1].lower()
-        plugin = self._get_plugin_for_extension(ext)
-        if not plugin:
-            return None
-
-        language_prompts = plugin.get_prompts()
-        context_prompt_template = self.plugin_config.get("general_prompts", {}).get(
-            "retrieve_context", ""
-        )
-
-        formatted_context_prompt = context_prompt_template.format(file_path=file_path)
-        relative_path = os.path.relpath(file_path, base_path)
-
-        try:
-            req: ReviewRequest = {
-                "file_path": file_path,
-                "snippet": snippet,
-                "retriever_code": qe_code,
-                "retriever_docs": qe_docs,
-                "context_prompt": formatted_context_prompt,
-                "language_prompts": language_prompts,
-                "default_prompt_key": "security_review_file",
-                "relative_file": relative_path,
-                "mode": "file",
-            }
-            return self._get_review_graph().review(req)
-        except Exception as e:
-            logger.error(f"Error processing file {file_path}: {e}")
-            return None
-
-    def get_code_files(self):
-        """
-        Return a list of file names in the self.codebase_path folder.
-        Evaluate the path with metisignore file, include/exclude paths if requested
-        """
-        base_path = os.path.abspath(self.codebase_path)
-        metisignore_spec = self.load_metisignore()
-        include_spec = None
-        if self.review_code_include_paths:
-            include_spec = pathspec.GitIgnoreSpec.from_lines(
-                self.review_code_include_paths
-            )
-        exclude_spec = None
-        if self.review_code_exclude_paths:
-            exclude_spec = pathspec.GitIgnoreSpec.from_lines(
-                self.review_code_exclude_paths
-            )
-        file_list = []
-        for root, _, files in os.walk(base_path):
-            for file in files:
-                full_path = os.path.join(root, file)
-                ext = os.path.splitext(file)[1].lower()
-                if ext not in self.code_exts:
-                    continue
-                rel_path = os.path.relpath(full_path, base_path)
-                if metisignore_spec and metisignore_spec.match_file(rel_path):
-                    continue
-                if include_spec and not include_spec.match_file(rel_path):
-                    continue
-                if exclude_spec and exclude_spec.match_file(rel_path):
-                    continue
-                file_list.append(full_path)
-        return file_list
-
-    def review_code(self):
-        """
-        Iterate all supported code files under `codebase_path` and yield
-        per-file review results. Uses a thread pool and continues on errors.
-        """
-        files = self.get_code_files()
-        if not files:
-            return
-        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            future_to_path = {
-                submit_with_current_context(executor, self.review_file, path): path
-                for path in files
-            }
-            for future in as_completed(future_to_path):
-                path = future_to_path[future]
-                try:
-                    result = future.result()
-                except Exception as e:
-                    logger.error(f"Error reviewing file {path}: {e}")
-                    yield None
-                    continue
-                if result:
-                    yield result
-                else:
-                    yield None
-
-    def review_patch(self, patch_file):
-        """
-        Reviews a patch/diff file by processing each file change.
-        """
-        qe_code, qe_docs = self._init_and_get_query_engines()
-        patch_text = read_file_content(patch_file)
-        try:
-            diff = unidiff.PatchSet.from_string(patch_text)
-            logger.info("Parsed the patch file successfully.")
-        except Exception as e:
-            logger.error(f"Error parsing patch file: {e}")
-            return {"reviews": [], "overall_changes": ""}
-        file_reviews = []
-        overall_summaries = []
-        base_path = os.path.abspath(self.codebase_path)
-        metisignore_spec = self.load_metisignore()
-        for file_diff in diff:
-            if file_diff.is_removed_file or file_diff.is_binary_file:
-                continue
-            abs_path = (
-                file_diff.path
-                if os.path.isabs(file_diff.path)
-                else os.path.join(base_path, file_diff.path)
-            )
-            relative_path = os.path.relpath(abs_path, base_path)
-            if metisignore_spec and metisignore_spec.match_file(relative_path):
-                continue
-            ext = os.path.splitext(file_diff.path)[1].lower()
-            plugin = self._get_plugin_for_extension(ext)
-            if not plugin:
-                continue
-            snippet = process_diff_file(
-                self.codebase_path, file_diff, self.max_token_length
-            )
-            if not snippet:
-                continue
-            context_prompt = self.plugin_config.get("general_prompts", {}).get(
-                "retrieve_context", ""
-            )
-            formatted_context = context_prompt.format(file_path=file_diff.path)
-
-            language_prompts = plugin.get_prompts()
-            try:
-                original_content = read_file_content(abs_path)
-                req: ReviewRequest = {
-                    "file_path": abs_path,
-                    "snippet": snippet,
-                    "retriever_code": qe_code,
-                    "retriever_docs": qe_docs,
-                    "context_prompt": formatted_context,
-                    "language_prompts": language_prompts,
-                    "default_prompt_key": "security_review",
-                    "relative_file": relative_path,
-                    "mode": "patch",
-                    "original_file": original_content or "",
-                }
-                review_dict = self._get_review_graph().review(req)
-            except Exception as e:
-                logger.error(f"Error processing review for {file_diff.path}: {e}")
-                review_dict = None
-            if review_dict:
-                file_reviews.append(review_dict)
-                issues = "\n".join(
-                    issue.get("issue", "") for issue in review_dict.get("reviews", [])
-                )
-                summary_prompt = language_prompts["snippet_security_summary"]
-                summary_prompt = apply_custom_guidance(
-                    summary_prompt,
-                    self.custom_prompt_text,
-                    self.custom_guidance_precedence,
-                )
-                changes_summary = summarize_changes(
-                    self.llm_provider,
-                    file_diff.path,
-                    issues,
-                    summary_prompt,
-                    callbacks=self.usage_runtime.hooks.callbacks,
-                )
-                if changes_summary:
-                    overall_summaries.append(changes_summary)
-        overall_changes = "\n\n".join(overall_summaries)
-        return {"reviews": file_reviews, "overall_changes": overall_changes}
-
-    def update_index(self, patch_text):
-        """
-        Updates the existing index by comparing two git commits.
-        """
-        try:
-            patch_set = unidiff.PatchSet.from_string(patch_text)
-            logger.info("Parsed the provided patch string successfully.")
-        except Exception as e:
-            raise ParsingError(f"Error parsing patch string: {e}")
-        self.vector_backend.init()
-        storage_context_code, storage_context_docs = (
-            self.vector_backend.get_storage_contexts()
-        )
-
-        index_code = VectorStoreIndex.from_vector_store(
-            self.vector_backend.vector_store_code,
-            storage_context=storage_context_code,
-            embed_model=self.get_embed_model_code(),
-            **self.usage_runtime.hooks.embed_model_kwargs(),
-        )
-        index_docs = VectorStoreIndex.from_vector_store(
-            self.vector_backend.vector_store_docs,
-            storage_context=storage_context_docs,
-            embed_model=self.get_embed_model_docs(),
-            **self.usage_runtime.hooks.embed_model_kwargs(),
-        )
-
-        doc_splitter = self._get_doc_splitter()
-
-        for diff_file in patch_set:
-            if diff_file.is_binary_file:
-                continue
-            doc_id = os.path.join(
-                os.path.basename(os.path.abspath(self.codebase_path)), diff_file.path
-            )
-            ext = os.path.splitext(doc_id)[1].lower()
-            target_index = (
-                index_code
-                if ext in self._get_all_supported_code_extensions()
-                else index_docs
-            )
-
-            if diff_file.is_removed_file:
-                target_index.delete_ref_doc(doc_id, delete_from_docstore=True)
-            else:
-                file_path = os.path.join(self.codebase_path, diff_file.path)
-                file_content = read_file_content(file_path)
-                if not file_content and diff_file.is_added_file:
-                    file_content = extract_content_from_diff(diff_file)
-                if not file_content:
-                    logger.warning("No content available for %s", diff_file.path)
-                    continue
-                doc = Document(
-                    text=file_content,
-                    metadata={"file_name": diff_file.path},
-                    id_=doc_id,
-                )
-
-                if diff_file.is_added_file:
-                    if ext in self._get_all_supported_code_extensions():
-                        plugin = self._get_plugin_for_extension(ext)
-                        if not plugin:
-                            continue
-                        splitter = self._get_splitter_cached(plugin)
-                        try:
-                            nodes = splitter.get_nodes_from_documents([doc])
-                        except Exception as e:
-                            logger.warning(
-                                f"Could not parse code with language {plugin.get_name()} for file {doc.id_} (ext {ext}): {e}"
-                            )
-                            continue
-                    else:
-                        nodes = doc_splitter.get_nodes_from_documents([doc])
-                    target_index.insert_nodes(nodes)
-                else:
-                    target_index.refresh_ref_docs([doc])
-                target_index.docstore.set_document_hash(doc.id_, doc.hash)
-        logger.info("Index update complete based on the provided patch diff.")
 
     def _normalize_top_k(self, value, default: int) -> int:
         try:
@@ -682,15 +297,15 @@ class MetisEngine:
         return qe_code, qe_docs
 
     def _init_and_get_query_engines(self):
-        if self._qe_code is not None and self._qe_docs is not None:
-            return self._qe_code, self._qe_docs
-        with self._query_engine_lock:
-            if self._qe_code is not None and self._qe_docs is not None:
-                return self._qe_code, self._qe_docs
+        if self._state.qe_code is not None and self._state.qe_docs is not None:
+            return self._state.qe_code, self._state.qe_docs
+        with self._state.query_engine_lock:
+            if self._state.qe_code is not None and self._state.qe_docs is not None:
+                return self._state.qe_code, self._state.qe_docs
             top_k = self._normalize_top_k(self.similarity_top_k, 5)
             qe_code, qe_docs = self._create_query_engines(top_k)
-            self._qe_code = qe_code
-            self._qe_docs = qe_docs
+            self._state.qe_code = qe_code
+            self._state.qe_docs = qe_docs
             return qe_code, qe_docs
 
     def triage_sarif_payload(
@@ -728,8 +343,8 @@ class MetisEngine:
         )
 
     def close(self):
-        self._qe_code = None
-        self._qe_docs = None
+        self._state.qe_code = None
+        self._state.qe_docs = None
         self._triage_service.close()
         close_fn = getattr(self.vector_backend, "close", None)
         if callable(close_fn):

--- a/src/metis/engine/graphs/triage/evidence.py
+++ b/src/metis/engine/graphs/triage/evidence.py
@@ -119,7 +119,7 @@ def _filter_resolved_macro_unresolved_hops(
     return kept
 
 
-def triage_node_collect_evidence(state: TriageState, *, tool_runner) -> TriageState:
+def triage_node_collect_evidence(state: TriageState, *, toolbox) -> TriageState:
     file_path = state.get("finding_file_path", "") or ""
     line = int(state.get("finding_line", 1) or 1)
     is_metis_source = bool(state.get("finding_is_metis", False))
@@ -162,7 +162,7 @@ def triage_node_collect_evidence(state: TriageState, *, tool_runner) -> TriageSt
     exact_line_context = _collect_file_context(
         state,
         sections,
-        tool_runner=tool_runner,
+        toolbox=toolbox,
         file_path=file_path,
         line=line,
         window_radius=window_radius,
@@ -204,7 +204,7 @@ def triage_node_collect_evidence(state: TriageState, *, tool_runner) -> TriageSt
     unresolved_macros, resolved_macros = _collect_macro_definition_sections(
         state,
         sections,
-        tool_runner=tool_runner,
+        toolbox=toolbox,
         file_path=file_path,
         macro_names=macro_candidates,
         max_sections=max_sections,
@@ -217,7 +217,7 @@ def triage_node_collect_evidence(state: TriageState, *, tool_runner) -> TriageSt
     ) = _gather_symbol_definition_hits(
         state,
         sections,
-        tool_runner=tool_runner,
+        toolbox=toolbox,
         symbols=symbols,
         file_path=file_path,
         max_followup_hits=C.DEFAULT_MAX_FOLLOWUP_HITS,
@@ -234,7 +234,7 @@ def triage_node_collect_evidence(state: TriageState, *, tool_runner) -> TriageSt
     _collect_hit_context_sections(
         state,
         sections,
-        tool_runner=tool_runner,
+        toolbox=toolbox,
         followup_hits=followup_hits,
         max_followup_hits=C.DEFAULT_MAX_FOLLOWUP_HITS,
         max_sections=max_sections,

--- a/src/metis/engine/graphs/triage/evidence_tools.py
+++ b/src/metis/engine/graphs/triage/evidence_tools.py
@@ -71,7 +71,7 @@ def _collect_file_context(
     state: TriageState,
     sections: list[str],
     *,
-    tool_runner,
+    toolbox,
     file_path: str,
     line: int,
     window_radius: int,
@@ -94,7 +94,7 @@ def _collect_file_context(
         max_lines=C.DEFAULT_CAPTURE_MAX_LINES,
         max_chars=C.DEFAULT_CAPTURE_MAX_CHARS,
         append_error_section=True,
-        invoke=lambda: tool_runner.sed(file_path, start, end),
+        invoke=lambda: toolbox.sed(file_path, start, end),
     )
     exact = _safe_tool_capture(
         state,
@@ -106,7 +106,7 @@ def _collect_file_context(
         max_lines=C.REPORTED_LINE_MAX_LINES,
         max_chars=C.REPORTED_LINE_MAX_CHARS,
         append_error_section=True,
-        invoke=lambda: tool_runner.sed(file_path, line, line),
+        invoke=lambda: toolbox.sed(file_path, line, line),
     )
     if exact:
         exact_line_context = exact
@@ -321,7 +321,7 @@ def _collect_macro_definition_sections(
     state: TriageState,
     sections: list[str],
     *,
-    tool_runner,
+    toolbox,
     file_path: str,
     macro_names: list[str],
     max_sections: int,
@@ -336,10 +336,10 @@ def _collect_macro_definition_sections(
         kind = op[0]
         if kind == "grep" and len(op) == 3:
             _, path, pattern = op
-            return tool_runner.grep(pattern, path)
+            return toolbox.grep(pattern, path)
         if kind == "sed" and len(op) == 4:
             _, path, start, end = op
-            return tool_runner.sed(path, start, end)
+            return toolbox.sed(path, start, end)
         return None
 
     def _safe_capture(
@@ -379,7 +379,7 @@ def _collect_macro_definition_sections(
         targeted_hit_context_max_chars=C.TARGETED_HIT_CONTEXT_MAX_CHARS,
         safe_tool_capture=_safe_capture,
         parse_grep_hits=_parse_grep_hits,
-        find_name_paths=lambda name: tool_runner.find_name(
+        find_name_paths=lambda name: toolbox.find_name(
             name,
             max_results=C.FIND_NAME_MAX_RESULTS,
         ),
@@ -405,7 +405,7 @@ def _gather_symbol_definition_hits(
     state: TriageState,
     sections: list[str],
     *,
-    tool_runner,
+    toolbox,
     symbols: list[str],
     file_path: str,
     max_followup_hits: int,
@@ -448,7 +448,7 @@ def _gather_symbol_definition_hits(
                 max_lines=C.RELATED_GREP_MAX_LINES,
                 max_chars=C.RELATED_GREP_MAX_CHARS,
                 append_error_section=False,
-                invoke=lambda p=path, q=probe: tool_runner.grep(q, p),
+                invoke=lambda p=path, q=probe: toolbox.grep(q, p),
             )
             if output is None:
                 continue
@@ -492,7 +492,7 @@ def _collect_hit_context_sections(
     state: TriageState,
     sections: list[str],
     *,
-    tool_runner,
+    toolbox,
     followup_hits: list[tuple[str, int]],
     max_followup_hits: int,
     max_sections: int,
@@ -518,5 +518,5 @@ def _collect_hit_context_sections(
             max_lines=C.HIT_CONTEXT_MAX_LINES,
             max_chars=C.HIT_CONTEXT_MAX_CHARS,
             append_error_section=True,
-            invoke=lambda p=path, s=start, e=end: tool_runner.sed(p, s, e),
+            invoke=lambda p=path, s=start, e=end: toolbox.sed(p, s, e),
         )

--- a/src/metis/engine/graphs/triage/graph.py
+++ b/src/metis/engine/graphs/triage/graph.py
@@ -24,13 +24,13 @@ class TriageGraph:
         self,
         llm_provider,
         llama_query_model,
-        tool_runner,
+        toolbox,
         plugin_config=None,
         chat_model_kwargs=None,
     ):
         self.llm_provider = llm_provider
         self.llama_query_model = llama_query_model
-        self.tool_runner = tool_runner
+        self.toolbox = toolbox
         general_prompts = (plugin_config or {}).get("general_prompts", {})
         self.triage_system_prompt = (
             general_prompts.get("triage_system_prompt")
@@ -67,7 +67,7 @@ class TriageGraph:
         graph.add_node("retrieve", triage_node_retrieve)
         graph.add_node(
             "collect_evidence",
-            partial(triage_node_collect_evidence, tool_runner=self.tool_runner),
+            partial(triage_node_collect_evidence, toolbox=self.toolbox),
         )
         graph.add_node(
             "triage",

--- a/src/metis/engine/indexing_service.py
+++ b/src/metis/engine/indexing_service.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+
+import unidiff
+from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
+from llama_index.core.schema import Document
+
+from metis.exceptions import ParsingError
+from metis.utils import read_file_content
+
+from .diff_utils import extract_content_from_diff
+from .helpers import prepare_nodes_iter
+from .repository import EngineRepository
+from .runtime import EngineConfig, EngineState
+
+logger = logging.getLogger("metis")
+
+
+class IndexingService:
+    def __init__(
+        self,
+        config: EngineConfig,
+        state: EngineState,
+        repository: EngineRepository,
+    ):
+        self._config = config
+        self._state = state
+        self._repository = repository
+
+    def index_codebase(self):
+        self.index_prepare_nodes()
+        self.index_finalize_embeddings()
+
+    def count_index_items(self) -> int:
+        docs_exts = self._config.plugin_config.get("docs", {}).get(
+            "supported_extensions", [".md"]
+        )
+        code_count = len(self._repository.get_code_files())
+
+        doc_count = 0
+        base_path = os.path.abspath(self._config.codebase_path)
+        for _, _, files in os.walk(base_path):
+            for file_name in files:
+                if os.path.splitext(file_name)[1].lower() in docs_exts:
+                    doc_count += 1
+
+        return code_count + doc_count
+
+    def index_prepare_nodes_iter(self):
+        docs_supported_exts = self._config.plugin_config.get("docs", {}).get(
+            "supported_extensions", [".md"]
+        )
+        code_supported_exts = self._repository.get_all_supported_code_extensions()
+
+        logger.info(f"Indexing codebase at: {self._config.codebase_path}")
+        reader = SimpleDirectoryReader(
+            input_dir=self._config.codebase_path,
+            recursive=True,
+            required_exts=code_supported_exts + docs_supported_exts,
+            filename_as_id=True,
+        )
+        documents = reader.load_data()
+        logger.info(
+            f"Loaded {len(documents)} documents from {self._config.codebase_path}"
+        )
+
+        self._config.vector_backend.init()
+        doc_splitter = self._repository.get_doc_splitter()
+        metisignore_spec = self._repository.load_metisignore()
+        base_path = os.path.abspath(self._config.codebase_path)
+        parent_dir = os.path.dirname(base_path)
+        code_docs = []
+        doc_docs = []
+        for doc in documents:
+            ext = os.path.splitext(doc.id_)[1].lower()
+            new_id = os.path.relpath(doc.id_, parent_dir)
+            doc.doc_id = new_id
+            doc.id_ = new_id
+
+            if metisignore_spec and metisignore_spec.match_file(
+                os.path.join(parent_dir, new_id)
+            ):
+                continue
+
+            if ext in docs_supported_exts:
+                doc_docs.append(doc)
+            elif ext in code_supported_exts:
+                code_docs.append(doc)
+
+        nodes_code, nodes_docs = yield from prepare_nodes_iter(
+            code_docs,
+            doc_docs,
+            self._repository.get_plugin_for_extension,
+            self._repository.get_splitter_cached,
+            doc_splitter,
+        )
+
+        self._state.pending_nodes = (nodes_code, nodes_docs)
+        return
+
+    def index_prepare_nodes(self):
+        for _ in self.index_prepare_nodes_iter():
+            pass
+
+    def index_finalize_embeddings(self):
+        pending = self._state.pending_nodes
+        if not pending:
+            return
+        nodes_code, nodes_docs = pending
+        storage_context_code, storage_context_docs = (
+            self._config.vector_backend.get_storage_contexts()
+        )
+        VectorStoreIndex(
+            nodes_code,
+            storage_context=storage_context_code,
+            embed_model=self._config.embed_model_code,
+            **self._config.usage_runtime.hooks.embed_model_kwargs(),
+        )
+
+        VectorStoreIndex(
+            nodes_docs,
+            storage_context=storage_context_docs,
+            embed_model=self._config.embed_model_docs,
+            **self._config.usage_runtime.hooks.embed_model_kwargs(),
+        )
+        self._state.pending_nodes = None
+
+    def update_index(self, patch_text):
+        try:
+            patch_set = unidiff.PatchSet.from_string(patch_text)
+            logger.info("Parsed the provided patch string successfully.")
+        except Exception as e:
+            raise ParsingError(f"Error parsing patch string: {e}")
+        self._config.vector_backend.init()
+        storage_context_code, storage_context_docs = (
+            self._config.vector_backend.get_storage_contexts()
+        )
+
+        index_code = VectorStoreIndex.from_vector_store(
+            self._config.vector_backend.vector_store_code,
+            storage_context=storage_context_code,
+            embed_model=self._config.embed_model_code,
+            **self._config.usage_runtime.hooks.embed_model_kwargs(),
+        )
+        index_docs = VectorStoreIndex.from_vector_store(
+            self._config.vector_backend.vector_store_docs,
+            storage_context=storage_context_docs,
+            embed_model=self._config.embed_model_docs,
+            **self._config.usage_runtime.hooks.embed_model_kwargs(),
+        )
+
+        doc_splitter = self._repository.get_doc_splitter()
+
+        for diff_file in patch_set:
+            if diff_file.is_binary_file:
+                continue
+            doc_id = os.path.join(
+                os.path.basename(os.path.abspath(self._config.codebase_path)),
+                diff_file.path,
+            )
+            ext = os.path.splitext(doc_id)[1].lower()
+            target_index = (
+                index_code
+                if ext in self._repository.get_all_supported_code_extensions()
+                else index_docs
+            )
+
+            if diff_file.is_removed_file:
+                target_index.delete_ref_doc(doc_id, delete_from_docstore=True)
+            else:
+                file_path = os.path.join(self._config.codebase_path, diff_file.path)
+                file_content = read_file_content(file_path)
+                if not file_content and diff_file.is_added_file:
+                    file_content = extract_content_from_diff(diff_file)
+                if not file_content:
+                    logger.warning("No content available for %s", diff_file.path)
+                    continue
+                doc = Document(
+                    text=file_content,
+                    metadata={"file_name": diff_file.path},
+                    id_=doc_id,
+                )
+
+                if diff_file.is_added_file:
+                    if ext in self._repository.get_all_supported_code_extensions():
+                        plugin = self._repository.get_plugin_for_extension(ext)
+                        if not plugin:
+                            continue
+                        splitter = self._repository.get_splitter_cached(plugin)
+                        try:
+                            nodes = splitter.get_nodes_from_documents([doc])
+                        except Exception as e:
+                            logger.warning(
+                                f"Could not parse code with language {plugin.get_name()} for file {doc.id_} (ext {ext}): {e}"
+                            )
+                            continue
+                    else:
+                        nodes = doc_splitter.get_nodes_from_documents([doc])
+                    target_index.insert_nodes(nodes)
+                else:
+                    target_index.refresh_ref_docs([doc])
+                target_index.docstore.set_document_hash(doc.id_, doc.hash)
+        logger.info("Index update complete based on the provided patch diff.")

--- a/src/metis/engine/repository.py
+++ b/src/metis/engine/repository.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pathspec
+from llama_index.core.node_parser import SentenceSplitter
+
+from .runtime import EngineConfig, EngineState
+
+logger = logging.getLogger("metis")
+
+
+class EngineRepository:
+    def __init__(self, config: EngineConfig, state: EngineState):
+        self._config = config
+        self._state = state
+
+    def get_plugin_for_extension(self, extension):
+        return self._config.ext_plugin_map.get(extension.lower())
+
+    def get_all_supported_code_extensions(self):
+        return sorted(self._config.code_exts)
+
+    def get_splitter_cached(self, plugin):
+        key = plugin.get_name()
+        if key in self._state.splitter_cache:
+            return self._state.splitter_cache[key]
+        splitter = plugin.get_splitter()
+        self._state.splitter_cache[key] = splitter
+        return splitter
+
+    def get_doc_splitter(self):
+        if self._state.doc_splitter is None:
+            self._state.doc_splitter = SentenceSplitter(
+                chunk_size=self._config.doc_chunk_size,
+                chunk_overlap=self._config.doc_chunk_overlap,
+            )
+        return self._state.doc_splitter
+
+    def rel_to_base(self, path):
+        base_path = os.path.abspath(self._config.codebase_path)
+        return base_path, os.path.relpath(path, base_path)
+
+    def load_metisignore(self) -> pathspec.GitIgnoreSpec | None:
+        try:
+            if not self._config.metisignore_file:
+                logger.info("No MetisIgnore file provided")
+                return None
+            with open(self._config.metisignore_file, "r") as f:
+                spec = pathspec.GitIgnoreSpec.from_lines(f)
+                logger.info(f"MetisIgnore file loaded: {self._config.metisignore_file}")
+            return spec
+        except FileNotFoundError:
+            logger.info(f"MetisIgnore file not loaded {self._config.metisignore_file}")
+            return None
+
+    def get_code_files(self):
+        base_path = os.path.abspath(self._config.codebase_path)
+        metisignore_spec = self.load_metisignore()
+        include_spec = None
+        if self._config.review_code_include_paths:
+            include_spec = pathspec.GitIgnoreSpec.from_lines(
+                self._config.review_code_include_paths
+            )
+        exclude_spec = None
+        if self._config.review_code_exclude_paths:
+            exclude_spec = pathspec.GitIgnoreSpec.from_lines(
+                self._config.review_code_exclude_paths
+            )
+        file_list = []
+        for root, _, files in os.walk(base_path):
+            for file in files:
+                full_path = os.path.join(root, file)
+                ext = os.path.splitext(file)[1].lower()
+                if ext not in self._config.code_exts:
+                    continue
+                rel_path = os.path.relpath(full_path, base_path)
+                if metisignore_spec and metisignore_spec.match_file(rel_path):
+                    continue
+                if include_spec and not include_spec.match_file(rel_path):
+                    continue
+                if exclude_spec and exclude_spec.match_file(rel_path):
+                    continue
+                file_list.append(full_path)
+        return file_list

--- a/src/metis/engine/review_service.py
+++ b/src/metis/engine/review_service.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+import unidiff
+
+from metis.usage import submit_with_current_context
+from metis.utils import read_file_content
+
+from .diff_utils import process_diff_file
+from .graphs.types import ReviewRequest
+from .helpers import apply_custom_guidance, summarize_changes
+from .repository import EngineRepository
+from .runtime import EngineConfig
+
+logger = logging.getLogger("metis")
+
+
+class ReviewService:
+    def __init__(
+        self,
+        config: EngineConfig,
+        repository: EngineRepository,
+        get_query_engines: Callable[[], tuple[Any, Any]],
+        review_graph_factory: Callable[[], Any],
+    ):
+        self._config = config
+        self._repository = repository
+        self._get_query_engines = get_query_engines
+        self._review_graph_factory = review_graph_factory
+
+    def get_code_files(self):
+        return self._repository.get_code_files()
+
+    def review_file(self, file_path):
+        qe_code, qe_docs = self._get_query_engines()
+        base_path = os.path.abspath(self._config.codebase_path)
+        snippet = read_file_content(file_path)
+        if not snippet:
+            return None
+
+        ext = os.path.splitext(file_path)[1].lower()
+        plugin = self._repository.get_plugin_for_extension(ext)
+        if not plugin:
+            return None
+
+        language_prompts = plugin.get_prompts()
+        context_prompt_template = self._config.plugin_config.get(
+            "general_prompts", {}
+        ).get("retrieve_context", "")
+
+        formatted_context_prompt = context_prompt_template.format(file_path=file_path)
+        relative_path = os.path.relpath(file_path, base_path)
+
+        try:
+            req: ReviewRequest = {
+                "file_path": file_path,
+                "snippet": snippet,
+                "retriever_code": qe_code,
+                "retriever_docs": qe_docs,
+                "context_prompt": formatted_context_prompt,
+                "language_prompts": language_prompts,
+                "default_prompt_key": "security_review_file",
+                "relative_file": relative_path,
+                "mode": "file",
+            }
+            return self._review_graph_factory().review(req)
+        except Exception as e:
+            logger.error(f"Error processing file {file_path}: {e}")
+            return None
+
+    def review_code(
+        self,
+        review_file_func=None,
+        get_code_files_func=None,
+    ) -> Iterator[dict | None]:
+        files = (get_code_files_func or self.get_code_files)()
+        if not files:
+            return
+        with ThreadPoolExecutor(max_workers=self._config.max_workers) as executor:
+            future_to_path = {
+                submit_with_current_context(
+                    executor, review_file_func or self.review_file, path
+                ): path
+                for path in files
+            }
+            for future in as_completed(future_to_path):
+                path = future_to_path[future]
+                try:
+                    result = future.result()
+                except Exception as e:
+                    logger.error(f"Error reviewing file {path}: {e}")
+                    yield None
+                    continue
+                if result:
+                    yield result
+                else:
+                    yield None
+
+    def review_patch(self, patch_file):
+        qe_code, qe_docs = self._get_query_engines()
+        patch_text = read_file_content(patch_file)
+        try:
+            diff = unidiff.PatchSet.from_string(patch_text)
+            logger.info("Parsed the patch file successfully.")
+        except Exception as e:
+            logger.error(f"Error parsing patch file: {e}")
+            return {"reviews": [], "overall_changes": ""}
+        file_reviews = []
+        overall_summaries = []
+        base_path = os.path.abspath(self._config.codebase_path)
+        metisignore_spec = self._repository.load_metisignore()
+        for file_diff in diff:
+            if file_diff.is_removed_file or file_diff.is_binary_file:
+                continue
+            abs_path = (
+                file_diff.path
+                if os.path.isabs(file_diff.path)
+                else os.path.join(base_path, file_diff.path)
+            )
+            relative_path = os.path.relpath(abs_path, base_path)
+            if metisignore_spec and metisignore_spec.match_file(relative_path):
+                continue
+            ext = os.path.splitext(file_diff.path)[1].lower()
+            plugin = self._repository.get_plugin_for_extension(ext)
+            if not plugin:
+                continue
+            snippet = process_diff_file(
+                self._config.codebase_path, file_diff, self._config.max_token_length
+            )
+            if not snippet:
+                continue
+            context_prompt = self._config.plugin_config.get("general_prompts", {}).get(
+                "retrieve_context", ""
+            )
+            formatted_context = context_prompt.format(file_path=file_diff.path)
+
+            language_prompts = plugin.get_prompts()
+            try:
+                original_content = read_file_content(abs_path)
+                req: ReviewRequest = {
+                    "file_path": abs_path,
+                    "snippet": snippet,
+                    "retriever_code": qe_code,
+                    "retriever_docs": qe_docs,
+                    "context_prompt": formatted_context,
+                    "language_prompts": language_prompts,
+                    "default_prompt_key": "security_review",
+                    "relative_file": relative_path,
+                    "mode": "patch",
+                    "original_file": original_content or "",
+                }
+                review_dict = self._review_graph_factory().review(req)
+            except Exception as e:
+                logger.error(f"Error processing review for {file_diff.path}: {e}")
+                review_dict = None
+            if review_dict:
+                file_reviews.append(review_dict)
+                issues = "\n".join(
+                    issue.get("issue", "") for issue in review_dict.get("reviews", [])
+                )
+                summary_prompt = language_prompts["snippet_security_summary"]
+                summary_prompt = apply_custom_guidance(
+                    summary_prompt,
+                    self._config.custom_prompt_text,
+                    self._config.custom_guidance_precedence,
+                )
+                changes_summary = summarize_changes(
+                    self._config.llm_provider,
+                    file_diff.path,
+                    issues,
+                    summary_prompt,
+                    callbacks=self._config.usage_runtime.hooks.callbacks,
+                )
+                if changes_summary:
+                    overall_summaries.append(changes_summary)
+        overall_changes = "\n\n".join(overall_summaries)
+        return {"reviews": file_reviews, "overall_changes": overall_changes}

--- a/src/metis/engine/runtime.py
+++ b/src/metis/engine/runtime.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any
+
+from metis.usage import UsageRuntime
+
+
+@dataclass(slots=True)
+class EngineConfig:
+    codebase_path: str
+    vector_backend: Any
+    llm_provider: Any
+    usage_runtime: UsageRuntime
+    plugin_config: dict[str, Any]
+    custom_prompt_text: str | None
+    custom_guidance_precedence: str
+    embed_model_code: Any
+    embed_model_docs: Any
+    max_workers: int
+    max_token_length: int
+    llama_query_model: str
+    similarity_top_k: int
+    response_mode: str
+    doc_chunk_size: int
+    doc_chunk_overlap: int
+    metisignore_file: str | None
+    review_code_include_paths: list[str]
+    review_code_exclude_paths: list[str]
+    code_exts: set[str] = field(default_factory=set)
+    ext_plugin_map: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class EngineState:
+    splitter_cache: dict[str, Any] = field(default_factory=dict)
+    doc_splitter: Any | None = None
+    review_graph: Any | None = None
+    ask_graph: Any | None = None
+    qe_code: Any | None = None
+    qe_docs: Any | None = None
+    pending_nodes: tuple[Any, Any] | None = None
+    query_engine_lock: Lock = field(default_factory=Lock)

--- a/src/metis/engine/tools/__init__.py
+++ b/src/metis/engine/tools/__init__.py
@@ -1,2 +1,13 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
+
+from .base import ToolBox, ToolContext, ToolDefinition
+from .registry import build_toolbox, get_tool_definitions
+
+__all__ = [
+    "ToolBox",
+    "ToolContext",
+    "ToolDefinition",
+    "build_toolbox",
+    "get_tool_definitions",
+]

--- a/src/metis/engine/tools/base.py
+++ b/src/metis/engine/tools/base.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+ToolInvoke = Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolContext:
+    codebase_path: str
+    timeout_seconds: int = 8
+    max_chars: int = 16000
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDefinition:
+    name: str
+    domains: tuple[str, ...]
+    provider: str
+    operation: str
+
+
+class ToolBox:
+    def __init__(self, tools: dict[str, ToolInvoke]):
+        self._tools = dict(tools)
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted(self._tools))
+
+    def list_tools(self) -> tuple[str, ...]:
+        return self.names
+
+    def has(self, name: str) -> bool:
+        return name in self._tools
+
+    def run(self, name: str, *args, **kwargs):
+        try:
+            tool = self._tools[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown tool: {name}") from exc
+        return tool(*args, **kwargs)
+
+    def grep(self, pattern: str, path: str) -> str:
+        return self.run("grep", pattern, path)
+
+    def find_name(self, name: str, max_results: int = 20) -> list[str]:
+        return self.run("find_name", name, max_results=max_results)
+
+    def cat(self, path: str) -> str:
+        return self.run("cat", path)
+
+    def sed(self, path: str, start_line: int, end_line: int) -> str:
+        return self.run("sed", path, start_line, end_line)

--- a/src/metis/engine/tools/registry.py
+++ b/src/metis/engine/tools/registry.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from .base import ToolBox, ToolContext, ToolDefinition
+from .static_tools import StaticToolRunner
+
+
+def get_tool_policies() -> dict[str, tuple[str, ...]]:
+    return {
+        "triage_evidence": ("grep", "find_name", "cat", "sed"),
+    }
+
+
+def _build_providers(context: ToolContext) -> dict[str, object]:
+    return {
+        "static": StaticToolRunner(
+            codebase_path=context.codebase_path,
+            timeout_seconds=context.timeout_seconds,
+            max_chars=context.max_chars,
+        )
+    }
+
+
+def _validate_registry(
+    definitions: tuple[ToolDefinition, ...],
+    providers: dict[str, object],
+) -> None:
+    seen_names: set[str] = set()
+    for definition in definitions:
+        if definition.name in seen_names:
+            raise ValueError(f"Duplicate tool name: {definition.name}")
+        seen_names.add(definition.name)
+
+        try:
+            provider = providers[definition.provider]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown tool provider '{definition.provider}' for tool '{definition.name}'"
+            ) from exc
+
+        if not hasattr(provider, definition.operation):
+            raise ValueError(
+                f"Tool '{definition.name}' references missing operation "
+                f"'{definition.operation}' on provider '{definition.provider}'"
+            )
+
+
+def _validate_policy_map(
+    definitions: tuple[ToolDefinition, ...],
+    policies: dict[str, tuple[str, ...]],
+) -> None:
+    known_names = {definition.name for definition in definitions}
+    for policy_name, tool_names in policies.items():
+        seen: set[str] = set()
+        for tool_name in tool_names:
+            if tool_name in seen:
+                raise ValueError(
+                    f"Policy '{policy_name}' contains duplicate tool '{tool_name}'"
+                )
+            seen.add(tool_name)
+            if tool_name not in known_names:
+                raise ValueError(
+                    f"Policy '{policy_name}' references unknown tool '{tool_name}'"
+                )
+
+
+def get_tool_definitions() -> tuple[ToolDefinition, ...]:
+    return (
+        ToolDefinition(
+            name="grep",
+            domains=tuple(get_tool_policies()),
+            provider="static",
+            operation="grep",
+        ),
+        ToolDefinition(
+            name="find_name",
+            domains=tuple(get_tool_policies()),
+            provider="static",
+            operation="find_name",
+        ),
+        ToolDefinition(
+            name="cat",
+            domains=tuple(get_tool_policies()),
+            provider="static",
+            operation="cat",
+        ),
+        ToolDefinition(
+            name="sed",
+            domains=tuple(get_tool_policies()),
+            provider="static",
+            operation="sed",
+        ),
+    )
+
+
+def build_toolbox(
+    *,
+    policy: str,
+    codebase_path: str,
+    timeout_seconds: int = 8,
+    max_chars: int = 16000,
+) -> ToolBox:
+    context = ToolContext(
+        codebase_path=codebase_path,
+        timeout_seconds=timeout_seconds,
+        max_chars=max_chars,
+    )
+    policies = get_tool_policies()
+    definitions = get_tool_definitions()
+    if policy not in policies:
+        raise ValueError(
+            f"Unknown tool policy '{policy}'. Known policies: {', '.join(sorted(policies))}"
+        )
+    providers = _build_providers(context)
+    _validate_registry(definitions, providers)
+    _validate_policy_map(definitions, policies)
+
+    allowed = set(policies[policy])
+    selected = {
+        definition.name: getattr(providers[definition.provider], definition.operation)
+        for definition in definitions
+        if definition.name in allowed
+    }
+    return ToolBox(selected)

--- a/src/metis/engine/triage_service_runtime.py
+++ b/src/metis/engine/triage_service_runtime.py
@@ -9,7 +9,7 @@ import threading
 
 from metis.engine.analysis.base import AnalyzerEvidence, AnalyzerRequest
 from metis.engine.graphs import TriageGraph
-from metis.engine.tools.static_tools import StaticToolRunner
+from metis.engine.tools.registry import build_toolbox
 from metis.exceptions import QueryEngineInitError
 
 from .triage_constants import DEFAULT_TRIAGE_SIMILARITY_TOP_K
@@ -40,14 +40,15 @@ class _FallbackTriageAnalyzer:
 
 class TriageServiceRuntimeMixin:
     def _build_triage_graph(self):
-        tool_runner = StaticToolRunner(
+        toolbox = build_toolbox(
+            policy="triage_evidence",
             codebase_path=self.codebase_path,
             timeout_seconds=self.triage_tool_timeout_seconds,
         )
         return TriageGraph(
             llm_provider=self.llm_provider,
             llama_query_model=self.llama_query_model,
-            tool_runner=tool_runner,
+            toolbox=toolbox,
             plugin_config=self.plugin_config,
             chat_model_kwargs=(
                 self._usage_hooks.chat_model_kwargs() if self._usage_hooks else {}

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from metis.cli import commands
+
+
+def test_run_review_code_uses_review_domain_surface(monkeypatch):
+    calls: list[str] = []
+
+    class _ReviewDomain:
+        def get_code_files(self):
+            calls.append("get_code_files")
+            return ["a.py"]
+
+        def review_code(self):
+            calls.append("review_code")
+            yield {"file": "a.py", "reviews": []}
+
+    engine = SimpleNamespace(review=_ReviewDomain())
+    args = SimpleNamespace(verbose=True, quiet=True, triage=False, output_file=None)
+
+    monkeypatch.setattr(commands, "print_console", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        commands, "iterate_with_progress", lambda _total, iterable: list(iterable)
+    )
+    monkeypatch.setattr(
+        commands, "_finalize_review_output", lambda *_args, **_kwargs: None
+    )
+
+    commands.run_review_code(engine, args)
+
+    assert calls == ["get_code_files", "review_code"]
+
+
+def test_run_update_uses_indexing_domain_surface(monkeypatch, tmp_path):
+    patch_file = tmp_path / "change.diff"
+    patch_file.write_text("diff --git a/a.py b/a.py", encoding="utf-8")
+
+    captured: list[str] = []
+
+    class _IndexingDomain:
+        def update_index(self, patch_text):
+            captured.append(patch_text)
+
+    engine = SimpleNamespace(indexing=_IndexingDomain())
+    args = SimpleNamespace(quiet=True)
+
+    monkeypatch.setattr(commands, "print_console", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        commands,
+        "with_spinner",
+        lambda _message, func, *func_args, **_func_kwargs: func(*func_args),
+    )
+
+    commands.run_update(engine, str(patch_file), args)
+
+    assert captured == ["diff --git a/a.py b/a.py"]
+
+
+def test_run_index_verbose_uses_indexing_domain_surface(monkeypatch):
+    calls: list[str] = []
+
+    class _IndexingDomain:
+        def count_index_items(self):
+            calls.append("count")
+            return 2
+
+        def index_prepare_nodes_iter(self):
+            calls.append("prepare")
+            yield None
+            yield None
+
+        def index_finalize_embeddings(self):
+            calls.append("finalize")
+
+    engine = SimpleNamespace(indexing=_IndexingDomain())
+
+    monkeypatch.setattr(commands, "print_console", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        commands, "iterate_with_progress", lambda _total, iterable: list(iterable)
+    )
+    monkeypatch.setattr(
+        commands, "with_timer", lambda _message, func, **_kwargs: func()
+    )
+
+    commands.run_index(engine, verbose=True, quiet=True)
+
+    assert calls == ["count", "prepare", "finalize"]

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -26,6 +26,8 @@ class _DummyEngine:
         self.codebase_path = codebase_path
         self.usage_runtime = UsageRuntime(codebase_path)
         self.closed = False
+        self.review = self
+        self.indexing = self
 
     def usage_command(self, command_name, target=None, display_name=None):
         return self.usage_runtime.command(

--- a/tests/test_engine_chroma.py
+++ b/tests/test_engine_chroma.py
@@ -52,7 +52,7 @@ def test_chroma_backend_indexing(tmp_path):
         **runtime,
     )
 
-    engine.index_codebase()
+    engine.indexing.index_codebase()
 
 
 def test_chroma_store_forces_rust_bindings(tmp_path):

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -60,7 +60,7 @@ def test_init_and_get_default_unavailable_metisignore():
         metisignore_file=".metisignore_file",
     )
     assert engine.metisignore_file == ".metisignore_file"
-    assert engine.load_metisignore() is None
+    assert engine.repository.load_metisignore() is None
 
 
 def test_init_and_get_default_available_metisignore():
@@ -81,7 +81,7 @@ def test_init_and_get_default_available_metisignore():
             response_mode="compact",
             metisignore_file=temp_file.name,
         )
-        assert engine.load_metisignore() is not None
+        assert engine.repository.load_metisignore() is not None
         assert engine.metisignore_file == temp_file.name
     assert engine is not None
 
@@ -225,3 +225,68 @@ def test_engine_reuses_injected_runtime_and_backend_embed_models(tmp_path):
     assert engine.get_embed_model_docs() is backend.embed_model_docs
     llm_provider.get_embed_model_code.assert_not_called()
     llm_provider.get_embed_model_docs.assert_not_called()
+
+
+def test_engine_exposes_focused_services_without_compat_aliases():
+    backend = Mock()
+    backend.init = Mock()
+    backend.get_query_engines = Mock(return_value=("code-qe", "docs-qe"))
+    llm_provider = Mock()
+    llm_provider.get_embed_model_code.return_value = Mock()
+    llm_provider.get_embed_model_docs.return_value = Mock()
+
+    engine = MetisEngine(
+        vector_backend=backend,
+        llm_provider=llm_provider,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    engine.review.review_code = Mock(return_value=iter([{"file": "a.py"}]))
+    engine.indexing.update_index = Mock()
+
+    results = list(engine.review.review_code())
+
+    assert engine.repository is not None
+    assert engine.review is not None
+    assert engine.indexing is not None
+    assert not hasattr(engine, "review_service")
+    assert not hasattr(engine, "indexing_service")
+    assert results == [{"file": "a.py"}]
+    engine.indexing.update_index("diff --git")
+    engine.indexing.update_index.assert_called_once_with("diff --git")
+
+
+def test_close_clears_query_cache_and_closes_backend():
+    backend = Mock()
+    backend.init = Mock()
+    backend.get_query_engines = Mock(return_value=("code-qe", "docs-qe"))
+    backend.close = Mock()
+    llm_provider = Mock()
+    llm_provider.get_embed_model_code.return_value = Mock()
+    llm_provider.get_embed_model_docs.return_value = Mock()
+
+    engine = MetisEngine(
+        vector_backend=backend,
+        llm_provider=llm_provider,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+    assert engine._init_and_get_query_engines() == ("code-qe", "docs-qe")
+    assert backend.get_query_engines.call_count == 1
+
+    engine.close()
+
+    assert engine._state.qe_code is None
+    assert engine._state.qe_docs is None
+    backend.close.assert_called_once()
+
+    assert engine._init_and_get_query_engines() == ("code-qe", "docs-qe")
+    assert backend.get_query_engines.call_count == 2

--- a/tests/test_engine_review.py
+++ b/tests/test_engine_review.py
@@ -11,8 +11,10 @@ def test_ask_question(engine):
 
 
 def test_review_code_runs(engine):
-    engine.review_file = Mock(return_value={"file": "test.py", "reviews": ["Issue"]})
-    results = list(engine.review_code())
+    engine.review.review_file = Mock(
+        return_value={"file": "test.py", "reviews": ["Issue"]}
+    )
+    results = list(engine.review.review_code())
     assert len(results) >= 1
     assert all("reviews" in r for r in results)
 
@@ -37,11 +39,13 @@ def test_review_patch_parses_and_reviews(engine, monkeypatch, tmp_path):
     monkeypatch.setattr(engine, "_get_review_graph", lambda: _DummyReviewGraph())
 
     # Ensure summaries are simple strings, not Mocks
-    import metis.engine.core as coremod
+    import metis.engine.review_service as review_service_mod
 
-    monkeypatch.setattr(coremod, "summarize_changes", lambda *a, **k: "summary")
+    monkeypatch.setattr(
+        review_service_mod, "summarize_changes", lambda *a, **k: "summary"
+    )
 
-    result = engine.review_patch(str(patch_file))
+    result = engine.review.review_patch(str(patch_file))
     assert "reviews" in result and isinstance(result["reviews"], list)
     assert any(r.get("file") == "test.py" for r in result["reviews"])
 
@@ -49,6 +53,6 @@ def test_review_patch_parses_and_reviews(engine, monkeypatch, tmp_path):
 def test_review_patch_handles_parse_error(engine, tmp_path):
     bad_patch_file = tmp_path / "bad.diff"
     bad_patch_file.write_text("INVALID PATCH FORMAT")
-    result = engine.review_patch(str(bad_patch_file))
+    result = engine.review.review_patch(str(bad_patch_file))
     assert "reviews" in result
     assert result["reviews"] == []

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from metis.engine.tools import build_toolbox, get_tool_definitions, registry
+from metis.engine.tools.base import ToolContext, ToolDefinition
+
+
+def test_tool_definitions_expose_named_tools():
+    defs = get_tool_definitions()
+    names = {tool.name for tool in defs}
+
+    assert names == {"grep", "find_name", "cat", "sed"}
+    assert all(tool.domains == ("triage_evidence",) for tool in defs)
+
+
+def test_build_toolbox_for_policy_exposes_list_and_invocation(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "a.c").write_text("alpha\nbeta\n", encoding="utf-8")
+
+    toolbox = build_toolbox(
+        policy="triage_evidence", codebase_path=str(tmp_path), max_chars=200
+    )
+
+    assert toolbox.list_tools() == ("cat", "find_name", "grep", "sed")
+    assert toolbox.has("grep") is True
+    assert any(
+        line.endswith("src/a.c:2:beta")
+        for line in toolbox.grep("beta", "src").splitlines()
+    )
+
+
+def test_build_toolbox_rejects_unknown_policy(tmp_path):
+    with pytest.raises(ValueError, match="Unknown tool policy"):
+        build_toolbox(policy="bogus", codebase_path=str(tmp_path))
+
+
+def test_validate_registry_rejects_duplicate_names(tmp_path):
+    context = ToolContext(codebase_path=str(tmp_path))
+    providers = registry._build_providers(context)
+    defs = (
+        ToolDefinition("grep", ("triage",), "static", "grep"),
+        ToolDefinition("grep", ("triage",), "static", "sed"),
+    )
+
+    with pytest.raises(ValueError, match="Duplicate tool name"):
+        registry._validate_registry(defs, providers)
+
+
+def test_validate_registry_rejects_unknown_provider(tmp_path):
+    defs = (ToolDefinition("grep", ("triage",), "missing", "grep"),)
+
+    with pytest.raises(ValueError, match="Unknown tool provider"):
+        registry._validate_registry(defs, providers={})
+
+
+def test_validate_registry_rejects_missing_operation(tmp_path):
+    context = ToolContext(codebase_path=str(tmp_path))
+    providers = registry._build_providers(context)
+    defs = (ToolDefinition("grep", ("triage",), "static", "missing_method"),)
+
+    with pytest.raises(ValueError, match="missing operation"):
+        registry._validate_registry(defs, providers)
+
+
+def test_validate_policy_map_rejects_unknown_tool_name():
+    defs = get_tool_definitions()
+    with pytest.raises(ValueError, match="references unknown tool"):
+        registry._validate_policy_map(defs, {"triage_evidence": ("missing_tool",)})
+
+
+def test_validate_policy_map_rejects_duplicate_tool_name():
+    defs = get_tool_definitions()
+    with pytest.raises(ValueError, match="contains duplicate tool"):
+        registry._validate_policy_map(defs, {"triage_evidence": ("grep", "grep")})

--- a/tests/test_triage_graph.py
+++ b/tests/test_triage_graph.py
@@ -19,7 +19,7 @@ def _build_graph():
     return TriageGraph(
         llm_provider=object(),
         llama_query_model="dummy",
-        tool_runner=object(),
+        toolbox=object(),
         plugin_config={},
     )
 

--- a/tests/test_triage_runtime.py
+++ b/tests/test_triage_runtime.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from metis.engine import triage_service_runtime
+
+
+def test_triage_runtime_builds_graph_with_domain_toolbox(engine, monkeypatch):
+    sentinel = object()
+    captured = {}
+
+    def _fake_build_toolbox(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(triage_service_runtime, "build_toolbox", _fake_build_toolbox)
+
+    graph = engine._triage_service._build_triage_graph()
+
+    assert graph.toolbox is sentinel
+    assert captured == {
+        "policy": "triage_evidence",
+        "codebase_path": engine.codebase_path,
+        "timeout_seconds": engine.triage_tool_timeout_seconds,
+    }

--- a/tests/test_triage_treesitter.py
+++ b/tests/test_triage_treesitter.py
@@ -131,7 +131,7 @@ def test_triage_collect_evidence_includes_analyzer_sections_and_scope_section():
         "triage_codebase_path": ".",
     }
 
-    out = triage_node_collect_evidence(state, tool_runner=runner)
+    out = triage_node_collect_evidence(state, toolbox=runner)
 
     evidence_pack = out.get("evidence_pack", "")
     assert "[ANALYZER_SUMMARY]" in evidence_pack
@@ -158,7 +158,7 @@ def test_triage_collect_evidence_runs_definition_grep_when_analyzer_weak():
         "triage_codebase_path": ".",
     }
 
-    out = triage_node_collect_evidence(state, tool_runner=runner)
+    out = triage_node_collect_evidence(state, toolbox=runner)
     evidence_pack = out.get("evidence_pack", "")
     assert "[ANALYZER_FALLBACK]" in evidence_pack
     assert "[ANALYZER_UNRESOLVED]" in evidence_pack
@@ -179,7 +179,7 @@ def test_triage_collect_evidence_enforces_max_sections(monkeypatch):
         "triage_codebase_path": ".",
     }
 
-    out = triage_node_collect_evidence(state, tool_runner=runner)
+    out = triage_node_collect_evidence(state, toolbox=runner)
 
     evidence_pack = out.get("evidence_pack", "")
     sections = [s for s in evidence_pack.split("\n\n") if s.strip()]
@@ -199,7 +199,7 @@ def test_triage_collect_evidence_external_source_uses_line_local_profile():
         "triage_codebase_path": ".",
     }
 
-    out = triage_node_collect_evidence(state, tool_runner=runner)
+    out = triage_node_collect_evidence(state, toolbox=runner)
     evidence_pack = out.get("evidence_pack", "")
     assert "[FILE_HEAD src/main.c]" not in evidence_pack
     assert all(path == "src/main.c" for path in runner.grep_paths)
@@ -219,7 +219,7 @@ def test_triage_collect_evidence_metis_appends_explanation_section():
         "triage_codebase_path": ".",
     }
 
-    out = triage_node_collect_evidence(state, tool_runner=runner)
+    out = triage_node_collect_evidence(state, toolbox=runner)
     evidence_pack = out.get("evidence_pack", "")
     assert "[METIS_EXPLANATION]" in evidence_pack
     assert "reasoning: foo reaches sink" in evidence_pack
@@ -237,7 +237,7 @@ def test_triage_collect_evidence_resolves_macro_definition_with_tools():
         "triage_codebase_path": ".",
     }
 
-    out = triage_node_collect_evidence(state, tool_runner=runner)
+    out = triage_node_collect_evidence(state, toolbox=runner)
     evidence_pack = out.get("evidence_pack", "")
     assert "MACRO_DEFINE_GREP PROJECT_STACK_ALLOC IN project_support.h" in evidence_pack
     assert "MACRO_DEFINE_CONTEXT PROJECT_STACK_ALLOC project_support.h" in evidence_pack
@@ -256,7 +256,7 @@ def test_triage_collect_evidence_resolves_macro_definition_via_find_name():
         "triage_codebase_path": ".",
     }
 
-    out = triage_node_collect_evidence(state, tool_runner=runner)
+    out = triage_node_collect_evidence(state, toolbox=runner)
     evidence_pack = out.get("evidence_pack", "")
     assert (
         "MACRO_DEFINE_GREP PROJECT_STACK_ALLOC IN include/project_support.h"

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -92,7 +92,7 @@ def test_review_code_propagates_usage_context_into_worker_threads():
         response_mode="compact",
     )
 
-    engine.get_code_files = lambda: ["a.py", "b.py"]
+    engine.review.get_code_files = lambda: ["a.py", "b.py"]
 
     def _review_file(path):
         engine.usage_runtime.collector.record(
@@ -105,10 +105,10 @@ def test_review_code_propagates_usage_context_into_worker_threads():
         )
         return {"file": path}
 
-    engine.review_file = _review_file
+    engine.review.review_file = _review_file
 
     with engine.usage_command("review_code") as command:
-        results = list(engine.review_code())
+        results = list(engine.review.review_code())
 
     record = engine.finalize_usage_command(command)
 
@@ -186,7 +186,7 @@ def test_index_codebase_records_embedding_usage(tmp_path):
     )
 
     with engine.usage_command("index") as command:
-        engine.index_codebase()
+        engine.indexing.index_codebase()
 
     record = engine.finalize_usage_command(command)
 


### PR DESCRIPTION
- breakdown core.py
- add runtime.py, repository.py, indexing_service.py, review_service.py
- move indexing/update logic out of core.py
- move review logic out of core.py
- expose stable engine domains: engine.review, engine.indexing, engine.repository
- move CLI wiring to stable engine domains
- encapsulate verbose indexing count in engine.indexing
- add shared tool primitives: ToolContext, ToolDefinition, ToolBox
- add central tool registry and policy-based toolbox assembly
- migrate triage to shared toolbox
- harden tool registry validation