### PR TITLE
fix(metisignore): support allowlist patterns consistently

### DIFF
--- a/src/metis/engine/indexing_service.py
+++ b/src/metis/engine/indexing_service.py
@@ -44,10 +44,15 @@ class IndexingService:
 
         doc_count = 0
         base_path = os.path.abspath(self._config.codebase_path)
-        for _, _, files in os.walk(base_path):
+        metisignore_spec = self._repository.load_metisignore()
+        for root, _, files in os.walk(base_path):
             for file_name in files:
-                if os.path.splitext(file_name)[1].lower() in docs_exts:
-                    doc_count += 1
+                full_path = os.path.join(root, file_name)
+                if os.path.splitext(file_name)[1].lower() not in docs_exts:
+                    continue
+                if self._repository.is_metisignored(full_path, spec=metisignore_spec):
+                    continue
+                doc_count += 1
 
         return code_count + doc_count
 
@@ -77,15 +82,12 @@ class IndexingService:
         code_docs = []
         doc_docs = []
         for doc in documents:
+            if self._repository.is_metisignored(doc.id_, spec=metisignore_spec):
+                continue
             ext = os.path.splitext(doc.id_)[1].lower()
             new_id = os.path.relpath(doc.id_, parent_dir)
             doc.doc_id = new_id
             doc.id_ = new_id
-
-            if metisignore_spec and metisignore_spec.match_file(
-                os.path.join(parent_dir, new_id)
-            ):
-                continue
 
             if ext in docs_supported_exts:
                 doc_docs.append(doc)

--- a/src/metis/engine/repository.py
+++ b/src/metis/engine/repository.py
@@ -45,17 +45,46 @@ class EngineRepository:
         base_path = os.path.abspath(self._config.codebase_path)
         return base_path, os.path.relpath(path, base_path)
 
+    def resolve_metisignore_path(self) -> str | None:
+        metisignore_file = self._config.metisignore_file
+        if not metisignore_file:
+            return None
+        if os.path.isabs(metisignore_file):
+            return metisignore_file
+        return os.path.abspath(
+            os.path.join(self._config.codebase_path, metisignore_file)
+        )
+
+    def normalize_match_path(self, path: str) -> str:
+        base_path = os.path.abspath(self._config.codebase_path)
+        if os.path.isabs(path):
+            abs_path = os.path.abspath(path)
+            try:
+                if os.path.commonpath([base_path, abs_path]) == base_path:
+                    return os.path.relpath(abs_path, base_path)
+            except ValueError:
+                return os.path.normpath(path)
+        return os.path.normpath(path)
+
+    def is_metisignored(
+        self, path: str, spec: pathspec.GitIgnoreSpec | None = None
+    ) -> bool:
+        if spec is None:
+            spec = self.load_metisignore()
+        return bool(spec and spec.match_file(self.normalize_match_path(path)))
+
     def load_metisignore(self) -> pathspec.GitIgnoreSpec | None:
+        metisignore_path = self.resolve_metisignore_path()
         try:
-            if not self._config.metisignore_file:
+            if not metisignore_path:
                 logger.info("No MetisIgnore file provided")
                 return None
-            with open(self._config.metisignore_file, "r") as f:
+            with open(metisignore_path, "r") as f:
                 spec = pathspec.GitIgnoreSpec.from_lines(f)
-                logger.info(f"MetisIgnore file loaded: {self._config.metisignore_file}")
+                logger.info(f"MetisIgnore file loaded: {metisignore_path}")
             return spec
         except FileNotFoundError:
-            logger.info(f"MetisIgnore file not loaded {self._config.metisignore_file}")
+            logger.info(f"MetisIgnore file not loaded {metisignore_path}")
             return None
 
     def get_code_files(self):
@@ -78,7 +107,7 @@ class EngineRepository:
                 ext = os.path.splitext(file)[1].lower()
                 if ext not in self._config.code_exts:
                     continue
-                rel_path = os.path.relpath(full_path, base_path)
+                rel_path = self.normalize_match_path(full_path)
                 if metisignore_spec and metisignore_spec.match_file(rel_path):
                     continue
                 if include_spec and not include_spec.match_file(rel_path):

--- a/src/metis/engine/review_service.py
+++ b/src/metis/engine/review_service.py
@@ -125,8 +125,8 @@ class ReviewService:
                 if os.path.isabs(file_diff.path)
                 else os.path.join(base_path, file_diff.path)
             )
-            relative_path = os.path.relpath(abs_path, base_path)
-            if metisignore_spec and metisignore_spec.match_file(relative_path):
+            relative_path = self._repository.normalize_match_path(abs_path)
+            if self._repository.is_metisignored(abs_path, spec=metisignore_spec):
                 continue
             ext = os.path.splitext(file_diff.path)[1].lower()
             plugin = self._repository.get_plugin_for_extension(ext)

--- a/tests/test_metisignore.py
+++ b/tests/test_metisignore.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import metis.engine.indexing_service as indexing_service_mod
+from metis.engine import MetisEngine
+
+
+def _build_engine(tmp_path, dummy_backend, dummy_llm):
+    return MetisEngine(
+        codebase_path=str(tmp_path),
+        vector_backend=dummy_backend,
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+    )
+
+
+def test_get_code_files_supports_default_metisignore_allowlist(
+    tmp_path, dummy_backend, dummy_llm
+):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "keep.py").write_text("print('keep')\n", encoding="utf-8")
+    (tmp_path / "src" / "drop.py").write_text("print('drop')\n", encoding="utf-8")
+    (tmp_path / ".metisignore").write_text("*\n!src/\n!src/keep.py\n", encoding="utf-8")
+
+    engine = _build_engine(tmp_path, dummy_backend, dummy_llm)
+
+    files = sorted(
+        Path(path).relative_to(tmp_path).as_posix()
+        for path in engine.repository.get_code_files()
+    )
+    assert files == ["src/keep.py"]
+
+
+def test_count_index_items_respects_metisignore_allowlist(
+    tmp_path, dummy_backend, dummy_llm
+):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "keep.py").write_text("print('keep')\n", encoding="utf-8")
+    (tmp_path / "src" / "drop.py").write_text("print('drop')\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# keep\n", encoding="utf-8")
+    (tmp_path / "notes.md").write_text("# drop\n", encoding="utf-8")
+    (tmp_path / ".metisignore").write_text(
+        "*\n!src/\n!src/keep.py\n!README.md\n", encoding="utf-8"
+    )
+
+    engine = _build_engine(tmp_path, dummy_backend, dummy_llm)
+
+    assert engine.indexing.count_index_items() == 2
+
+
+def test_index_prepare_nodes_respects_nested_metisignore_allowlist(
+    tmp_path, dummy_backend, dummy_llm, monkeypatch
+):
+    (tmp_path / ".metisignore").write_text(
+        "*\n!src/\n!src/keep.py\n!README.md\n", encoding="utf-8"
+    )
+
+    engine = _build_engine(tmp_path, dummy_backend, dummy_llm)
+
+    documents = [
+        SimpleNamespace(
+            id_=str(tmp_path / "src" / "keep.py"),
+            doc_id=str(tmp_path / "src" / "keep.py"),
+        ),
+        SimpleNamespace(
+            id_=str(tmp_path / "src" / "drop.py"),
+            doc_id=str(tmp_path / "src" / "drop.py"),
+        ),
+        SimpleNamespace(
+            id_=str(tmp_path / "README.md"),
+            doc_id=str(tmp_path / "README.md"),
+        ),
+        SimpleNamespace(
+            id_=str(tmp_path / "notes.md"),
+            doc_id=str(tmp_path / "notes.md"),
+        ),
+    ]
+
+    class _DummyReader:
+        def __init__(self, **_kwargs):
+            pass
+
+        def load_data(self):
+            return list(documents)
+
+    captured = {}
+
+    def _fake_prepare_nodes_iter(code_docs, doc_docs, *_args):
+        captured["code_ids"] = [doc.id_ for doc in code_docs]
+        captured["doc_ids"] = [doc.id_ for doc in doc_docs]
+        if False:
+            yield None
+        return (["code-node"], ["doc-node"])
+
+    monkeypatch.setattr(indexing_service_mod, "SimpleDirectoryReader", _DummyReader)
+    monkeypatch.setattr(
+        indexing_service_mod, "prepare_nodes_iter", _fake_prepare_nodes_iter
+    )
+
+    engine.indexing.index_prepare_nodes()
+
+    assert captured == {
+        "code_ids": [f"{tmp_path.name}/src/keep.py"],
+        "doc_ids": [f"{tmp_path.name}/README.md"],
+    }
+    assert engine._state.pending_nodes == (["code-node"], ["doc-node"])
+
+
+def test_review_patch_respects_metisignore_allowlist(
+    tmp_path, dummy_backend, dummy_llm, monkeypatch
+):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "keep.py").write_text("print('keep')\n", encoding="utf-8")
+    (tmp_path / "src" / "drop.py").write_text("print('drop')\n", encoding="utf-8")
+    (tmp_path / ".metisignore").write_text("*\n!src/\n!src/keep.py\n", encoding="utf-8")
+
+    patch = """--- a/src/keep.py
++++ b/src/keep.py
+@@ -1 +1,2 @@
+ print('keep')
++print('still-keep')
+--- a/src/drop.py
++++ b/src/drop.py
+@@ -1 +1,2 @@
+ print('drop')
++print('should-not-review')
+"""
+    patch_file = tmp_path / "change.diff"
+    patch_file.write_text(patch, encoding="utf-8")
+
+    engine = _build_engine(tmp_path, dummy_backend, dummy_llm)
+    reviewed = []
+
+    class _DummyReviewGraph:
+        def review(self, req):
+            reviewed.append(req["relative_file"])
+            return {
+                "file": req["relative_file"],
+                "reviews": [{"issue": f"issue in {req['relative_file']}"}],
+            }
+
+    import metis.engine.review_service as review_service_mod
+
+    monkeypatch.setattr(engine, "_get_review_graph", lambda: _DummyReviewGraph())
+    monkeypatch.setattr(
+        review_service_mod, "summarize_changes", lambda *args, **kwargs: "summary"
+    )
+
+    result = engine.review.review_patch(str(patch_file))
+
+    assert reviewed == ["src/keep.py"]
+    assert [review["file"] for review in result["reviews"]] == ["src/keep.py"]
+    assert result["overall_changes"] == "summary"


### PR DESCRIPTION
  Normalize .metisignore checks to codebase-relative paths so negated
  patterns like !src/keep.py work across code discovery, indexing, and
  patch review.

  Resolve the default .metisignore relative to codebase_path, and use
  the shared matcher when counting indexable docs and filtering prepared
  nodes.

  Add regression tests for get_code_files(), count_index_items(),
  index_prepare_nodes(), and review_patch().