### PR TITLE
feat(review): add shared on-demand rag tooling and simplify review prompts

### DIFF
--- a/src/metis/cli/commands.py
+++ b/src/metis/cli/commands.py
@@ -8,6 +8,7 @@ from rich.markup import escape
 
 from metis.engine.options import ReviewOptions, TriageOptions
 from .command_runtime import CommandRuntime
+from .review_cli import make_review_debug_callback
 from metis.utils import read_file_content, safe_decode_unicode
 from metis.sarif.writer import generate_sarif
 from metis.usage import usage_operation
@@ -37,8 +38,11 @@ def _print_no_index_warning(args, runtime: CommandRuntime):
     runtime.no_index_warning_emitted = True
 
 
-def _review_options_for_runtime(runtime: CommandRuntime) -> ReviewOptions:
-    return ReviewOptions(use_retrieval_context=runtime.use_retrieval_context)
+def _review_options_for_runtime(args, runtime: CommandRuntime) -> ReviewOptions:
+    return ReviewOptions(
+        use_retrieval_context=runtime.use_retrieval_context,
+        debug_callback=make_review_debug_callback(args),
+    )
 
 
 def _triage_options_for_runtime(args, runtime: CommandRuntime) -> TriageOptions:
@@ -89,7 +93,7 @@ def run_review(engine, patch_file, args, runtime: CommandRuntime):
     if not check_file_exists(patch_file):
         return
     _print_no_index_warning(args, runtime)
-    options = _review_options_for_runtime(runtime)
+    options = _review_options_for_runtime(args, runtime)
     results = with_spinner(
         "Reviewing patch...",
         engine.review.review_patch,
@@ -104,7 +108,7 @@ def run_file_review(engine, file_path, args, runtime: CommandRuntime):
     if not check_file_exists(file_path):
         return
     _print_no_index_warning(args, runtime)
-    options = _review_options_for_runtime(runtime)
+    options = _review_options_for_runtime(args, runtime)
     raw_result = with_spinner(
         f"Reviewing file {file_path}...",
         engine.review.review_file,
@@ -123,7 +127,7 @@ def run_file_review(engine, file_path, args, runtime: CommandRuntime):
 
 def run_review_code(engine, args, runtime: CommandRuntime):
     _print_no_index_warning(args, runtime)
-    options = _review_options_for_runtime(runtime)
+    options = _review_options_for_runtime(args, runtime)
     if args.verbose:
         print_console("[cyan]Reviewing codebase...[/cyan]", args.quiet)
         total = len(engine.review.get_code_files())

--- a/src/metis/cli/review_cli.py
+++ b/src/metis/cli/review_cli.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from rich.markup import escape
+
+from .utils import print_console
+
+
+def make_review_debug_callback(args):
+    log_level = str(getattr(args, "log_level", "") or "").upper()
+    if log_level != "DEBUG" or not bool(getattr(args, "verbose", False)):
+        return None
+
+    def _clip(value, limit=900):
+        text = str(value or "")
+        if len(text) <= limit:
+            return text
+        return text[:limit] + "\n...[truncated]"
+
+    def _summarize_text(value):
+        text = str(value or "")
+        lines = text.splitlines()
+        return f"chars={len(text)} lines={len(lines)}"
+
+    def _looks_like_error_text(tool_name: str, tool_output: str) -> bool:
+        text = str(tool_output or "").strip()
+        if not text:
+            return False
+        lowered = text.lower()
+        if text.startswith("Tool execution failed:"):
+            return True
+        if "no such file" in lowered or "not found" in lowered:
+            return True
+        if "failed:" in lowered or "error" in lowered:
+            return True
+        if tool_name in {"cat", "sed", "grep"} and len(text.splitlines()) == 1:
+            return True
+        return False
+
+    def _callback(event):
+        if event.get("event") != "tool_call":
+            return
+        tool_name = str(event.get("tool_name", "unknown"))
+        print_console(
+            f"[bright_black]-- review debug: tool {escape(tool_name)} --[/bright_black]",
+            args.quiet,
+        )
+        print_console(escape(_clip(event.get("tool_args"))), args.quiet)
+        tool_output = event.get("tool_output")
+        if isinstance(tool_output, str):
+            summary = f"tool_output {_summarize_text(tool_output)} (omitted)"
+            if _looks_like_error_text(tool_name, tool_output):
+                summary += " [possible error text]"
+            print_console(f"[bright_black]{summary}[/bright_black]", args.quiet)
+            if str(tool_output or "").startswith("Tool execution failed:"):
+                print_console(
+                    escape(_clip(tool_output)),
+                    args.quiet,
+                )
+            return
+        print_console(
+            f"[bright_black]tool_output_type={escape(type(tool_output).__name__)}[/bright_black]",
+            args.quiet,
+        )
+        print_console(escape(_clip(tool_output)), args.quiet)
+
+    return _callback

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -19,6 +19,7 @@ from .review_service import ReviewService
 from .runtime import EngineConfig, EngineState
 from .triage_constants import DEFAULT_TRIAGE_SIMILARITY_TOP_K
 from .triage_service import TriageService
+from .tools.registry import build_toolbox
 
 logger = logging.getLogger("metis")
 
@@ -217,6 +218,11 @@ class MetisEngine:
         if self._state.review_graph is None:
             self._state.review_graph = ReviewGraph(
                 llm_provider=self.llm_provider,
+                toolbox=build_toolbox(
+                    policy="code_evidence",
+                    codebase_path=self.codebase_path,
+                    timeout_seconds=self.triage_tool_timeout_seconds,
+                ),
                 plugin_config=self.plugin_config,
                 custom_prompt_text=self.custom_prompt_text,
                 custom_guidance_precedence=self.custom_guidance_precedence,

--- a/src/metis/engine/graphs/review.py
+++ b/src/metis/engine/graphs/review.py
@@ -3,7 +3,7 @@
 
 import logging
 from functools import partial
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
@@ -11,10 +11,9 @@ from langgraph.graph import StateGraph, END
 from langgraph.cache.memory import InMemoryCache
 
 from metis.utils import split_snippet, parse_json_output, enrich_issues
+from .review_tools import build_review_langchain_tools, run_review_tool_phase
 from .schemas import ReviewResponseModel, review_schema_prompt
 from .utils import (
-    retrieve_text,
-    synthesize_context,
     build_review_system_prompt,
     sanitize_review_payload,
 )
@@ -49,14 +48,23 @@ def _normalize_reviews(raw) -> list[dict]:
     return []
 
 
-def _build_body_text(state: ReviewState) -> str:
+def _build_body_text(state: ReviewState, *, include_tool_evidence: bool = True) -> str:
     """
     Format the user/body portion of the review prompt based on mode.
     """
     snippet = state.get("snippet", "") or ""
-    context = state.get("context", "") or ""
+    tool_evidence = state.get("tool_evidence", "") or ""
+    tool_evidence_summary = state.get("tool_evidence_summary", "") or ""
+    tool_evidence_citations = state.get("tool_evidence_citations", "") or ""
     mode = state.get("mode", "file")
-    include_context = bool(state.get("use_retrieval_context", True))
+
+    if not tool_evidence and (tool_evidence_summary or tool_evidence_citations):
+        tool_sections: list[str] = []
+        if tool_evidence_summary:
+            tool_sections.extend(["[SUMMARY]", tool_evidence_summary.strip(), ""])
+        if tool_evidence_citations:
+            tool_sections.extend(["[CITATIONS]", tool_evidence_citations.strip(), ""])
+        tool_evidence = "\n".join(part for part in tool_sections if part).strip()
 
     if mode == "file":
         file_path = state.get("file_path", "") or ""
@@ -66,11 +74,15 @@ def _build_body_text(state: ReviewState) -> str:
             snippet,
             "",
         ]
-        if include_context:
-            sections.extend(["CONTEXT:", context, ""])
+        if include_tool_evidence and tool_evidence:
+            sections.extend(["TOOL_EVIDENCE:", tool_evidence, ""])
     else:
+        file_path = state.get("file_path", "") or ""
         original_file = state.get("original_file") or ""
         sections = [
+            "FILE_PATH:",
+            file_path,
+            "",
             "ORIGINAL_FILE:",
             original_file,
             "",
@@ -78,8 +90,8 @@ def _build_body_text(state: ReviewState) -> str:
             snippet,
             "",
         ]
-        if include_context:
-            sections.extend(["CONTEXT:", context, ""])
+        if include_tool_evidence and tool_evidence:
+            sections.extend(["TOOL_EVIDENCE:", tool_evidence, ""])
 
     return "\n".join(sections)
 
@@ -98,20 +110,6 @@ def _post_process_reviews(
     return normalized_reviews
 
 
-def review_node_retrieve(state: ReviewState) -> ReviewState:
-    if not state.get("use_retrieval_context", True):
-        new_state: ReviewState = dict(state)
-        new_state["context"] = ""
-        return new_state
-    cp = state.get("context_prompt", "")
-    code = retrieve_text(state.get("retriever_code"), cp)
-    docs = retrieve_text(state.get("retriever_docs"), cp)
-    context = synthesize_context(code, docs)
-    new_state: ReviewState = dict(state)
-    new_state["context"] = context
-    return new_state
-
-
 def review_node_build_prompt(
     state: ReviewState,
     language_prompts: dict,
@@ -121,8 +119,10 @@ def review_node_build_prompt(
     custom_guidance_precedence: str,
     schema_prompt_section: str,
     hardware_cwe_guidance: str = "",
+    tool_guidance: str = "",
 ) -> ReviewState:
-    include_relevant_context = bool(state.get("use_retrieval_context", True))
+    retrieval_enabled = bool(state.get("use_retrieval_context", True))
+    new_state = cast(ReviewState, dict(state))
     system = build_review_system_prompt(
         language_prompts,
         default_prompt_key,
@@ -131,10 +131,65 @@ def review_node_build_prompt(
         custom_guidance_precedence,
         schema_prompt_section,
         hardware_cwe_guidance,
-        include_relevant_context=include_relevant_context,
+        tool_guidance=tool_guidance if retrieval_enabled else "",
     )
-    new_state: ReviewState = dict(state)
     new_state["system_prompt"] = system
+    return new_state
+
+
+def review_node_collect_tool_evidence(
+    state: ReviewState,
+    *,
+    chat_model,
+    toolbox,
+    tool_system_prompt: str,
+    tool_system_prompt_no_rag: str,
+) -> ReviewState:
+    new_state = cast(ReviewState, dict(state))
+    new_state["tool_evidence"] = ""
+    new_state["tool_evidence_summary"] = ""
+    new_state["tool_evidence_citations"] = ""
+    if toolbox is None or chat_model is None:
+        return new_state
+    if not hasattr(chat_model, "bind_tools"):
+        return new_state
+
+    active_toolbox = (
+        toolbox
+        if bool(state.get("use_retrieval_context", True))
+        else toolbox.without("rag_search")
+    )
+    active_tool_prompt = (
+        tool_system_prompt
+        if bool(state.get("use_retrieval_context", True))
+        else tool_system_prompt_no_rag
+    )
+    tools, tools_by_name = build_review_langchain_tools(
+        active_toolbox,
+        retriever_code=state.get("retriever_code"),
+        retriever_docs=state.get("retriever_docs"),
+        debug_callback=state.get("debug_callback"),
+    )
+    if not tools:
+        return new_state
+
+    try:
+        outputs = run_review_tool_phase(
+            chat_model=chat_model,
+            tools=tools,
+            tools_by_name=tools_by_name,
+            system_prompt=active_tool_prompt,
+            body_text=_build_body_text(state, include_tool_evidence=False),
+        )
+    except Exception as exc:
+        logger.warning("Review tool evidence phase failed: %s", exc)
+        return new_state
+
+    new_state["tool_evidence"] = outputs.get("tool_evidence", "") or ""
+    new_state["tool_evidence_summary"] = outputs.get("tool_evidence_summary", "") or ""
+    new_state["tool_evidence_citations"] = (
+        outputs.get("tool_evidence_citations", "") or ""
+    )
     return new_state
 
 
@@ -163,7 +218,7 @@ def review_node_llm(
             raw = None
 
     reviews = _normalize_reviews(raw)
-    new_state: ReviewState = dict(state)
+    new_state = cast(ReviewState, dict(state))
     new_state["parsed_reviews"] = reviews
     return new_state
 
@@ -175,7 +230,7 @@ def review_node_parse(state: ReviewState) -> ReviewState:
         state.get("file_path", "") or "",
     )
 
-    new_state: ReviewState = dict(state)
+    new_state = cast(ReviewState, dict(state))
     new_state["parsed_reviews"] = normalized
     return new_state
 
@@ -184,6 +239,7 @@ class ReviewGraph:
     def __init__(
         self,
         llm_provider,
+        toolbox,
         plugin_config,
         custom_prompt_text,
         custom_guidance_precedence,
@@ -192,6 +248,7 @@ class ReviewGraph:
         chat_model_kwargs: dict[str, Any] | None = None,
     ):
         self.llm_provider = llm_provider
+        self.toolbox = toolbox
         self.plugin_config = plugin_config
         self.custom_prompt_text = custom_prompt_text
         self.custom_guidance_precedence = custom_guidance_precedence or ""
@@ -203,20 +260,48 @@ class ReviewGraph:
         self.report_prompt = self.plugin_config.get("general_prompts", {}).get(
             "security_review_report", ""
         )
+        self.review_tool_guidance = self.plugin_config.get("general_prompts", {}).get(
+            "review_tool_guidance", ""
+        )
+        self.review_tool_system_prompt = self.plugin_config.get(
+            "general_prompts", {}
+        ).get(
+            "review_tool_system_prompt",
+            (
+                "You are gathering grounded static evidence for a security review. "
+                "Use tools only when they materially improve confidence. "
+                "Prefer local inspection first with sed/cat, then broader lookup with grep/find_name. "
+                "Keep tool use bounded and return a concise plain-text evidence summary."
+            ),
+        )
+        self.review_tool_system_prompt_no_rag = self.plugin_config.get(
+            "general_prompts", {}
+        ).get(
+            "review_tool_system_prompt_no_rag",
+            (
+                "You are gathering grounded static evidence for a security review. "
+                "Use tools only when they materially improve confidence. "
+                "Prefer local inspection first with sed/cat on the current file or hunk. "
+                "Use grep or find_name for broader lookup only when direct local inspection is not enough. "
+                "Keep tool use bounded and evidence-driven. "
+                "After finishing tool use, return a concise plain-text evidence summary. Do not return JSON."
+            ),
+        )
         self.hardware_cwe_guidance = self.plugin_config.get("general_prompts", {}).get(
             "hardware_cwe_guidance", ""
         )
 
+        self._review_chat_model = None
         self._structured_review_node = None
         self._fallback_review_node = None
-        self._structured_review_node = self._create_structured_review_runnable()
+        self._structured_review_node = self._create_review_runnables()
         if self._structured_review_node is None and self._fallback_review_node is None:
             raise RuntimeError(
                 "Unable to create review runnable; OpenAI-based provider required."
             )
-        self._app_cache = {}
+        self._app_cache: dict[tuple[int, str], Any] = {}
 
-    def _create_structured_review_runnable(self):
+    def _create_review_runnables(self):
         get_chat_model = getattr(self.llm_provider, "get_chat_model", None)
         if not callable(get_chat_model):
             return None
@@ -229,6 +314,7 @@ class ReviewGraph:
                 "Unable to instantiate chat model for structured output: %s", exc
             )
             return None
+        self._review_chat_model = chat_model
         prompt = ChatPromptTemplate.from_messages(
             [("system", "{system_prompt}"), ("user", "{body_text}")]
         )
@@ -251,16 +337,23 @@ class ReviewGraph:
             return cached
 
         graph = StateGraph(ReviewState)
-        retrieve = review_node_retrieve
         build_prompt = partial(
             review_node_build_prompt,
             language_prompts=language_prompts,
             default_prompt_key=default_prompt_key,
             report_prompt=self.report_prompt,
+            tool_guidance=self.review_tool_guidance,
             custom_prompt_text=self.custom_prompt_text,
             custom_guidance_precedence=self.custom_guidance_precedence,
             schema_prompt_section=self._schema_prompt_section,
             hardware_cwe_guidance=self.hardware_cwe_guidance,
+        )
+        collect_tool_evidence = partial(
+            review_node_collect_tool_evidence,
+            chat_model=self._review_chat_model,
+            toolbox=self.toolbox,
+            tool_system_prompt=self.review_tool_system_prompt,
+            tool_system_prompt_no_rag=self.review_tool_system_prompt_no_rag,
         )
         review = partial(
             review_node_llm,
@@ -269,14 +362,14 @@ class ReviewGraph:
         )
         parse = review_node_parse
 
-        graph.add_node("retrieve", retrieve)
         graph.add_node("build_prompt", build_prompt)
+        graph.add_node("collect_tool_evidence", collect_tool_evidence)
         graph.add_node("review", review)
         graph.add_node("parse", parse)
 
-        graph.set_entry_point("retrieve")
-        graph.add_edge("retrieve", "build_prompt")
-        graph.add_edge("build_prompt", "review")
+        graph.set_entry_point("build_prompt")
+        graph.add_edge("build_prompt", "collect_tool_evidence")
+        graph.add_edge("collect_tool_evidence", "review")
         graph.add_edge("review", "parse")
         graph.add_edge("parse", END)
 
@@ -289,16 +382,16 @@ class ReviewGraph:
         snippet = request["snippet"]
         retriever_code = request["retriever_code"]
         retriever_docs = request["retriever_docs"]
-        context_prompt = request["context_prompt"]
         language_prompts = request["language_prompts"]
         default_prompt_key = request.get("default_prompt_key", "security_review_file")
         relative_file = request.get("relative_file")
         mode = request.get("mode", "file")
         original_file = request.get("original_file")
         use_retrieval_context = bool(request.get("use_retrieval_context", True))
+        debug_callback = request.get("debug_callback")
 
         chunks = split_snippet(snippet, self.max_token_length)
-        accumulated = []
+        accumulated: list[dict] = []
         app = self._build_app(language_prompts, default_prompt_key)
         for chunk in chunks:
             state = {
@@ -306,11 +399,11 @@ class ReviewGraph:
                 "snippet": chunk,
                 "retriever_code": retriever_code,
                 "retriever_docs": retriever_docs,
-                "context_prompt": context_prompt,
                 "relative_file": relative_file,
                 "mode": mode,
                 "original_file": original_file,
                 "use_retrieval_context": use_retrieval_context,
+                "debug_callback": debug_callback,
             }
             out = app.invoke(state)
             chunk_reviews = out.get("parsed_reviews", []) or []
@@ -319,15 +412,15 @@ class ReviewGraph:
 
         if not accumulated:
             file_display = relative_file if relative_file else file_path
-            result = {
+            empty_result: dict[str, Any] = {
                 "file": file_display,
                 "file_path": file_path,
                 "reviews": [],
             }
-            return result
+            return empty_result
 
         file_display = relative_file if relative_file else file_path
-        result = {
+        result: dict[str, Any] = {
             "file": file_display,
             "file_path": file_path,
             "reviews": accumulated,

--- a/src/metis/engine/graphs/review.py
+++ b/src/metis/engine/graphs/review.py
@@ -10,16 +10,28 @@ from langchain_core.output_parsers import StrOutputParser
 from langgraph.graph import StateGraph, END
 from langgraph.cache.memory import InMemoryCache
 
+from metis.engine.retrieval_support import retrieve_context_deterministic
 from metis.utils import split_snippet, parse_json_output, enrich_issues
+from .review_retrieval import (
+    assess_review_context_quality,
+    build_review_evidence_frame,
+    build_review_retrieval_query,
+    compute_review_obligation_coverage,
+)
 from .review_tools import build_review_langchain_tools, run_review_tool_phase
 from .schemas import ReviewResponseModel, review_schema_prompt
 from .utils import (
     build_review_system_prompt,
     sanitize_review_payload,
+    synthesize_context,
 )
 from .types import ReviewRequest, ReviewState
 
 logger = logging.getLogger("metis")
+
+_REVIEW_BASELINE_CONTEXT_MAX_CHARS = 3600
+_REVIEW_BASELINE_CODE_CONTEXT_CHARS = 2600
+_REVIEW_BASELINE_DOC_CONTEXT_CHARS = 1000
 
 
 def _normalize_reviews(raw) -> list[dict]:
@@ -53,18 +65,10 @@ def _build_body_text(state: ReviewState, *, include_tool_evidence: bool = True) 
     Format the user/body portion of the review prompt based on mode.
     """
     snippet = state.get("snippet", "") or ""
+    baseline_context = state.get("baseline_context", "") or ""
+    review_evidence_frame = state.get("review_evidence_frame", "") or ""
     tool_evidence = state.get("tool_evidence", "") or ""
-    tool_evidence_summary = state.get("tool_evidence_summary", "") or ""
-    tool_evidence_citations = state.get("tool_evidence_citations", "") or ""
     mode = state.get("mode", "file")
-
-    if not tool_evidence and (tool_evidence_summary or tool_evidence_citations):
-        tool_sections: list[str] = []
-        if tool_evidence_summary:
-            tool_sections.extend(["[SUMMARY]", tool_evidence_summary.strip(), ""])
-        if tool_evidence_citations:
-            tool_sections.extend(["[CITATIONS]", tool_evidence_citations.strip(), ""])
-        tool_evidence = "\n".join(part for part in tool_sections if part).strip()
 
     if mode == "file":
         file_path = state.get("file_path", "") or ""
@@ -74,6 +78,10 @@ def _build_body_text(state: ReviewState, *, include_tool_evidence: bool = True) 
             snippet,
             "",
         ]
+        if baseline_context:
+            sections.extend(["BASELINE_CONTEXT:", baseline_context, ""])
+        if review_evidence_frame:
+            sections.extend(["REVIEW_EVIDENCE_FRAME:", review_evidence_frame, ""])
         if include_tool_evidence and tool_evidence:
             sections.extend(["TOOL_EVIDENCE:", tool_evidence, ""])
     else:
@@ -90,10 +98,23 @@ def _build_body_text(state: ReviewState, *, include_tool_evidence: bool = True) 
             snippet,
             "",
         ]
+        if baseline_context:
+            sections.extend(["BASELINE_CONTEXT:", baseline_context, ""])
+        if review_evidence_frame:
+            sections.extend(["REVIEW_EVIDENCE_FRAME:", review_evidence_frame, ""])
         if include_tool_evidence and tool_evidence:
             sections.extend(["TOOL_EVIDENCE:", tool_evidence, ""])
 
     return "\n".join(sections)
+
+
+def _emit_review_debug(debug_callback, event: str, **payload) -> None:
+    if not callable(debug_callback):
+        return
+    try:
+        debug_callback({"event": event, **payload})
+    except Exception:
+        logger.debug("Review debug callback failed", exc_info=True)
 
 
 def _post_process_reviews(
@@ -123,6 +144,14 @@ def review_node_build_prompt(
 ) -> ReviewState:
     retrieval_enabled = bool(state.get("use_retrieval_context", True))
     new_state = cast(ReviewState, dict(state))
+    grounding_guidance = ""
+    if retrieval_enabled:
+        grounding_guidance = (
+            "Additional retrieval grounding may be provided as BASELINE_CONTEXT and "
+            "REVIEW_EVIDENCE_FRAME. Treat BASELINE_CONTEXT as deterministic repository "
+            "context and REVIEW_EVIDENCE_FRAME as evidence obligations plus likely gaps. "
+            "If either section is empty, ignore it."
+        )
     system = build_review_system_prompt(
         language_prompts,
         default_prompt_key,
@@ -131,9 +160,92 @@ def review_node_build_prompt(
         custom_guidance_precedence,
         schema_prompt_section,
         hardware_cwe_guidance,
-        tool_guidance=tool_guidance if retrieval_enabled else "",
+        tool_guidance=(
+            "\n".join(part for part in (grounding_guidance, tool_guidance) if part)
+            if retrieval_enabled
+            else ""
+        ),
     )
     new_state["system_prompt"] = system
+    return new_state
+
+
+def review_node_collect_baseline_context(state: ReviewState) -> ReviewState:
+    new_state = cast(ReviewState, dict(state))
+    new_state["baseline_context_query"] = ""
+    new_state["baseline_context"] = ""
+    new_state["baseline_context_quality"] = ""
+    new_state["review_evidence_frame"] = ""
+    if not bool(state.get("use_retrieval_context", True)):
+        return new_state
+
+    query, symbols, focus_terms = build_review_retrieval_query(
+        file_path=str(state.get("file_path", "") or ""),
+        relative_file=str(state.get("relative_file", "") or ""),
+        mode=str(state.get("mode", "file") or "file"),
+        snippet=str(state.get("snippet", "") or ""),
+        original_file=str(state.get("original_file", "") or ""),
+    )
+    code = retrieve_context_deterministic(
+        state.get("retriever_code"),
+        query,
+        max_chars=_REVIEW_BASELINE_CODE_CONTEXT_CHARS,
+    )
+    docs = retrieve_context_deterministic(
+        state.get("retriever_docs"),
+        query,
+        max_chars=_REVIEW_BASELINE_DOC_CONTEXT_CHARS,
+    )
+
+    code_ok, code_quality = assess_review_context_quality(
+        code,
+        file_path=str(state.get("file_path", "") or ""),
+        symbols=symbols,
+        focus_terms=focus_terms,
+    )
+    docs_ok, docs_quality = assess_review_context_quality(
+        docs,
+        file_path=str(state.get("file_path", "") or ""),
+        symbols=symbols,
+        focus_terms=focus_terms,
+    )
+
+    accepted_code = code if code_ok else ""
+    accepted_docs = docs if docs_ok else ""
+    baseline_context = synthesize_context(accepted_code, accepted_docs)
+    quality_parts = [
+        f"code={code_quality or 'empty'}",
+        f"docs={docs_quality or 'empty'}",
+    ]
+    if baseline_context and len(baseline_context) > _REVIEW_BASELINE_CONTEXT_MAX_CHARS:
+        baseline_context = (
+            baseline_context[:_REVIEW_BASELINE_CONTEXT_MAX_CHARS] + "\n...[truncated]"
+        )
+
+    new_state["baseline_context_query"] = query
+    new_state["baseline_context"] = baseline_context
+    new_state["baseline_context_quality"] = ", ".join(quality_parts)
+    baseline_coverage = compute_review_obligation_coverage(
+        baseline_context,
+        symbols=symbols,
+        focus_terms=focus_terms,
+    )
+    new_state["review_evidence_frame"] = build_review_evidence_frame(
+        query=query,
+        symbols=symbols,
+        focus_terms=focus_terms,
+        baseline_quality=new_state["baseline_context_quality"],
+        baseline_context=baseline_context,
+        coverage=baseline_coverage,
+    )
+    _emit_review_debug(
+        state.get("debug_callback"),
+        "retrieval",
+        query=query,
+        code_quality=code_quality,
+        docs_quality=docs_quality,
+        baseline_context=baseline_context,
+    )
     return new_state
 
 
@@ -147,8 +259,6 @@ def review_node_collect_tool_evidence(
 ) -> ReviewState:
     new_state = cast(ReviewState, dict(state))
     new_state["tool_evidence"] = ""
-    new_state["tool_evidence_summary"] = ""
-    new_state["tool_evidence_citations"] = ""
     if toolbox is None or chat_model is None:
         return new_state
     if not hasattr(chat_model, "bind_tools"):
@@ -173,6 +283,19 @@ def review_node_collect_tool_evidence(
     if not tools:
         return new_state
 
+    baseline_query, symbols, focus_terms = build_review_retrieval_query(
+        file_path=str(state.get("file_path", "") or ""),
+        relative_file=str(state.get("relative_file", "") or ""),
+        mode=str(state.get("mode", "file") or "file"),
+        snippet=str(state.get("snippet", "") or ""),
+        original_file=str(state.get("original_file", "") or ""),
+    )
+    baseline_coverage = compute_review_obligation_coverage(
+        str(state.get("baseline_context", "") or ""),
+        symbols=symbols,
+        focus_terms=focus_terms,
+    )
+
     try:
         outputs = run_review_tool_phase(
             chat_model=chat_model,
@@ -180,15 +303,42 @@ def review_node_collect_tool_evidence(
             tools_by_name=tools_by_name,
             system_prompt=active_tool_prompt,
             body_text=_build_body_text(state, include_tool_evidence=False),
+            review_search_context={
+                "file_path": str(state.get("file_path", "") or ""),
+                "mode": str(state.get("mode", "file") or "file"),
+                "symbols": symbols,
+                "focus_terms": focus_terms,
+                "baseline_query": baseline_query,
+                "uncovered_obligations": [
+                    name for name, covered in baseline_coverage.items() if not covered
+                ],
+            },
         )
     except Exception as exc:
         logger.warning("Review tool evidence phase failed: %s", exc)
         return new_state
 
     new_state["tool_evidence"] = outputs.get("tool_evidence", "") or ""
-    new_state["tool_evidence_summary"] = outputs.get("tool_evidence_summary", "") or ""
-    new_state["tool_evidence_citations"] = (
-        outputs.get("tool_evidence_citations", "") or ""
+    combined_evidence = "\n\n".join(
+        part
+        for part in (
+            str(state.get("baseline_context", "") or "").strip(),
+            new_state["tool_evidence"].strip(),
+        )
+        if part
+    )
+    combined_coverage = compute_review_obligation_coverage(
+        combined_evidence,
+        symbols=symbols,
+        focus_terms=focus_terms,
+    )
+    new_state["review_evidence_frame"] = build_review_evidence_frame(
+        query=baseline_query,
+        symbols=symbols,
+        focus_terms=focus_terms,
+        baseline_quality=str(state.get("baseline_context_quality", "") or ""),
+        baseline_context=str(state.get("baseline_context", "") or ""),
+        coverage=combined_coverage,
     )
     return new_state
 
@@ -348,6 +498,7 @@ class ReviewGraph:
             schema_prompt_section=self._schema_prompt_section,
             hardware_cwe_guidance=self.hardware_cwe_guidance,
         )
+        collect_baseline_context = review_node_collect_baseline_context
         collect_tool_evidence = partial(
             review_node_collect_tool_evidence,
             chat_model=self._review_chat_model,
@@ -363,12 +514,14 @@ class ReviewGraph:
         parse = review_node_parse
 
         graph.add_node("build_prompt", build_prompt)
+        graph.add_node("collect_baseline_context", collect_baseline_context)
         graph.add_node("collect_tool_evidence", collect_tool_evidence)
         graph.add_node("review", review)
         graph.add_node("parse", parse)
 
         graph.set_entry_point("build_prompt")
-        graph.add_edge("build_prompt", "collect_tool_evidence")
+        graph.add_edge("build_prompt", "collect_baseline_context")
+        graph.add_edge("collect_baseline_context", "collect_tool_evidence")
         graph.add_edge("collect_tool_evidence", "review")
         graph.add_edge("review", "parse")
         graph.add_edge("parse", END)

--- a/src/metis/engine/graphs/review_retrieval.py
+++ b/src/metis/engine/graphs/review_retrieval.py
@@ -1,0 +1,507 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+from metis.engine.analysis.c_family_helpers import extract_code_like_symbols
+
+REVIEW_SECURITY_QUERY_TERMS = (
+    "auth",
+    "authorize",
+    "permission",
+    "privilege",
+    "token",
+    "secret",
+    "key",
+    "password",
+    "crypto",
+    "sanitize",
+    "validate",
+    "check",
+    "bound",
+    "length",
+    "overflow",
+    "underflow",
+    "memcpy",
+    "strcpy",
+    "malloc",
+    "free",
+    "sql",
+    "query",
+    "command",
+    "exec",
+    "deserialize",
+    "upload",
+    "path",
+)
+
+REVIEW_OBLIGATION_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "component purpose": (
+        "purpose",
+        "component",
+        "module",
+        "responsible",
+        "responsibility",
+        "enforce",
+        "enforcement",
+    ),
+    "externally controlled inputs": (
+        "input",
+        "extern",
+        "user",
+        "request",
+        "argument",
+        "arg",
+        "token",
+        "payload",
+    ),
+    "callers or wrappers": (
+        "caller",
+        "called by",
+        "call site",
+        "wrapper",
+        "invoked",
+        "used by",
+        "reference",
+    ),
+    "trust or privilege boundary": (
+        "trust",
+        "boundary",
+        "privilege",
+        "permission",
+        "authorize",
+        "auth",
+        "role",
+        "principal",
+    ),
+    "validation / sanitization / authorization checks": (
+        "validate",
+        "validation",
+        "sanitize",
+        "sanitization",
+        "check",
+        "guard",
+        "verify",
+        "bounds",
+        "length",
+        "authorize",
+    ),
+    "key unresolved gaps": (
+        "gap",
+        "unknown",
+        "unclear",
+        "unresolved",
+        "missing",
+        "none",
+    ),
+}
+
+REVIEW_OBLIGATION_SECTION_NAMES: dict[str, str] = {
+    "component purpose": "COMPONENT_PURPOSE",
+    "externally controlled inputs": "INPUT_SOURCES",
+    "callers or wrappers": "RELATED_CALLERS",
+    "trust or privilege boundary": "TRUST_BOUNDARY",
+    "validation / sanitization / authorization checks": "VALIDATION_GUARDS",
+    "key unresolved gaps": "UNRESOLVED",
+}
+
+_SECTION_HEADER_RE = re.compile(r"^\[([A-Z_]+)\]\s*$", re.MULTILINE)
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+_LOW_VALUE_QUERY_TOKENS = {
+    "what",
+    "when",
+    "where",
+    "which",
+    "this",
+    "that",
+    "code",
+    "docs",
+    "file",
+    "mode",
+    "scope",
+    "question",
+    "security",
+    "review",
+    "evidence",
+    "collection",
+    "related",
+    "current",
+    "around",
+    "implementation",
+}
+
+
+def extract_review_focus_terms(
+    file_path: str,
+    snippet: str,
+    original_file: str = "",
+    *,
+    limit: int = 8,
+) -> list[str]:
+    lowered = " ".join(
+        str(part or "") for part in (snippet, file_path, original_file)
+    ).lower()
+    terms: list[str] = []
+    for term in REVIEW_SECURITY_QUERY_TERMS:
+        if term in lowered:
+            terms.append(term)
+            if len(terms) >= limit:
+                break
+    return terms
+
+
+def build_review_retrieval_query(
+    *,
+    file_path: str,
+    relative_file: str = "",
+    mode: str = "file",
+    snippet: str,
+    original_file: str = "",
+) -> tuple[str, list[str], list[str]]:
+    symbols = extract_code_like_symbols(
+        file_path,
+        relative_file,
+        snippet,
+        original_file,
+        limit=12,
+    )
+    focus_terms = extract_review_focus_terms(file_path, snippet, original_file)
+    symbol_text = ", ".join(symbols) if symbols else "<none>"
+    focus_text = ", ".join(focus_terms) if focus_terms else "<none>"
+    scope_text = (
+        "changed code and the surrounding implementation"
+        if mode == "patch"
+        else "the current file and directly related callers, helpers, and guards"
+    )
+    query = (
+        "Security review evidence collection.\n"
+        f"Review scope: {scope_text}.\n"
+        f"File: {file_path or '<unknown>'}\n"
+        f"Mode: {mode}\n"
+        f"Candidate symbols: {symbol_text}\n"
+        f"Security focus terms: {focus_text}\n"
+        f"Snippet:\n{snippet}\n\n"
+        "Question: What related code or documentation explains the component purpose, "
+        "externally controlled inputs, callers, trust boundaries, validation or sanitization "
+        "responsibilities, enforcement points, and security-relevant assumptions for this code?"
+    )
+    return query, symbols, focus_terms
+
+
+def assess_review_context_quality(
+    text: str,
+    *,
+    file_path: str,
+    symbols: list[str],
+    focus_terms: list[str],
+) -> tuple[bool, str]:
+    normalized = str(text or "").strip()
+    if not normalized:
+        return False, "empty"
+
+    lowered = normalized.lower()
+    score = 0
+    reasons: list[str] = []
+
+    file_name = Path(file_path).name.lower()
+    if file_name and file_name in lowered:
+        score += 2
+        reasons.append("file-name")
+
+    matched_symbols = [
+        symbol for symbol in symbols if symbol and symbol.lower() in lowered
+    ]
+    if matched_symbols:
+        score += min(3, len(matched_symbols))
+        reasons.append(f"symbols={len(matched_symbols)}")
+
+    matched_focus = [term for term in focus_terms if term and term in lowered]
+    if matched_focus:
+        score += min(2, len(matched_focus))
+        reasons.append(f"security-terms={len(matched_focus)}")
+
+    query_tokens = build_review_quality_tokens(
+        file_path=file_path,
+        symbols=symbols,
+        focus_terms=focus_terms,
+    )
+    matched_query_tokens = [token for token in query_tokens if token in lowered]
+    if matched_query_tokens:
+        score += min(3, len(matched_query_tokens))
+        reasons.append(f"query-tokens={len(matched_query_tokens)}")
+
+    typed_sections = parse_review_typed_sections(normalized)
+    relevant_typed_sections = {
+        name: content
+        for name, content in typed_sections.items()
+        if name in REVIEW_OBLIGATION_SECTION_NAMES.values()
+    }
+    if relevant_typed_sections:
+        score += min(3, len(relevant_typed_sections))
+        reasons.append(f"typed-sections={len(relevant_typed_sections)}")
+
+    coverage = compute_review_obligation_coverage(
+        normalized,
+        symbols=symbols,
+        focus_terms=focus_terms,
+    )
+    covered_count = sum(1 for covered in coverage.values() if covered)
+    if covered_count:
+        score += min(3, covered_count)
+        reasons.append(f"obligations={covered_count}")
+
+    if "[" in normalized and "]" in normalized:
+        score += 1
+        reasons.append("citations")
+
+    if ":" in normalized:
+        score += 1
+        reasons.append("structured")
+
+    strong_signal = (
+        bool(file_name and file_name in lowered)
+        or bool(matched_symbols)
+        or bool(matched_query_tokens)
+        or bool(relevant_typed_sections)
+        or (covered_count >= 2)
+    )
+    verdict = score >= 2 and strong_signal
+    if verdict:
+        return True, ",".join(reasons) if reasons else "accepted"
+    detail = ",".join(reasons) if reasons else "insufficient-match"
+    return False, f"low-signal:{detail}"
+
+
+def compute_review_obligation_coverage(
+    text: str,
+    *,
+    symbols: list[str],
+    focus_terms: list[str],
+) -> dict[str, bool]:
+    lowered = str(text or "").lower()
+    typed_sections = parse_review_typed_sections(text)
+    coverage: dict[str, bool] = {}
+    for obligation, keywords in REVIEW_OBLIGATION_KEYWORDS.items():
+        keyword_match = any(keyword in lowered for keyword in keywords)
+        symbol_match = obligation == "callers or wrappers" and any(
+            symbol and symbol.lower() in lowered for symbol in symbols
+        )
+        focus_match = obligation == "trust or privilege boundary" and any(
+            term in lowered for term in focus_terms
+        )
+        section_name = REVIEW_OBLIGATION_SECTION_NAMES[obligation]
+        section_match = bool(typed_sections.get(section_name))
+        coverage[obligation] = bool(
+            section_match or keyword_match or symbol_match or focus_match
+        )
+    return coverage
+
+
+def missing_review_obligations(coverage: dict[str, bool]) -> list[str]:
+    return [name for name, covered in coverage.items() if not covered]
+
+
+def build_review_evidence_frame(
+    *,
+    query: str,
+    symbols: list[str],
+    focus_terms: list[str],
+    baseline_quality: str,
+    baseline_context: str,
+    coverage: dict[str, bool],
+) -> str:
+    if baseline_context:
+        gaps = (
+            "Prefer citing baseline context first, then use tools only for unresolved "
+            "obligations."
+        )
+    else:
+        gaps = (
+            "Baseline retrieval was weak or empty; use tools to resolve missing callers, "
+            "guards, and trust boundaries."
+        )
+    missing = missing_review_obligations(coverage)
+    sections = [
+        "[RETRIEVAL_QUERY]",
+        query.strip(),
+        "",
+        "[CANDIDATE_SYMBOLS]",
+        ", ".join(symbols) if symbols else "<none>",
+        "",
+        "[SECURITY_FOCUS]",
+        ", ".join(focus_terms) if focus_terms else "<none>",
+        "",
+        "[BASELINE_RETRIEVAL_QUALITY]",
+        baseline_quality or "unknown",
+        "",
+        "[OBLIGATION_COVERAGE]",
+        "\n".join(
+            f"- {name}: {'covered' if covered else 'missing'}"
+            for name, covered in coverage.items()
+        ),
+        "",
+        "[MISSING_OBLIGATIONS]",
+        "\n".join(f"- {name}" for name in missing) if missing else "- <none>",
+        "",
+        "[GAP_HINT]",
+        gaps,
+    ]
+    return "\n".join(sections).strip()
+
+
+def shape_review_rag_query(
+    raw_query: str,
+    *,
+    file_path: str,
+    mode: str,
+    symbols: list[str],
+    focus_terms: list[str],
+    uncovered_obligations: list[str],
+    baseline_query: str = "",
+) -> str:
+    normalized_query = str(raw_query or "").strip()
+    if not normalized_query:
+        normalized_query = (
+            "What related code or docs resolve the missing security review obligations?"
+        )
+    symbol_text = ", ".join(symbols[:10]) if symbols else "<none>"
+    focus_text = ", ".join(focus_terms[:8]) if focus_terms else "<none>"
+    obligation_text = (
+        ", ".join(uncovered_obligations) if uncovered_obligations else "<none>"
+    )
+    sections = [
+        "Security review targeted retrieval.",
+        f"File: {file_path or '<unknown>'}",
+        f"Mode: {mode or 'file'}",
+        f"Candidate symbols: {symbol_text}",
+        f"Security focus terms: {focus_text}",
+        f"Missing obligations: {obligation_text}",
+        f"Requested lookup: {normalized_query}",
+    ]
+    if baseline_query:
+        sections.extend(["", "[BASELINE_RETRIEVAL_QUESTION]", baseline_query.strip()])
+    sections.extend(
+        [
+            "",
+            "Return code-first evidence that helps resolve the missing obligations. "
+            "Prefer callers, wrappers, guards, trust boundaries, and enforcement logic.",
+        ]
+    )
+    return "\n".join(sections).strip()
+
+
+def build_review_quality_tokens(
+    *,
+    file_path: str,
+    symbols: list[str],
+    focus_terms: list[str],
+) -> list[str]:
+    path_tokens = [
+        token.lower()
+        for token in _TOKEN_RE.findall(Path(file_path or "").name)
+        if token.lower() not in _LOW_VALUE_QUERY_TOKENS
+    ]
+    symbol_tokens = [
+        token.lower()
+        for token in symbols
+        if token and token.lower() not in _LOW_VALUE_QUERY_TOKENS
+    ]
+    focus_tokens = [
+        token.lower()
+        for token in focus_terms
+        if token and token.lower() not in _LOW_VALUE_QUERY_TOKENS
+    ]
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for token in path_tokens + symbol_tokens + focus_tokens:
+        if token in seen:
+            continue
+        seen.add(token)
+        ordered.append(token)
+    return ordered
+
+
+def classify_review_evidence(
+    text: str,
+    *,
+    symbols: list[str],
+    focus_terms: list[str],
+) -> dict[str, list[str]]:
+    buckets = {name: [] for name in REVIEW_OBLIGATION_SECTION_NAMES.values()}
+    normalized = str(text or "").strip()
+    if not normalized:
+        return buckets
+
+    segments = [
+        segment.strip()
+        for segment in re.split(r"\n\s*\n", normalized)
+        if segment.strip()
+    ]
+    lowered_focus = [term.lower() for term in focus_terms if term]
+    lowered_symbols = [symbol.lower() for symbol in symbols if symbol]
+
+    for segment in segments:
+        lowered = segment.lower()
+        if any(
+            keyword in lowered
+            for keyword in REVIEW_OBLIGATION_KEYWORDS["component purpose"]
+        ):
+            buckets["COMPONENT_PURPOSE"].append(segment)
+        if any(
+            keyword in lowered
+            for keyword in REVIEW_OBLIGATION_KEYWORDS["externally controlled inputs"]
+        ):
+            buckets["INPUT_SOURCES"].append(segment)
+        if any(
+            keyword in lowered
+            for keyword in REVIEW_OBLIGATION_KEYWORDS["callers or wrappers"]
+        ) or any(symbol in lowered for symbol in lowered_symbols):
+            buckets["RELATED_CALLERS"].append(segment)
+        if any(
+            keyword in lowered
+            for keyword in REVIEW_OBLIGATION_KEYWORDS["trust or privilege boundary"]
+        ) or any(term in lowered for term in lowered_focus):
+            buckets["TRUST_BOUNDARY"].append(segment)
+        if any(
+            keyword in lowered
+            for keyword in REVIEW_OBLIGATION_KEYWORDS[
+                "validation / sanitization / authorization checks"
+            ]
+        ):
+            buckets["VALIDATION_GUARDS"].append(segment)
+        if any(
+            keyword in lowered
+            for keyword in REVIEW_OBLIGATION_KEYWORDS["key unresolved gaps"]
+        ):
+            buckets["UNRESOLVED"].append(segment)
+
+    for key, values in buckets.items():
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            compact = value.strip()
+            if not compact or compact in seen:
+                continue
+            seen.add(compact)
+            deduped.append(compact)
+        buckets[key] = deduped
+    return buckets
+
+
+def parse_review_typed_sections(text: str) -> dict[str, str]:
+    normalized = str(text or "")
+    matches = list(_SECTION_HEADER_RE.finditer(normalized))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        name = match.group(1)
+        start = match.end()
+        end = (
+            matches[index + 1].start() if index + 1 < len(matches) else len(normalized)
+        )
+        content = normalized[start:end].strip()
+        if content:
+            sections[name] = content
+    return sections

--- a/src/metis/engine/graphs/review_tools.py
+++ b/src/metis/engine/graphs/review_tools.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("metis")
+
+MAX_REVIEW_TOOL_ROUNDS = 4
+MAX_REVIEW_TOOL_EVIDENCE_CHARS = 6000
+MAX_REVIEW_TOOL_CITATION_EXCERPT_CHARS = 240
+
+
+class _SedArgs(BaseModel):
+    path: str = Field(description="Repository-relative file path to inspect")
+    start_line: int = Field(description="Inclusive 1-based start line number")
+    end_line: int = Field(description="Inclusive 1-based end line number")
+
+
+class _CatArgs(BaseModel):
+    path: str = Field(description="Repository-relative file path to read")
+
+
+class _GrepArgs(BaseModel):
+    pattern: str = Field(description="Regular expression or literal text to search")
+    path: str = Field(description="Repository-relative file or directory to search")
+
+
+class _FindNameArgs(BaseModel):
+    name: str = Field(description="Exact filename to locate")
+    max_results: int = Field(
+        default=20, description="Maximum number of matches to return"
+    )
+
+
+class _RagArgs(BaseModel):
+    query: str = Field(
+        description="Question or search text for indexed code and docs retrieval"
+    )
+
+
+def _clip_text(value: Any, limit: int = MAX_REVIEW_TOOL_EVIDENCE_CHARS) -> str:
+    text = str(value or "")
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "\n...[truncated]"
+
+
+def _stringify_tool_output(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(str(item) for item in value)
+    if isinstance(value, dict):
+        return json.dumps(value, indent=2, sort_keys=True)
+    return str(value)
+
+
+def _emit_review_debug(debug_callback, event: str, **payload) -> None:
+    if not callable(debug_callback):
+        return
+    try:
+        debug_callback({"event": event, **payload})
+    except Exception:
+        logger.debug("Review debug callback failed", exc_info=True)
+
+
+def build_review_langchain_tools(
+    toolbox,
+    *,
+    retriever_code=None,
+    retriever_docs=None,
+    debug_callback=None,
+):
+    def _tool_debug_args(name: str, **kwargs) -> dict[str, Any]:
+        out = dict(kwargs)
+        describe_call = getattr(toolbox, "describe_call", None)
+        try:
+            if callable(describe_call):
+                details = describe_call(name, **kwargs)
+            else:
+                details = toolbox.describe(name)
+        except Exception:
+            return out
+        if not isinstance(details, dict):
+            return out
+        for key, value in details.items():
+            out.setdefault(key, value)
+        return out
+
+    def _wrap_tool(name: str, description: str, args_schema, invoke):
+        def _runner(**kwargs):
+            try:
+                result = invoke(**kwargs)
+            except Exception as exc:
+                output = f"Tool execution failed: {exc}"
+                _emit_review_debug(
+                    debug_callback,
+                    "tool_call",
+                    tool_name=name,
+                    tool_args=_tool_debug_args(name, **kwargs),
+                    tool_output=output,
+                )
+                return output
+
+            output = _stringify_tool_output(result)
+            _emit_review_debug(
+                debug_callback,
+                "tool_call",
+                tool_name=name,
+                tool_args=_tool_debug_args(name, **kwargs),
+                tool_output=output,
+            )
+            return output
+
+        return StructuredTool.from_function(
+            func=_runner,
+            name=name,
+            description=description,
+            args_schema=args_schema,
+        )
+
+    tools = [
+        _wrap_tool(
+            "sed",
+            (
+                "Read an inclusive line range from a repository-relative file. "
+                "Prefer this first for local inspection around the reported code."
+            ),
+            _SedArgs,
+            lambda path, start_line, end_line: toolbox.sed(path, start_line, end_line),
+        ),
+        _wrap_tool(
+            "cat",
+            "Read an entire repository-relative file when local context is needed.",
+            _CatArgs,
+            lambda path: toolbox.cat(path),
+        ),
+        _wrap_tool(
+            "grep",
+            (
+                "Search for text, regex matches, references, or call sites inside a "
+                "repository-relative file or directory."
+            ),
+            _GrepArgs,
+            lambda pattern, path: toolbox.grep(pattern, path),
+        ),
+        _wrap_tool(
+            "find_name",
+            "Locate files by exact filename inside the repository.",
+            _FindNameArgs,
+            lambda name, max_results=20: toolbox.find_name(
+                name, max_results=max_results
+            ),
+        ),
+    ]
+    if toolbox.has("rag_search"):
+        tools.append(
+            _wrap_tool(
+                "rag_search",
+                (
+                    "Ask a natural-language question over indexed code and documentation. "
+                    "Returns separate CODE_RAG and DOCS_RAG sections. Use this for broader "
+                    "semantic context such as what a module does, how it is used, what related "
+                    "code or docs matter, and what higher-level behavior or assumptions explain "
+                    "the current file. Do not use this for exact symbol or file lookup when grep, "
+                    "find_name, sed, or cat are a better fit."
+                ),
+                _RagArgs,
+                lambda query: toolbox.rag_search(
+                    query,
+                    retriever_code=retriever_code,
+                    retriever_docs=retriever_docs,
+                ),
+            )
+        )
+    return tools, {tool.name: tool for tool in tools}
+
+
+def _message_content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if text:
+                    parts.append(str(text))
+        return "\n".join(part.strip() for part in parts if str(part).strip()).strip()
+    return str(content or "").strip()
+
+
+def _clip_excerpt(
+    value: Any,
+    *,
+    limit: int = MAX_REVIEW_TOOL_CITATION_EXCERPT_CHARS,
+) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."
+
+
+def _format_tool_citation(
+    tool_name: str,
+    tool_args: dict[str, Any],
+    result_text: str,
+) -> str:
+    details: list[str] = [f"tool={tool_name}"]
+    path = str(tool_args.get("path", "") or "").strip()
+    if path:
+        details.append(f"path={path}")
+    if tool_name == "sed":
+        start_line = tool_args.get("start_line")
+        end_line = tool_args.get("end_line")
+        if start_line is not None and end_line is not None:
+            details.append(f"lines={start_line}-{end_line}")
+    query = str(tool_args.get("query", "") or "").strip()
+    if query:
+        details.append(f"query={json.dumps(query)}")
+    pattern = str(tool_args.get("pattern", "") or "").strip()
+    if pattern:
+        details.append(f"pattern={json.dumps(pattern)}")
+    name = str(tool_args.get("name", "") or "").strip()
+    if name:
+        details.append(f"name={json.dumps(name)}")
+
+    excerpt = _clip_excerpt(result_text)
+    if excerpt:
+        details.append(f"excerpt={json.dumps(excerpt)}")
+    return " | ".join(details)
+
+
+def _format_tool_evidence(
+    *,
+    summary: str,
+    citations: list[str],
+    transcript: str,
+) -> str:
+    sections: list[str] = []
+    if summary:
+        sections.extend(["[SUMMARY]", summary.strip(), ""])
+    if citations:
+        sections.extend(["[CITATIONS]", "\n".join(citations), ""])
+    formatted = "\n".join(part for part in sections if part).strip()
+    if formatted:
+        return _clip_text(formatted)
+    return _clip_text(transcript)
+
+
+def run_review_tool_phase(
+    *,
+    chat_model,
+    tools: list[StructuredTool],
+    tools_by_name: dict[str, StructuredTool],
+    system_prompt: str,
+    body_text: str,
+) -> dict[str, str]:
+    transcript_parts: list[str] = []
+    citations: list[str] = []
+    messages = [SystemMessage(system_prompt), HumanMessage(body_text)]
+    tool_model = chat_model.bind_tools(tools)
+    summary = ""
+
+    for _ in range(MAX_REVIEW_TOOL_ROUNDS):
+        ai_message = tool_model.invoke(messages)
+        messages.append(ai_message)
+        tool_calls = list(getattr(ai_message, "tool_calls", []) or [])
+        if not tool_calls:
+            summary = _message_content_to_text(getattr(ai_message, "content", ""))
+            if summary:
+                transcript_parts.append(f"[EVIDENCE_SUMMARY]\n{summary}")
+            break
+
+        for tool_call in tool_calls:
+            tool_name = str(tool_call.get("name", "") or "")
+            tool_id = str(tool_call.get("id", "") or "")
+            tool_args = tool_call.get("args") or {}
+            tool = tools_by_name.get(tool_name)
+            if tool is None:
+                result_text = f"Unknown tool: {tool_name}"
+            else:
+                try:
+                    result = tool.invoke(tool_args)
+                except Exception as exc:
+                    result = f"Tool execution failed: {exc}"
+                result_text = _stringify_tool_output(result)
+
+            transcript_parts.append(
+                f"[TOOL {tool_name}]\nargs={json.dumps(tool_args, sort_keys=True)}\n{_clip_text(result_text, limit=1600)}"
+            )
+            citations.append(_format_tool_citation(tool_name, tool_args, result_text))
+            messages.append(
+                ToolMessage(
+                    content=result_text,
+                    tool_call_id=tool_id,
+                )
+            )
+
+    transcript = "\n\n".join(part for part in transcript_parts if part)
+    evidence = _format_tool_evidence(
+        summary=summary,
+        citations=citations,
+        transcript=transcript,
+    )
+    return {
+        "tool_evidence": evidence,
+        "tool_evidence_summary": _clip_text(summary) if summary else "",
+        "tool_evidence_citations": (
+            _clip_text("\n".join(citations)) if citations else ""
+        ),
+    }

--- a/src/metis/engine/graphs/review_tools.py
+++ b/src/metis/engine/graphs/review_tools.py
@@ -11,11 +11,18 @@ from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, Field
 
+from .review_retrieval import (
+    assess_review_context_quality,
+    classify_review_evidence,
+    shape_review_rag_query,
+)
+
 logger = logging.getLogger("metis")
 
 MAX_REVIEW_TOOL_ROUNDS = 4
 MAX_REVIEW_TOOL_EVIDENCE_CHARS = 6000
 MAX_REVIEW_TOOL_CITATION_EXCERPT_CHARS = 240
+MAX_REVIEW_RAG_CALLS = 1
 
 
 class _SedArgs(BaseModel):
@@ -245,18 +252,49 @@ def _format_tool_citation(
 def _format_tool_evidence(
     *,
     summary: str,
+    local_inspection: list[str],
+    repo_lookups: list[str],
+    rag_context: list[str],
+    typed_evidence: dict[str, list[str]],
+    notes: list[str],
     citations: list[str],
-    transcript: str,
 ) -> str:
     sections: list[str] = []
     if summary:
-        sections.extend(["[SUMMARY]", summary.strip(), ""])
+        sections.extend(["[TOOL_SUMMARY]", summary.strip(), ""])
+    if local_inspection:
+        sections.extend(["[LOCAL_INSPECTION]", "\n\n".join(local_inspection), ""])
+    if repo_lookups:
+        sections.extend(["[REPO_LOOKUPS]", "\n\n".join(repo_lookups), ""])
+    if rag_context:
+        sections.extend(["[RAG_CONTEXT]", "\n\n".join(rag_context), ""])
+    for section_name in (
+        "COMPONENT_PURPOSE",
+        "INPUT_SOURCES",
+        "RELATED_CALLERS",
+        "TRUST_BOUNDARY",
+        "VALIDATION_GUARDS",
+        "UNRESOLVED",
+    ):
+        values = typed_evidence.get(section_name) or []
+        if values:
+            sections.extend([f"[{section_name}]", "\n\n".join(values), ""])
+    if notes:
+        sections.extend(["[RETRIEVAL_NOTES]", "\n".join(notes), ""])
     if citations:
-        sections.extend(["[CITATIONS]", "\n".join(citations), ""])
+        sections.extend(["[TOOL_CITATIONS]", "\n".join(citations), ""])
     formatted = "\n".join(part for part in sections if part).strip()
     if formatted:
         return _clip_text(formatted)
-    return _clip_text(transcript)
+    return ""
+
+
+def _allowed_review_tools_for_round(round_index: int) -> set[str]:
+    if round_index <= 0:
+        return {"sed", "cat"}
+    if round_index == 1:
+        return {"sed", "cat", "grep", "find_name"}
+    return {"sed", "cat", "grep", "find_name", "rag_search"}
 
 
 def run_review_tool_phase(
@@ -266,40 +304,130 @@ def run_review_tool_phase(
     tools_by_name: dict[str, StructuredTool],
     system_prompt: str,
     body_text: str,
+    review_search_context: dict[str, Any] | None = None,
 ) -> dict[str, str]:
-    transcript_parts: list[str] = []
+    local_inspection: list[str] = []
+    repo_lookups: list[str] = []
+    rag_context: list[str] = []
+    typed_evidence: dict[str, list[str]] = {
+        "COMPONENT_PURPOSE": [],
+        "INPUT_SOURCES": [],
+        "RELATED_CALLERS": [],
+        "TRUST_BOUNDARY": [],
+        "VALIDATION_GUARDS": [],
+        "UNRESOLVED": [],
+    }
+    notes: list[str] = []
     citations: list[str] = []
     messages = [SystemMessage(system_prompt), HumanMessage(body_text)]
     tool_model = chat_model.bind_tools(tools)
     summary = ""
+    rag_calls = 0
 
-    for _ in range(MAX_REVIEW_TOOL_ROUNDS):
+    for round_index in range(MAX_REVIEW_TOOL_ROUNDS):
         ai_message = tool_model.invoke(messages)
         messages.append(ai_message)
         tool_calls = list(getattr(ai_message, "tool_calls", []) or [])
         if not tool_calls:
             summary = _message_content_to_text(getattr(ai_message, "content", ""))
-            if summary:
-                transcript_parts.append(f"[EVIDENCE_SUMMARY]\n{summary}")
             break
 
         for tool_call in tool_calls:
             tool_name = str(tool_call.get("name", "") or "")
             tool_id = str(tool_call.get("id", "") or "")
-            tool_args = tool_call.get("args") or {}
+            tool_args = dict(tool_call.get("args") or {})
             tool = tools_by_name.get(tool_name)
-            if tool is None:
+            allowed_tools = _allowed_review_tools_for_round(round_index)
+            if tool_name not in allowed_tools:
+                allowed_text = ", ".join(sorted(allowed_tools))
+                result_text = (
+                    f"Tool {tool_name} is disabled in review stage {round_index + 1}. "
+                    f"Allowed tools now: {allowed_text}"
+                )
+                notes.append(result_text)
+            elif tool_name == "rag_search" and rag_calls >= MAX_REVIEW_RAG_CALLS:
+                result_text = "rag_search already used in this review tool phase."
+                notes.append(result_text)
+            elif tool is None:
                 result_text = f"Unknown tool: {tool_name}"
+                notes.append(result_text)
             else:
+                if tool_name == "rag_search":
+                    tool_args["query"] = shape_review_rag_query(
+                        str(tool_args.get("query", "") or ""),
+                        file_path=str(
+                            (review_search_context or {}).get("file_path", "") or ""
+                        ),
+                        mode=str(
+                            (review_search_context or {}).get("mode", "file") or "file"
+                        ),
+                        symbols=list(
+                            (review_search_context or {}).get("symbols", []) or []
+                        ),
+                        focus_terms=list(
+                            (review_search_context or {}).get("focus_terms", []) or []
+                        ),
+                        uncovered_obligations=list(
+                            (review_search_context or {}).get(
+                                "uncovered_obligations", []
+                            )
+                            or []
+                        ),
+                        baseline_query=str(
+                            (review_search_context or {}).get("baseline_query", "")
+                            or ""
+                        ),
+                    )
                 try:
                     result = tool.invoke(tool_args)
                 except Exception as exc:
                     result = f"Tool execution failed: {exc}"
                 result_text = _stringify_tool_output(result)
+                if tool_name == "rag_search":
+                    rag_calls += 1
+                    accepted, quality = assess_review_context_quality(
+                        result_text,
+                        file_path=str(
+                            (review_search_context or {}).get("file_path", "") or ""
+                        ),
+                        symbols=list(
+                            (review_search_context or {}).get("symbols", []) or []
+                        ),
+                        focus_terms=list(
+                            (review_search_context or {}).get("focus_terms", []) or []
+                        ),
+                    )
+                    if not accepted:
+                        result_text = (
+                            "[RAG_REJECTED]\n"
+                            f"quality={quality}\n"
+                            f"query={json.dumps(tool_args.get('query', ''), ensure_ascii=True)}"
+                        )
+                        notes.append(f"rag_search rejected: {quality}")
 
-            transcript_parts.append(
-                f"[TOOL {tool_name}]\nargs={json.dumps(tool_args, sort_keys=True)}\n{_clip_text(result_text, limit=1600)}"
+            formatted_tool_output = (
+                f"[TOOL {tool_name}]\nargs={json.dumps(tool_args, sort_keys=True)}\n"
+                f"{_clip_text(result_text, limit=1600)}"
             )
+            if tool_name in {"sed", "cat"}:
+                local_inspection.append(formatted_tool_output)
+            elif tool_name in {"grep", "find_name"}:
+                repo_lookups.append(formatted_tool_output)
+            elif tool_name == "rag_search":
+                rag_context.append(formatted_tool_output)
+            else:
+                notes.append(formatted_tool_output)
+            classified = classify_review_evidence(
+                result_text,
+                symbols=list((review_search_context or {}).get("symbols", []) or []),
+                focus_terms=list(
+                    (review_search_context or {}).get("focus_terms", []) or []
+                ),
+            )
+            for section_name, values in classified.items():
+                if not values:
+                    continue
+                typed_evidence.setdefault(section_name, []).extend(values)
             citations.append(_format_tool_citation(tool_name, tool_args, result_text))
             messages.append(
                 ToolMessage(
@@ -308,16 +436,13 @@ def run_review_tool_phase(
                 )
             )
 
-    transcript = "\n\n".join(part for part in transcript_parts if part)
     evidence = _format_tool_evidence(
         summary=summary,
+        local_inspection=local_inspection,
+        repo_lookups=repo_lookups,
+        rag_context=rag_context,
+        typed_evidence=typed_evidence,
+        notes=notes,
         citations=citations,
-        transcript=transcript,
     )
-    return {
-        "tool_evidence": evidence,
-        "tool_evidence_summary": _clip_text(summary) if summary else "",
-        "tool_evidence_citations": (
-            _clip_text("\n".join(citations)) if citations else ""
-        ),
-    }
+    return {"tool_evidence": evidence}

--- a/src/metis/engine/graphs/triage/evidence_tools.py
+++ b/src/metis/engine/graphs/triage/evidence_tools.py
@@ -71,11 +71,12 @@ def _safe_tool_capture(
 
 def _tool_debug_args(toolbox, tool_name: str, **tool_args) -> dict:
     out = dict(tool_args)
-    describe = getattr(toolbox, "describe", None)
-    if not callable(describe):
-        return out
+    describe_call = getattr(toolbox, "describe_call", None)
     try:
-        details = describe(tool_name)
+        if callable(describe_call):
+            details = describe_call(tool_name, **tool_args)
+        else:
+            details = toolbox.describe(tool_name)
     except Exception:
         return out
     if not isinstance(details, dict):

--- a/src/metis/engine/graphs/triage/graph.py
+++ b/src/metis/engine/graphs/triage/graph.py
@@ -64,7 +64,10 @@ class TriageGraph:
             return self._app
         self._ensure_models()
         graph = StateGraph(TriageState)
-        graph.add_node("retrieve", triage_node_retrieve)
+        graph.add_node(
+            "retrieve",
+            partial(triage_node_retrieve, toolbox=self.toolbox),
+        )
         graph.add_node(
             "collect_evidence",
             partial(triage_node_collect_evidence, toolbox=self.toolbox),

--- a/src/metis/engine/graphs/triage/retrieval.py
+++ b/src/metis/engine/graphs/triage/retrieval.py
@@ -1,73 +1,13 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import hashlib
-
 from metis.engine.analysis.c_family_helpers import extract_code_like_symbols
+from metis.engine.retrieval_support import retrieve_context_deterministic
 
 from . import constants as C
 from .debug import _emit_debug
 from ..types import TriageState
 from ..utils import synthesize_context
-
-
-def _normalize_doc(doc):
-    content = str(getattr(doc, "page_content", "") or "")
-    meta = getattr(doc, "metadata", {}) or {}
-    source = str(
-        meta.get("file_path") or meta.get("source") or meta.get("doc_id") or ""
-    )
-    raw_line = meta.get("line") or meta.get("start_line") or meta.get("line_number")
-    try:
-        line = int(raw_line)
-    except Exception:
-        line = 0
-    digest = hashlib.sha256(content.encode("utf-8", errors="ignore")).hexdigest()
-    return source, line, content, digest
-
-
-def _retrieve_context_deterministic(
-    retriever, query: str, max_chars: int = C.RETRIEVAL_CONTEXT_MAX_CHARS
-) -> str:
-    try:
-        docs = retriever.get_relevant_documents(query) or []
-    except Exception:
-        return ""
-
-    normalized = [_normalize_doc(doc) for doc in docs]
-    dedup = {}
-    for source, line, content, digest in normalized:
-        key = (source, line, digest)
-        dedup[key] = (source, line, content, digest)
-
-    ordered = sorted(
-        dedup.values(),
-        key=lambda x: (
-            x[0].lower(),
-            x[1],
-            x[3],
-        ),
-    )
-
-    parts: list[str] = []
-    used = 0
-    for source, line, content, _digest in ordered:
-        label = source if source else "<unknown>"
-        line_label = f":{line}" if line > 0 else ""
-        section = f"[{label}{line_label}]\n{content.strip()}\n"
-        if not section.strip():
-            continue
-        remaining = max_chars - used
-        if remaining <= 0:
-            break
-        if len(section) > remaining:
-            parts.append(section[:remaining] + "\n...[truncated]")
-            used = max_chars
-            break
-        parts.append(section)
-        used += len(section)
-
-    return "\n".join(parts).strip()
 
 
 def _extract_symbol_candidates(
@@ -109,15 +49,38 @@ def _build_retrieval_query(state: TriageState) -> str:
     )
 
 
-def triage_node_retrieve(state: TriageState) -> TriageState:
+def triage_node_retrieve(state: TriageState, *, toolbox) -> TriageState:
     if not state.get("use_retrieval_context", True):
-        new_state: TriageState = dict(state)
-        new_state["context"] = ""
-        return new_state
+        disabled_state: TriageState = dict(state)
+        disabled_state["context"] = ""
+        return disabled_state
     query = _build_retrieval_query(state)
-    code = _retrieve_context_deterministic(state.get("retriever_code"), query)
-    docs = _retrieve_context_deterministic(state.get("retriever_docs"), query)
-    context = synthesize_context(code, docs)
+    if getattr(toolbox, "has", lambda _name: False)("rag_search"):
+        context = toolbox.rag_search(
+            query,
+            retriever_code=state.get("retriever_code"),
+            retriever_docs=state.get("retriever_docs"),
+        )
+        _emit_debug(
+            state,
+            "tool_call",
+            tool_name="rag_search",
+            tool_args={"query": query, "sources": ["code", "docs"]},
+            tool_output=context,
+        )
+        code = docs = ""
+    else:
+        code = retrieve_context_deterministic(
+            state.get("retriever_code"),
+            query,
+            max_chars=C.RETRIEVAL_CONTEXT_MAX_CHARS,
+        )
+        docs = retrieve_context_deterministic(
+            state.get("retriever_docs"),
+            query,
+            max_chars=C.RETRIEVAL_CONTEXT_MAX_CHARS,
+        )
+        context = synthesize_context(code, docs)
     _emit_debug(
         state,
         "retrieval",
@@ -126,6 +89,6 @@ def triage_node_retrieve(state: TriageState) -> TriageState:
         docs_context=docs,
         context=context,
     )
-    new_state: TriageState = dict(state)
-    new_state["context"] = context
-    return new_state
+    next_state: TriageState = dict(state)
+    next_state["context"] = context
+    return next_state

--- a/src/metis/engine/graphs/types.py
+++ b/src/metis/engine/graphs/types.py
@@ -8,7 +8,6 @@ class ReviewRequest(TypedDict):
     # Required fields
     file_path: Required[str]
     snippet: Required[str]
-    context_prompt: Required[str]
     language_prompts: Required[Dict[str, str]]
 
     # Optional fields
@@ -37,14 +36,15 @@ class ReviewState(TypedDict, total=False):
     snippet: str
     retriever_code: Any
     retriever_docs: Any
-    context_prompt: str
     relative_file: Optional[str]
     mode: str
     original_file: Optional[str]
     use_retrieval_context: bool
     debug_callback: Any
     # Derived
-    context: str
+    tool_evidence: str
+    tool_evidence_summary: str
+    tool_evidence_citations: str
     system_prompt: str
     parsed_reviews: list[dict]
 

--- a/src/metis/engine/graphs/types.py
+++ b/src/metis/engine/graphs/types.py
@@ -42,9 +42,11 @@ class ReviewState(TypedDict, total=False):
     use_retrieval_context: bool
     debug_callback: Any
     # Derived
+    baseline_context_query: str
+    baseline_context: str
+    baseline_context_quality: str
+    review_evidence_frame: str
     tool_evidence: str
-    tool_evidence_summary: str
-    tool_evidence_citations: str
     system_prompt: str
     parsed_reviews: list[dict]
 

--- a/src/metis/engine/graphs/utils.py
+++ b/src/metis/engine/graphs/utils.py
@@ -2,63 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import re
 from typing import Annotated, Literal, get_args, get_origin
 
 from metis.engine.helpers import apply_custom_guidance
 from .schemas import ReviewIssueModel
 
 logger = logging.getLogger("metis")
-
-_RELEVANT_CONTEXT_PLACEHOLDER_VALUES = {
-    "[[RELEVANT_CONTEXT_INPUT_CHANGES]]": (
-        "2. RELEVANT_CONTEXT - information about what these changes do."
-    ),
-    "[[RELEVANT_CONTEXT_INPUT_RTL]]": (
-        "2. RELEVANT_CONTEXT - information about what these changes do "
-        "(e.g., interface intent, security assumptions)."
-    ),
-    "[[RELEVANT_CONTEXT_INPUT_MODULE_PACKAGE]]": (
-        "2. RELEVANT_CONTEXT - information about what this "
-        "module/package/interface does and how it is used"
-    ),
-    "[[RELEVANT_CONTEXT_INPUT_MODULE]]": (
-        "2. RELEVANT_CONTEXT - information about what this module does "
-        "and how it is used"
-    ),
-    "[[RELEVANT_CONTEXT_INPUT_TD]]": (
-        "2) RELEVANT_CONTEXT — notes about target, subtarget features, "
-        "expected semantics, and patches."
-    ),
-    "[[RELEVANT_CONTEXT_INPUT_TERRAFORM]]": (
-        "2) RELEVANT_CONTEXT – Short notes explaining intent, environment "
-        "(e.g., prod/stage),\n"
-        "           cloud(s) targeted, and any linked modules or policies "
-        "that inform how changes behave."
-    ),
-    "[[RELEVANT_CONTEXT_ADDITIONAL_DETAILS]]": (
-        "RELEVANT_CONTEXT: Additional details or commentary on the snippet."
-    ),
-    "[[RELEVANT_CONTEXT]]": "- If it is empty, ignore it.",
-    "[[RELEVANT_CONTEXT_UNINDENTED]]": "If it is empty, ignore it.",
-    "[[RELEVANT_CONTEXT_TWO_SPACE]]": "- If it is empty, ignore it.",
-    "[[RELEVANT_CONTEXT_NAMED]]": ("- If RELEVANT_CONTEXT is empty, ignore it."),
-    "[[RELEVANT_CONTEXT_ASSERTION_GUIDANCE]]": (
-        '- Assertions: ensure security properties are not "simulation-only" '
-        "crutches when RELEVANT_CONTEXT expects enforcement in RTL."
-    ),
-    "[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]]": " and RELEVANT_CONTEXT",
-    "[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]]": ", RELEVANT_CONTEXT",
-    "[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]]": " or context",
-    "[[RELEVANT_CONTEXT_CODE_PROVIDED_SUFFIX]]": " and context",
-    "[[RELEVANT_CONTEXT_TD_PROVIDED_SUFFIX]]": " or provided context",
-    "[[RELEVANT_CONTEXT_PATCH_JUSTIFICATION_SUFFIX]]": ", and RELEVANT_CONTEXT",
-    "[[RELEVANT_CONTEXT_SNIPPET_VALIDATION_SUFFIX]]": " and RELEVANT_CONTEXT",
-    "[[RELEVANT_CONTEXT_INTERNAL_ONLY_SUFFIX]]": " in RELEVANT_CONTEXT",
-    "[[RELEVANT_CONTEXT_TERRAFORM_ORIGINAL_PREFIX]]": "RELEVANT_CONTEXT/",
-    "[[ORIGINAL_FILE_INDEX_DOT]]": "3.",
-    "[[ORIGINAL_FILE_INDEX_PAREN]]": "3)",
-}
 
 
 def retrieve_text(retriever, query):
@@ -82,94 +31,6 @@ def synthesize_context(code_text, doc_text):
     if doc_text:
         parts.append(doc_text)
     return "\n\n".join(p for p in parts if p)
-
-
-def _build_review_prompt_without_context(text: str) -> str:
-    cleaned = (text or "").replace("[[ORIGINAL_FILE_INDEX_DOT]]", "2.")
-    cleaned = cleaned.replace("[[ORIGINAL_FILE_INDEX_PAREN]]", "2)")
-    if "RELEVANT_CONTEXT" in cleaned:
-        cleaned = re.sub(
-            r",\s*RELEVANT_CONTEXT,\s*\n\s*and ORIGINAL_FILE",
-            " and ORIGINAL_FILE",
-            cleaned,
-        )
-        cleaned = cleaned.replace(
-            ", ORIGINAL_FILE, and RELEVANT_CONTEXT",
-            " and ORIGINAL_FILE",
-        )
-        cleaned = cleaned.replace(
-            ", RELEVANT_CONTEXT, and ORIGINAL_FILE",
-            " and ORIGINAL_FILE",
-        )
-        cleaned = cleaned.replace(" and RELEVANT_CONTEXT", "")
-        cleaned = cleaned.replace(" or context provided", " provided")
-        cleaned = cleaned.replace(" and context provided", " provided")
-        cleaned = cleaned.replace(" or provided context", "")
-        cleaned = cleaned.replace(" in RELEVANT_CONTEXT", "")
-        cleaned = cleaned.replace("RELEVANT_CONTEXT/", "")
-        cleaned = re.sub(
-            r"^\s*2[\.\)]\s+RELEVANT_CONTEXT\s+[-–—].*\n?",
-            "",
-            cleaned,
-            flags=re.MULTILINE,
-        )
-        cleaned = re.sub(
-            r"^(\s*)3([\.\)])\s+ORIGINAL_FILE",
-            r"\g<1>2\2 ORIGINAL_FILE",
-            cleaned,
-            flags=re.MULTILINE,
-        )
-        cleaned = re.sub(
-            r"^\s*- If RELEVANT_CONTEXT is empty, ignore it\.\n?",
-            "",
-            cleaned,
-            flags=re.MULTILINE,
-        )
-        cleaned = re.sub(
-            r"^\s*- If it is empty, ignore it\.\n?",
-            "",
-            cleaned,
-            flags=re.MULTILINE,
-        )
-        cleaned = re.sub(
-            r"^\s*If it is empty, ignore it\.\n?",
-            "",
-            cleaned,
-            flags=re.MULTILINE,
-        )
-        cleaned = re.sub(
-            r"^\s*RELEVANT_CONTEXT: Additional details or commentary on the snippet\.\n?",
-            "",
-            cleaned,
-            flags=re.MULTILINE,
-        )
-        cleaned = re.sub(
-            r'^\s*- Assertions: ensure security properties are not "simulation-only" crutches when RELEVANT_CONTEXT expects enforcement in RTL\.\n?',
-            "",
-            cleaned,
-            flags=re.MULTILINE,
-        )
-    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
-    return cleaned.strip()
-
-
-def _replace_relevant_context_placeholders(
-    text: str,
-    *,
-    include_relevant_context: bool,
-) -> str:
-    updated = text
-    for placeholder, value in _RELEVANT_CONTEXT_PLACEHOLDER_VALUES.items():
-        replacement = value if include_relevant_context else ""
-        if placeholder == "[[ORIGINAL_FILE_INDEX_DOT]]":
-            replacement = "3." if include_relevant_context else "2."
-        elif placeholder == "[[ORIGINAL_FILE_INDEX_PAREN]]":
-            replacement = "3)" if include_relevant_context else "2)"
-        updated = updated.replace(
-            placeholder,
-            replacement,
-        )
-    return updated
 
 
 def _is_string_field(annotation):
@@ -260,13 +121,17 @@ def build_review_system_prompt(
     custom_guidance_precedence,
     schema_prompt_section,
     hardware_cwe_guidance="",
-    include_relevant_context=True,
+    tool_guidance="",
 ):
     """Compose the system prompt for a review in a single place."""
-    base = (
-        f"{language_prompts[default_prompt_key]} \n "
-        f"{language_prompts['security_review_checks']} \n {report_prompt}"
-    )
+    sections = [
+        language_prompts[default_prompt_key],
+        language_prompts["security_review_checks"],
+    ]
+    if tool_guidance:
+        sections.append(tool_guidance)
+    sections.append(report_prompt)
+    base = " \n ".join(sections)
     schema_placeholder = "[[REVIEW_SCHEMA_FIELDS]]"
     hardware_placeholder = "[[HARDWARE_CWE_GUIDANCE]]"
 
@@ -284,13 +149,7 @@ def build_review_system_prompt(
                 "Hardware CWE guidance placeholder found but guidance text is empty"
             )
         base = base.replace(hardware_placeholder, hardware_cwe_guidance)
-    base = _replace_relevant_context_placeholders(
-        base,
-        include_relevant_context=include_relevant_context,
-    )
     base = apply_custom_guidance(
         base, custom_prompt_text, custom_guidance_precedence or ""
     )
-    if not include_relevant_context:
-        return _build_review_prompt_without_context(base)
     return base

--- a/src/metis/engine/options.py
+++ b/src/metis/engine/options.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
 class ReviewOptions:
     use_retrieval_context: bool = True
+    debug_callback: Any = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,16 +23,27 @@ def coerce_review_options(
     options: ReviewOptions | None = None,
     *,
     use_retrieval_context: bool | None = None,
+    debug_callback: Any = None,
 ) -> ReviewOptions:
     if options is None:
         return ReviewOptions(
             use_retrieval_context=(
                 True if use_retrieval_context is None else use_retrieval_context
-            )
+            ),
+            debug_callback=debug_callback,
         )
-    if use_retrieval_context is None:
+    if use_retrieval_context is None and debug_callback is None:
         return options
-    return ReviewOptions(use_retrieval_context=use_retrieval_context)
+    return ReviewOptions(
+        use_retrieval_context=(
+            options.use_retrieval_context
+            if use_retrieval_context is None
+            else use_retrieval_context
+        ),
+        debug_callback=(
+            options.debug_callback if debug_callback is None else debug_callback
+        ),
+    )
 
 
 def coerce_triage_options(

--- a/src/metis/engine/retrieval_support.py
+++ b/src/metis/engine/retrieval_support.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+
+
+def normalize_retrieved_doc(doc):
+    content = str(getattr(doc, "page_content", "") or "")
+    meta = getattr(doc, "metadata", {}) or {}
+    source = str(
+        meta.get("file_path") or meta.get("source") or meta.get("doc_id") or ""
+    )
+    raw_line = meta.get("line") or meta.get("start_line") or meta.get("line_number")
+    try:
+        line = int(raw_line)
+    except Exception:
+        line = 0
+    digest = hashlib.sha256(content.encode("utf-8", errors="ignore")).hexdigest()
+    return source, line, content, digest
+
+
+def retrieve_context_deterministic(
+    retriever,
+    query: str,
+    *,
+    max_chars: int,
+) -> str:
+    if retriever is None:
+        return ""
+    try:
+        docs = retriever.get_relevant_documents(query) or []
+    except Exception:
+        return ""
+
+    normalized = [normalize_retrieved_doc(doc) for doc in docs]
+    dedup = {}
+    for source, line, content, digest in normalized:
+        key = (source, line, digest)
+        dedup[key] = (source, line, content, digest)
+
+    ordered = sorted(
+        dedup.values(),
+        key=lambda x: (
+            x[0].lower(),
+            x[1],
+            x[3],
+        ),
+    )
+
+    parts: list[str] = []
+    used = 0
+    for source, line, content, _digest in ordered:
+        label = source if source else "<unknown>"
+        line_label = f":{line}" if line > 0 else ""
+        section = f"[{label}{line_label}]\n{content.strip()}\n"
+        if not section.strip():
+            continue
+        remaining = max_chars - used
+        if remaining <= 0:
+            break
+        if len(section) > remaining:
+            parts.append(section[:remaining] + "\n...[truncated]")
+            used = max_chars
+            break
+        parts.append(section)
+        used += len(section)
+
+    return "\n".join(parts).strip()

--- a/src/metis/engine/review_service.py
+++ b/src/metis/engine/review_service.py
@@ -66,11 +66,6 @@ class ReviewService:
             return None
 
         language_prompts = plugin.get_prompts()
-        context_prompt_template = self._config.plugin_config.get(
-            "general_prompts", {}
-        ).get("retrieve_context", "")
-
-        formatted_context_prompt = context_prompt_template.format(file_path=file_path)
         relative_path = os.path.relpath(file_path, base_path)
 
         try:
@@ -79,12 +74,12 @@ class ReviewService:
                 "snippet": snippet,
                 "retriever_code": qe_code,
                 "retriever_docs": qe_docs,
-                "context_prompt": formatted_context_prompt,
                 "language_prompts": language_prompts,
                 "default_prompt_key": "security_review_file",
                 "relative_file": relative_path,
                 "mode": "file",
                 "use_retrieval_context": options.use_retrieval_context,
+                "debug_callback": options.debug_callback,
             }
             return self._review_graph_factory().review(req)
         except Exception as e:
@@ -207,11 +202,6 @@ class ReviewService:
             )
             if not snippet:
                 continue
-            context_prompt = self._config.plugin_config.get("general_prompts", {}).get(
-                "retrieve_context", ""
-            )
-            formatted_context = context_prompt.format(file_path=file_diff.path)
-
             language_prompts = plugin.get_prompts()
             try:
                 original_content = read_file_content(abs_path)
@@ -220,13 +210,13 @@ class ReviewService:
                     "snippet": snippet,
                     "retriever_code": qe_code,
                     "retriever_docs": qe_docs,
-                    "context_prompt": formatted_context,
                     "language_prompts": language_prompts,
                     "default_prompt_key": "security_review",
                     "relative_file": relative_path,
                     "mode": "patch",
                     "original_file": original_content or "",
                     "use_retrieval_context": options.use_retrieval_context,
+                    "debug_callback": options.debug_callback,
                 }
                 review_dict = self._review_graph_factory().review(req)
             except Exception as e:

--- a/src/metis/engine/tools/base.py
+++ b/src/metis/engine/tools/base.py
@@ -39,6 +39,12 @@ class ToolBox:
     def has(self, name: str) -> bool:
         return name in self._tools
 
+    def without(self, *names: str) -> "ToolBox":
+        blocked = set(names)
+        return ToolBox(
+            {name: tool for name, tool in self._tools.items() if name not in blocked}
+        )
+
     def run(self, name: str, *args, **kwargs):
         try:
             tool = self._tools[name]
@@ -62,6 +68,21 @@ class ToolBox:
             return {}
         return dict(details)
 
+    def describe_call(self, name: str, *args, **kwargs) -> dict[str, Any]:
+        try:
+            tool = self._tools[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown tool: {name}") from exc
+        provider = getattr(tool, "__self__", None)
+        if provider is None:
+            return self.describe(name)
+        describe_call = getattr(provider, "describe_call", None)
+        if callable(describe_call):
+            details = describe_call(name, *args, **kwargs)
+            if isinstance(details, dict):
+                return dict(details)
+        return self.describe(name)
+
     def grep(self, pattern: str, path: str) -> str:
         return self.run("grep", pattern, path)
 
@@ -73,3 +94,17 @@ class ToolBox:
 
     def sed(self, path: str, start_line: int, end_line: int) -> str:
         return self.run("sed", path, start_line, end_line)
+
+    def rag_search(
+        self,
+        query: str,
+        *,
+        retriever_code=None,
+        retriever_docs=None,
+    ) -> str:
+        return self.run(
+            "rag_search",
+            query,
+            retriever_code=retriever_code,
+            retriever_docs=retriever_docs,
+        )

--- a/src/metis/engine/tools/registry.py
+++ b/src/metis/engine/tools/registry.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 from .base import ToolBox, ToolContext, ToolDefinition
+from .retrieval_tools import RetrievalToolRunner
 from .static_tools import StaticToolRunner
 
 
 def get_tool_policies() -> dict[str, tuple[str, ...]]:
     return {
-        "triage_evidence": ("grep", "find_name", "cat", "sed"),
+        "code_evidence": ("grep", "find_name", "cat", "sed", "rag_search"),
+        "triage_evidence": ("grep", "find_name", "cat", "sed", "rag_search"),
     }
 
 
@@ -19,7 +21,10 @@ def _build_providers(context: ToolContext) -> dict[str, object]:
             codebase_path=context.codebase_path,
             timeout_seconds=context.timeout_seconds,
             max_chars=context.max_chars,
-        )
+        ),
+        "retrieval": RetrievalToolRunner(
+            max_chars=context.max_chars,
+        ),
     }
 
 
@@ -91,6 +96,12 @@ def get_tool_definitions() -> tuple[ToolDefinition, ...]:
             domains=tuple(get_tool_policies()),
             provider="static",
             operation="sed",
+        ),
+        ToolDefinition(
+            name="rag_search",
+            domains=tuple(get_tool_policies()),
+            provider="retrieval",
+            operation="rag_search",
         ),
     )
 

--- a/src/metis/engine/tools/retrieval_tools.py
+++ b/src/metis/engine/tools/retrieval_tools.py
@@ -21,16 +21,17 @@ class RetrievalToolRunner:
         if not normalized_query:
             return "[RAG_SEARCH]\nEmpty query."
 
-        half_budget = max(400, self.max_chars // 2)
+        code_budget = max(600, int(self.max_chars * 0.7))
+        docs_budget = max(400, self.max_chars - code_budget)
         code = retrieve_context_deterministic(
             retriever_code,
             normalized_query,
-            max_chars=half_budget,
+            max_chars=code_budget,
         )
         docs = retrieve_context_deterministic(
             retriever_docs,
             normalized_query,
-            max_chars=half_budget,
+            max_chars=docs_budget,
         )
 
         sections: list[str] = ["[RAG_QUERY]", normalized_query, ""]

--- a/src/metis/engine/tools/retrieval_tools.py
+++ b/src/metis/engine/tools/retrieval_tools.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from metis.engine.retrieval_support import retrieve_context_deterministic
+
+
+class RetrievalToolRunner:
+    def __init__(self, *, max_chars: int = 16000):
+        self.max_chars = max_chars
+
+    def rag_search(
+        self,
+        query: str,
+        *,
+        retriever_code=None,
+        retriever_docs=None,
+    ) -> str:
+        normalized_query = str(query or "").strip()
+        if not normalized_query:
+            return "[RAG_SEARCH]\nEmpty query."
+
+        half_budget = max(400, self.max_chars // 2)
+        code = retrieve_context_deterministic(
+            retriever_code,
+            normalized_query,
+            max_chars=half_budget,
+        )
+        docs = retrieve_context_deterministic(
+            retriever_docs,
+            normalized_query,
+            max_chars=half_budget,
+        )
+
+        sections: list[str] = ["[RAG_QUERY]", normalized_query, ""]
+        if retriever_code is None:
+            sections.extend(["[CODE_RAG_STATUS]", "unavailable", ""])
+        else:
+            sections.extend(["[CODE_RAG]", code or "<none>", ""])
+
+        if retriever_docs is None:
+            sections.extend(["[DOCS_RAG_STATUS]", "unavailable", ""])
+        else:
+            sections.extend(["[DOCS_RAG]", docs or "<none>", ""])
+
+        if retriever_code is None and retriever_docs is None:
+            sections.extend(
+                [
+                    "[RAG_SEARCH_STATUS]",
+                    "retrieval unavailable; continuing without indexed context",
+                ]
+            )
+
+        text = "\n".join(sections).strip()
+        if len(text) <= self.max_chars:
+            return text
+        return text[: self.max_chars] + "\n...[truncated]"

--- a/src/metis/engine/tools/static_tools.py
+++ b/src/metis/engine/tools/static_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from pathlib import PurePosixPath
 import re
 import shutil
 import subprocess
@@ -14,6 +15,25 @@ from typing import Sequence
 _PYTHON_REGEX_REWRITES = (
     ("[[:space:]]", r"\s"),
     ("[[:blank:]]", r"[ \t]"),
+)
+_SHELL_REGEX_REWRITES = (
+    (r"\s", "[[:space:]]"),
+    (r"\S", "[^[:space:]]"),
+    (r"\d", "[[:digit:]]"),
+    (r"\D", "[^[:digit:]]"),
+    (r"\w", "[[:alnum:]_]"),
+    (r"\W", "[^[:alnum:]_]"),
+    ("(?:", "("),
+    (r"\A", "^"),
+    (r"\Z", "$"),
+)
+_RISKY_SHELL_GREP_PATTERNS = (
+    re.compile(r"\\[1-9]"),
+    re.compile(r"\\[bB]"),
+    re.compile(r"\\[pPkKQEGg]"),
+    re.compile(r"\(\?(?!i\))"),
+    re.compile(r"(\*\?|\+\?|\?\?|\*\+|\+\+|\?\+)"),
+    re.compile(r"\{\d+(,\d*)?\}[?+]"),
 )
 
 
@@ -48,14 +68,99 @@ class StaticToolRunner:
             return {"backend": backend}
         return {}
 
+    def describe_call(self, name: str, *args, **kwargs) -> dict[str, str]:
+        if name != "grep":
+            return self.describe_tool(name)
+        pattern = ""
+        if args:
+            pattern = str(args[0] or "")
+        elif "pattern" in kwargs:
+            pattern = str(kwargs.get("pattern") or "")
+        backend = self._grep_backend(pattern)
+        return {"backend": backend}
+
     def _resolve_path(self, raw_path: str) -> Path:
-        candidate = (self.codebase_path / raw_path).resolve()
-        if (
-            candidate != self.codebase_path
-            and self.codebase_path not in candidate.parents
-        ):
+        fallback = None
+        for candidate_raw in self._normalize_tool_path_candidates(raw_path):
+            if os.path.isabs(candidate_raw):
+                candidate = Path(candidate_raw).resolve()
+            else:
+                candidate = (self.codebase_path / candidate_raw).resolve()
+            if not self._is_within_codebase(candidate):
+                continue
+            if fallback is None:
+                fallback = candidate
+            if candidate.exists():
+                return candidate
+        if fallback is None:
             raise ValueError("Path escapes codebase")
-        return candidate
+        return fallback
+
+    def _is_within_codebase(self, candidate: Path) -> bool:
+        return (
+            candidate == self.codebase_path or self.codebase_path in candidate.parents
+        )
+
+    def _normalize_tool_path_candidates(self, raw_path: str) -> list[str]:
+        raw = str(raw_path or "").strip()
+        if not raw:
+            return [raw]
+        if os.path.isabs(raw):
+            return [raw]
+
+        normalized = raw.replace("\\", "/")
+        while normalized.startswith("./"):
+            normalized = normalized[2:]
+        normalized = normalized or "."
+
+        candidates: list[str] = []
+        seen: set[str] = set()
+
+        def add(candidate: str) -> None:
+            text = str(candidate or "").strip() or "."
+            if text in seen:
+                return
+            seen.add(text)
+            candidates.append(text)
+
+        add(normalized)
+
+        raw_parts = PurePosixPath(normalized).parts
+        codebase_parts = tuple(
+            part
+            for part in PurePosixPath(self.codebase_path.as_posix()).parts
+            if part != "/"
+        )
+        suffixes = sorted(
+            (
+                codebase_parts[idx:]
+                for idx in range(len(codebase_parts))
+                if codebase_parts[idx:]
+            ),
+            key=len,
+            reverse=True,
+        )
+        for suffix in suffixes:
+            if len(suffix) > len(raw_parts):
+                continue
+            if raw_parts[: len(suffix)] != suffix:
+                continue
+            remainder = raw_parts[len(suffix) :]
+            add(PurePosixPath(*remainder).as_posix() if remainder else ".")
+
+        tail_candidates = [
+            codebase_parts[idx:]
+            for idx in range(len(codebase_parts))
+            if codebase_parts[idx:]
+        ]
+        for tail in tail_candidates:
+            if len(raw_parts) > len(tail):
+                continue
+            if tail[: len(raw_parts)] != raw_parts:
+                continue
+            add(".")
+
+        return candidates
 
     def _run(
         self,
@@ -82,6 +187,55 @@ class StaticToolRunner:
             return text[: self.max_chars] + "\n...[truncated]"
         return text
 
+    def _grep_backend(self, pattern: str) -> str:
+        if not self._has_grep:
+            return "python_regex"
+        if self._is_risky_shell_grep_pattern(pattern):
+            return "python_regex"
+        return "shell_grep"
+
+    def _is_risky_shell_grep_pattern(self, pattern: str) -> bool:
+        text = str(pattern or "")
+        for compiled in _RISKY_SHELL_GREP_PATTERNS:
+            if compiled.search(text):
+                return True
+        return False
+
+    def _normalize_shell_grep_pattern(self, pattern: str) -> tuple[str, bool]:
+        normalized = str(pattern or "")
+        ignore_case = False
+        if normalized.startswith("(?i)"):
+            ignore_case = True
+            normalized = normalized[4:]
+        for source, replacement in _SHELL_REGEX_REWRITES:
+            normalized = normalized.replace(source, replacement)
+        return normalized, ignore_case
+
+    def _compile_python_regex(self, pattern: str) -> re.Pattern[str]:
+        normalized, ignore_case = self._normalize_shell_grep_pattern(pattern)
+        translated = normalized
+        for source, replacement in _PYTHON_REGEX_REWRITES:
+            translated = translated.replace(source, replacement)
+        flags = re.IGNORECASE if ignore_case else 0
+        return re.compile(translated, flags)
+
+    def _prepare_grep_call(
+        self, pattern: str
+    ) -> tuple[str, list[str] | re.Pattern[str]]:
+        backend = self._grep_backend(pattern)
+        if backend == "shell_grep":
+            normalized, ignore_case = self._normalize_shell_grep_pattern(pattern)
+            argv = ["grep"]
+            if ignore_case:
+                argv.append("-i")
+            argv.extend(["-HREn", "--", normalized])
+            return backend, argv
+        try:
+            compiled = self._compile_python_regex(pattern)
+        except re.error as exc:
+            raise ValueError(f"Invalid grep pattern: {exc}") from exc
+        return backend, compiled
+
     def _iter_files(self, base: Path):
         if base.is_file():
             yield base
@@ -95,19 +249,14 @@ class StaticToolRunner:
 
     def grep(self, pattern: str, path: str) -> str:
         target = self._resolve_path(path)
-        if self._has_grep:
+        backend, prepared = self._prepare_grep_call(pattern)
+        if backend == "shell_grep":
             return self._run(
-                ["grep", "-HREn", "--", pattern, str(target)],
+                [*prepared, str(target)],
                 ok_returncodes=(0, 1),
             )
 
-        try:
-            translated = pattern
-            for source, replacement in _PYTHON_REGEX_REWRITES:
-                translated = translated.replace(source, replacement)
-            regex = re.compile(translated)
-        except re.error as exc:
-            raise ValueError(f"Invalid grep pattern: {exc}") from exc
+        regex = prepared
 
         lines: list[str] = []
         for file_path in self._iter_files(target):

--- a/src/metis/engine/tools/static_tools.py
+++ b/src/metis/engine/tools/static_tools.py
@@ -42,16 +42,32 @@ class StaticToolRunner:
         self,
         *,
         codebase_path: str,
+        workspace_root: str | None = None,
         timeout_seconds: int = 8,
         max_chars: int = 16000,
     ):
         self.codebase_path = Path(codebase_path).resolve()
+        self.workspace_root = self._resolve_workspace_root(workspace_root)
+        self.search_root = self.workspace_root
         self.timeout_seconds = timeout_seconds
         self.max_chars = max_chars
         self._has_grep = shutil.which("grep") is not None
         self._has_find = shutil.which("find") is not None
         self._has_cat = shutil.which("cat") is not None
         self._has_sed = shutil.which("sed") is not None
+
+    def _resolve_workspace_root(self, workspace_root: str | None) -> Path:
+        if workspace_root:
+            root = Path(workspace_root).resolve()
+            if root == self.codebase_path or root in self.codebase_path.parents:
+                return root
+            return self.codebase_path
+
+        for candidate in (self.codebase_path, *self.codebase_path.parents):
+            git_dir = candidate / ".git"
+            if git_dir.exists():
+                return candidate
+        return self.codebase_path
 
     def describe_tool(self, name: str) -> dict[str, str]:
         if name == "grep":
@@ -82,24 +98,39 @@ class StaticToolRunner:
     def _resolve_path(self, raw_path: str) -> Path:
         fallback = None
         for candidate_raw in self._normalize_tool_path_candidates(raw_path):
-            if os.path.isabs(candidate_raw):
-                candidate = Path(candidate_raw).resolve()
-            else:
-                candidate = (self.codebase_path / candidate_raw).resolve()
-            if not self._is_within_codebase(candidate):
-                continue
-            if fallback is None:
-                fallback = candidate
-            if candidate.exists():
-                return candidate
+            for base_root in self._candidate_base_roots(candidate_raw):
+                if os.path.isabs(candidate_raw):
+                    candidate = Path(candidate_raw).resolve()
+                else:
+                    candidate = (base_root / candidate_raw).resolve()
+                if not self._is_within_allowed_roots(candidate):
+                    continue
+                if fallback is None:
+                    fallback = candidate
+                if candidate.exists():
+                    return candidate
         if fallback is None:
             raise ValueError("Path escapes codebase")
         return fallback
 
-    def _is_within_codebase(self, candidate: Path) -> bool:
-        return (
-            candidate == self.codebase_path or self.codebase_path in candidate.parents
-        )
+    def _candidate_base_roots(self, candidate_raw: str) -> list[Path]:
+        if os.path.isabs(candidate_raw):
+            return [Path("/")]
+        ordered: list[Path] = []
+        for root in (self.codebase_path, self.workspace_root):
+            if root in ordered:
+                continue
+            ordered.append(root)
+        return ordered
+
+    def _is_within_allowed_roots(self, candidate: Path) -> bool:
+        for root in {self.codebase_path, self.workspace_root}:
+            if candidate == root or root in candidate.parents:
+                return True
+        return False
+
+    def _display_root(self) -> Path:
+        return self.workspace_root
 
     def _normalize_tool_path_candidates(self, raw_path: str) -> list[str]:
         raw = str(raw_path or "").strip()
@@ -260,7 +291,7 @@ class StaticToolRunner:
 
         lines: list[str] = []
         for file_path in self._iter_files(target):
-            rel = file_path.relative_to(self.codebase_path).as_posix()
+            rel = file_path.relative_to(self._display_root()).as_posix()
             try:
                 text = file_path.read_text(encoding="utf-8", errors="ignore")
             except Exception:
@@ -276,22 +307,29 @@ class StaticToolRunner:
         if not name or "/" in name or "\\" in name:
             return []
         if self._has_find:
-            output = self._run(["find", ".", "-type", "f", "-name", name])
+            output = self._run(
+                ["find", str(self.search_root), "-type", "f", "-name", name]
+            )
             found: list[str] = []
             for line in (output or "").splitlines():
                 item = line.strip()
                 if not item or item.startswith("find:"):
                     continue
-                if item.startswith("./"):
-                    item = item[2:]
-                found.append(item.replace("\\", "/"))
+                candidate = Path(item)
+                try:
+                    rel = (
+                        candidate.resolve().relative_to(self._display_root()).as_posix()
+                    )
+                except Exception:
+                    rel = item[2:] if item.startswith("./") else item
+                found.append(rel.replace("\\", "/"))
         else:
             found = []
-            for file_path in self._iter_files(self.codebase_path):
+            for file_path in self._iter_files(self.search_root):
                 if file_path.name != name:
                     continue
                 try:
-                    item = file_path.relative_to(self.codebase_path).as_posix()
+                    item = file_path.relative_to(self._display_root()).as_posix()
                 except Exception:
                     continue
                 found.append(item)

--- a/src/metis/engine/triage_service_runtime.py
+++ b/src/metis/engine/triage_service_runtime.py
@@ -41,7 +41,7 @@ class _FallbackTriageAnalyzer:
 class TriageServiceRuntimeMixin:
     def _build_triage_graph(self):
         toolbox = build_toolbox(
-            policy="triage_evidence",
+            policy="code_evidence",
             codebase_path=self.codebase_path,
             timeout_seconds=self.triage_tool_timeout_seconds,
         )

--- a/src/metis/plugins/plugins.yaml
+++ b/src/metis/plugins/plugins.yaml
@@ -7,17 +7,50 @@ general_prompts:
     instructions or checks below, follow 'Custom Guidance'. If guidance excludes
     certain issue classes, omit them from analysis and do not report them unless
     directly necessary to explain another issue.
-  retrieve_context: |-
-    You are a senior software engineer and your task is to explain what the following FILE does and what its purpose is.
-    Include any data flows, function calls, or dependencies that could impact security.
-    Make sure you flag any function input that is externally controlled.
-    FILE: {file_path}
   security_review_report: |-
-    3. How to Report
+    4. How to Report
         - List all identified security issues in a JSON array.
         - Each element must strictly follow this structure:
           [[REVIEW_SCHEMA_FIELDS]]
         - IMPORTANT: If no identified security issues are found, return: {\"reviews\": []}
+  review_tool_guidance: |-
+    3. How to Use Tool Evidence
+        - If TOOL_EVIDENCE is present, treat it as additional grounding alongside FILE, FILE_CHANGES, ORIGINAL_FILE, and any directly provided context.
+        - Prefer local inspection first with `sed` / `cat` before broader lookup with `grep` / `find_name` when more evidence is needed.
+        - Use `rag_search` when local inspection is not enough and you need broader security-relevant context from indexed code and docs.
+        - In particular, use `rag_search` to ask:
+          - what inputs reach this file, function, or module and whether any may be externally controlled
+          - what the component is architecturally supposed to do
+          - how the code is used by callers, wrappers, or surrounding subsystems
+          - what trust boundaries, privilege boundaries, or security assumptions apply
+          - what related checks, validation steps, authorization gates, sanitization steps, or enforcement points exist elsewhere
+          - whether the implementation aligns with the intended security design and documented behavior
+        - Phrase `rag_search` queries as short natural-language security questions, not keyword bags.
+        - Good examples include:
+          - “What inputs reach this component, and are any externally controlled?”
+          - “What is this module supposed to enforce from a security perspective?”
+          - “How is this function used by callers, and what security assumptions do they rely on?”
+          - “What related code or docs explain the trust boundary around this logic?”
+          - “Where are authentication, authorization, validation, or sanitization responsibilities defined for this path?”
+        - `rag_search` can return separate code and docs sections; use both when they are relevant.
+        - Do not use `rag_search` for exact symbol/file lookup when `grep`, `find_name`, `sed`, or `cat` are a better fit.
+        - Do not invent tool results that are not present in TOOL_EVIDENCE.
+  review_tool_system_prompt: |-
+    You are gathering grounded static evidence for a security code review.
+    Use tools only when they materially improve confidence.
+    Prefer local inspection first with sed/cat on the current file or hunk.
+    Use rag_search when you need broader security context across indexed code and docs, especially for questions about attacker-controlled inputs, module purpose, architecture, trust boundaries, privilege expectations, validation or sanitization responsibilities, enforcement points, and whether the implementation matches the intended security design.
+    Ask rag_search focused natural-language security questions, not keyword bags.
+    Use grep or find_name for broader lookup only when direct local inspection is not enough.
+    Keep tool use bounded and evidence-driven.
+    After finishing tool use, return a concise plain-text evidence summary. Do not return JSON.
+  review_tool_system_prompt_no_rag: |-
+    You are gathering grounded static evidence for a security code review.
+    Use tools only when they materially improve confidence.
+    Prefer local inspection first with sed/cat on the current file or hunk.
+    Use grep or find_name for broader lookup only when direct local inspection is not enough.
+    Keep tool use bounded and evidence-driven.
+    After finishing tool use, return a concise plain-text evidence summary. Do not return JSON.
   triage_system_prompt: |-
     You triage static analysis findings.
     Decide whether the finding is valid, invalid, or inconclusive based on static code evidence.
@@ -53,7 +86,7 @@ general_prompts:
     {tool_outputs}
   hardware_cwe_guidance: |-
     2. What to Check (CWE-based, hardware-focused)
-       - Treat ALL control/inputs as potentially adversarial unless explicitly proven internal-only[[RELEVANT_CONTEXT_INTERNAL_ONLY_SUFFIX]].
+       - Treat ALL control/inputs as potentially adversarial unless explicitly proven internal-only in TOOL_EVIDENCE.
          Externally-controlled candidates commonly include: reset, clock enables, test/debug enables,
          strap pins, fuse/OTP reads, JTAG/scan signals, memory-mapped register writes, bus transactions,
          interrupt lines, and power/debug state transitions.
@@ -133,32 +166,32 @@ plugins:
     prompts: &c_cpp_prompts
       security_review_file: |-
         You are a thorough security engineer specializing in C/C++.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE.
-           - Only produce findings that are fully justified by FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]]. If no real issues exist, return an empty reviews list.
-           [[RELEVANT_CONTEXT]]
+           - Only produce findings that are fully justified by FILE and TOOL_EVIDENCE. If no real issues exist, return an empty reviews list.
+           - If TOOL_EVIDENCE is empty, ignore it.
       security_review: |-
         You are a thorough security engineer specializing in C/C++.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported
-        by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE_CHANGES - a set of code changes with lines marked by “+” indicating what has been added or “-” for removed.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” but take into account how they interact with the whole file.
-           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE [[RELEVANT_CONTEXT_PATCH_JUSTIFICATION_SUFFIX]]. If no real issues exist, return an empty reviews list.
-           [[RELEVANT_CONTEXT]]
+           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE , and TOOL_EVIDENCE. If no real issues exist, return an empty reviews list.
+           - If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
            - Look for potential security issues such as:
@@ -183,11 +216,11 @@ plugins:
       validation_review: |-
         You will be given:
         SNIPPET: The relevant C/C++ code snippet.
-        RELEVANT CONTEXT: Additional details or commentary on the snippet.
+        TOOL_EVIDENCE: Additional details or commentary on the snippet.
         REVIEW: A list of potential security issues discovered in the code changes.
 
         Your task is to:
-        1. Carefully examine each item in the REVIEW. Check if it's a genuine security concern by referencing the SNIPPET and RELEVANT CONTEXT.
+        1. Carefully examine each item in the REVIEW. Check if it's a genuine security concern by referencing the SNIPPET and TOOL_EVIDENCE.
         2. Remove any issues that are false positives or are already mitigated in the code (e.g., null checks exist, safe boundaries are enforced, etc.).
         3. Keep only the issues that definitely represent real security risks.
         4. If an issue is missing details, add the necessary clarifications or background.
@@ -212,22 +245,22 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in RTL security for SystemVerilog designs.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported by
-        the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        the specific changes or TOOL_EVIDENCE provided.
 
         You will be given:
         1. FILE_CHANGES - a set of SystemVerilog code changes with lines marked by "+" (added) or "-" (removed).
-        [[RELEVANT_CONTEXT_INPUT_RTL]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - the original file before being modified (may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - the original file before being modified (may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of FILE_CHANGES, focusing on "+" and "-" lines but reasoning about full-module behavior.
-           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE[[RELEVANT_CONTEXT_PATCH_JUSTIFICATION_SUFFIX]].
+           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE, and TOOL_EVIDENCE.
            - If no real issues exist, return an empty reviews list.
            - If ORIGINAL_FILE is empty, ignore it.
-           [[RELEVANT_CONTEXT_NAMED]]
+           - If TOOL_EVIDENCE is empty, ignore it.
 
         Output requirements:
         - Output ONLY a JSON object: {\"reviews\": [...]}
@@ -237,19 +270,19 @@ plugins:
 
       security_review_file: |-
         You are a thorough security engineer specializing in RTL security for SystemVerilog designs.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific code[[RELEVANT_CONTEXT_CODE_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific code or TOOL_EVIDENCE provided.
 
         You will be given:
         1. FILE - a SystemVerilog source file
-        [[RELEVANT_CONTEXT_INPUT_MODULE_PACKAGE]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search about related module/package behavior. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of FILE.
-           - Only produce findings that are fully justified by FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
+           - Only produce findings that are fully justified by FILE and TOOL_EVIDENCE.
            - If no real issues exist, return an empty reviews list.
-           [[RELEVANT_CONTEXT_NAMED]]
+           - If TOOL_EVIDENCE is empty, ignore it.
 
         Output requirements:
         - Output ONLY a JSON object: {\"reviews\": [...]}
@@ -266,17 +299,17 @@ plugins:
         - `bind` inserted logic or assertions changing behavior in synthesizable builds (often CWE-1191 / CWE-1234).
         - Use of DPI/PLI/VPI in synthesizable contexts or mixed RTL/TB packages leaking secrets or enabling backdoors (CWE-1191 / CWE-1431).
         - `unique/priority case` and incomplete case coverage leading to unintended privilege paths or latch inference (often CWE-1262 / CWE-1298).
-        [[RELEVANT_CONTEXT_ASSERTION_GUIDANCE]]
+        - Assertions: ensure security properties are not "simulation-only" crutches when TOOL_EVIDENCE suggests enforcement should exist in RTL.
           (If properties imply missing enforcement logic, map to the relevant CWE, commonly CWE-1262 / CWE-1191.)
 
       validation_review: |-
         You will be given:
         SNIPPET: The relevant SystemVerilog code snippet.
-        [[RELEVANT_CONTEXT_ADDITIONAL_DETAILS]]
+        TOOL_EVIDENCE: Additional details or commentary on the snippet.
         REVIEW: A list of potential security issues discovered.
 
         Your task is to:
-        1. Validate each item against SNIPPET[[RELEVANT_CONTEXT_SNIPPET_VALIDATION_SUFFIX]].
+        1. Validate each item against SNIPPET and TOOL_EVIDENCE.
         2. Remove false positives or issues already mitigated (e.g., deterministic reset, sticky locks, explicit privilege checks).
         3. Keep only issues that definitely represent real security risks.
         4. If no real issues remain, respond with an empty array: [].
@@ -303,22 +336,22 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in RTL security for Verilog designs.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported by
-        the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        the specific changes or TOOL_EVIDENCE provided.
 
         You will be given:
         1. FILE_CHANGES - a set of RTL code changes with lines marked by "+" (added) or "-" (removed).
-        [[RELEVANT_CONTEXT_INPUT_RTL]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - the original file before being modified (may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - the original file before being modified (may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of FILE_CHANGES, focusing on "+" and "-" lines but reasoning about full-module behavior.
-           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE[[RELEVANT_CONTEXT_PATCH_JUSTIFICATION_SUFFIX]].
+           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE, and TOOL_EVIDENCE.
            - If no real issues exist, return an empty reviews list.
            - If ORIGINAL_FILE is empty, ignore it.
-           [[RELEVANT_CONTEXT_NAMED]]
+           - If TOOL_EVIDENCE is empty, ignore it.
 
         Output requirements:
         - Output ONLY a JSON object: {\"reviews\": [...]}
@@ -328,19 +361,19 @@ plugins:
 
       security_review_file: |-
         You are a thorough security engineer specializing in RTL security for Verilog designs.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific code[[RELEVANT_CONTEXT_CODE_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific code or TOOL_EVIDENCE provided.
 
         You will be given:
         1. FILE - a Verilog RTL file
-        [[RELEVANT_CONTEXT_INPUT_MODULE]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search about related module behavior. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of FILE.
-           - Only produce findings that are fully justified by FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
+           - Only produce findings that are fully justified by FILE and TOOL_EVIDENCE.
            - If no real issues exist, return an empty reviews list.
-           [[RELEVANT_CONTEXT_NAMED]]
+           - If TOOL_EVIDENCE is empty, ignore it.
 
         Output requirements:
         - Output ONLY a JSON object: {\"reviews\": [...]}
@@ -354,11 +387,11 @@ plugins:
       validation_review: |-
         You will be given:
         SNIPPET: The relevant Verilog code snippet.
-        [[RELEVANT_CONTEXT_ADDITIONAL_DETAILS]]
+        TOOL_EVIDENCE: Additional details or commentary on the snippet.
         REVIEW: A list of potential security issues discovered.
 
         Your task is to:
-        1. Validate each item against SNIPPET[[RELEVANT_CONTEXT_SNIPPET_VALIDATION_SUFFIX]].
+        1. Validate each item against SNIPPET and TOOL_EVIDENCE.
         2. Remove false positives or issues already mitigated (e.g., deterministic reset, sticky locks, explicit privilege checks).
         3. Keep only issues that definitely represent real security risks.
         4. If no real issues remain, respond with an empty array: [].
@@ -388,26 +421,26 @@ plugins:
     prompts:
       security_review: |-
         1. You are a thorough security engineer specializing in LLVM TableGen (.td) specifications.
-        Always tie identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
-        and ORIGINAL_FILE. Do not introduce conclusions that are not supported by the .td contents[[RELEVANT_CONTEXT_TD_PROVIDED_SUFFIX]].
+        Always tie identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
+        and ORIGINAL_FILE. Do not introduce conclusions that are not supported by the .td contents or TOOL_EVIDENCE.
 
         You will be given:
         1) FILE_CHANGES — a set of .td changes with lines marked by “+” (added) or “-” (removed).
-        [[RELEVANT_CONTEXT_INPUT_TD]]
-        [[ORIGINAL_FILE_INDEX_PAREN]] ORIGINAL_FILE — the original TableGen file (this may be empty).
+        2) TOOL_EVIDENCE — optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3) ORIGINAL_FILE — the original TableGen file (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” but taking into account how they interact with the whole file.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
       security_review_file: |-
         1. You are a thorough security engineer specializing in LLVM TableGen (.td) specifications.
-        Always tie identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce conclusions that are not supported by the .td contents[[RELEVANT_CONTEXT_TD_PROVIDED_SUFFIX]].
+        Always tie identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce conclusions that are not supported by the .td contents or TOOL_EVIDENCE.
 
         You will be given:
         1) FILE — a TableGen file (e.g., instruction/operand/register definitions, patterns, features).
-        [[RELEVANT_CONTEXT_INPUT_TD]]
+        2) TOOL_EVIDENCE — optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
       security_review_checks: |-
         Your tasks:
@@ -460,18 +493,18 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in Python.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported
-        by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE_CHANGES - a set of code changes with lines marked by “+” indicating what has been added or “-” for removed.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” but take into account how they interact with the whole file.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
            - Look for potential security issues such as:
@@ -484,16 +517,16 @@ plugins:
       attempt_fix: "Based on the issues detected in the Python code changes, propose a fix patch. Issues: {issues} Patch: {patch}"
       security_review_file: |-
         You are a thorough security engineer specializing in Python.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
   ruby:
     supported_extensions: [".rb"]
     splitting:
@@ -503,18 +536,18 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in Ruby.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported
-        by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE_CHANGES - a set of code changes with lines marked by “+” indicating what has been added or “-” for removed.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” but take into account how they interact with the whole file.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
            - Look for potential security issues such as:
@@ -527,16 +560,16 @@ plugins:
       attempt_fix: "Based on the issues detected in the Ruby code changes, propose a fix patch. Issues: {issues} Patch: {patch}"
       security_review_file: |-
         You are a thorough security engineer specializing in Ruby.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
   go:
     supported_extensions: [".go"]
     splitting:
@@ -546,19 +579,19 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in Go services, CLIs, and libraries.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported
-        by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE_CHANGES - a set of Go code changes with lines marked by “+” for additions and “-” for removals.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” while reasoning about how they interact with the entire package.
-           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE[[RELEVANT_CONTEXT_PATCH_JUSTIFICATION_SUFFIX]]. If no real issues exist, return an empty reviews list.
-           [[RELEVANT_CONTEXT]]
+           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE, and TOOL_EVIDENCE. If no real issues exist, return an empty reviews list.
+           - If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
            - Look for potential security issues such as:
@@ -576,16 +609,16 @@ plugins:
       attempt_fix: "Based on the issues detected in the Go code changes, propose a fix patch. Issues: {issues} Patch: {patch}"
       security_review_file: |-
         You are a thorough security engineer specializing in Go.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
   typescript:
     supported_extensions: [".ts", ".tsx"]
     splitting:
@@ -595,18 +628,18 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in TypeScript across both Node.js and browser environments.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported
-        by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE_CHANGES - a set of code changes with lines marked by “+” indicating what has been added or “-” for removed.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” but take into account how they interact with the whole file.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
            - Look for potential security issues such as:
@@ -625,16 +658,16 @@ plugins:
       attempt_fix: "Based on the issues detected in the TypeScript code changes, propose a fix patch. Issues: {issues} Patch: {patch}"
       security_review_file: |-
         You are a thorough security engineer specializing in TypeScript across both Node.js and browser environments.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
   solidity:
     supported_extensions: [".sol"]
     splitting:
@@ -644,20 +677,20 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in Solidity smart contracts and the EVM.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported by the specific
         changes or context provided.
 
         You will be given:
         1. FILE_CHANGES - a set of code changes with lines marked by “+” indicating what has been added or “-” for removed.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” while considering interactions with the whole file.
-           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE[[RELEVANT_CONTEXT_PATCH_JUSTIFICATION_SUFFIX]]. If no real issues exist, return an empty reviews list.
-           [[RELEVANT_CONTEXT]]
+           - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE, and TOOL_EVIDENCE. If no real issues exist, return an empty reviews list.
+           - If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
            - Look for potential security issues such as:
@@ -684,16 +717,16 @@ plugins:
       attempt_fix: "Based on the issues detected in the Solidity code changes, propose a fix patch. Issues: {issues} Patch: {patch}"
       security_review_file: |-
         You are a thorough security engineer specializing in Solidity smart contracts and the EVM.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
   rust:
     supported_extensions: [".rs"]
     splitting:
@@ -703,18 +736,18 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in Rust.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported
-        by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE_CHANGES - a set of code changes with lines marked by “+” indicating what has been added or “-” for removed.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” but take into account how they interact with the whole file.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
         - Look for potential security issues such as:
@@ -740,16 +773,16 @@ plugins:
       attempt_fix: "Based on the issues detected in the Rust code changes, propose a fix patch. Issues: {issues} Patch: {patch}"
       security_review_file: |-
         You are a thorough security engineer specializing in Rust.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
   terraform:
     supported_extensions: [".tf"]
     splitting:
@@ -759,17 +792,17 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in Terraform (HCL) and cloud security.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce security conclusions that are not supported by the
-        specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided. Where possible, cite exact line numbers and resource
+        specific changes or TOOL_EVIDENCE provided. Where possible, cite exact line numbers and resource
         addresses from FILE_CHANGES.
 
         You will be given:
         1) FILE_CHANGES  – A unified diff of Terraform files (HCL) with lines marked by “+” for
            additions and “-” for removals. This may include modules, variables, providers,
            backend configuration, and environment files. Treat “+” and “-” as the primary scope.
-        [[RELEVANT_CONTEXT_INPUT_TERRAFORM]]
-        [[ORIGINAL_FILE_INDEX_PAREN]] ORIGINAL_FILE  – The original configuration before modification. Use this to understand
+        2) TOOL_EVIDENCE – optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3) ORIGINAL_FILE  – The original configuration before modification. Use this to understand
            how changes alter behavior. (If empty, ignore.)
 
         Your tasks are:
@@ -778,7 +811,7 @@ plugins:
            - Review the security implications of FILE_CHANGES, focusing on “+” (added) and “-”
              (removed) lines, but reason about how these interact with the whole module/stack.
            - Only draw conclusions that are directly evidenced by FILE_CHANGES and/or
-             [[RELEVANT_CONTEXT_TERRAFORM_ORIGINAL_PREFIX]]ORIGINAL_FILE.
+             ORIGINAL_FILE.
       security_review_checks: |-
         2. What to check
         - Look for potential security issues such as:
@@ -793,16 +826,16 @@ plugins:
       attempt_fix: "Based on the issues detected in the terraform code changes, propose a fix/patch. Issues: {issues} Patch: {patch}"
       security_review_file: |-
         You are a thorough DecSecOps engineer specializing in Terraform.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
            - Review the security implications of the FILE.
-        [[RELEVANT_CONTEXT_UNINDENTED]]
+        If TOOL_EVIDENCE is empty, ignore it.
   php:
     supported_extensions: [".php", ".phps", ".phtm", ".phtml", ".phpt", ".pht", ".php2", ".php3", ".php4", ".php5", ".php6", ".php7", ".php8"]
     splitting:
@@ -812,32 +845,32 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in PHP.
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported
-        by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE_CHANGES - a set of code changes with lines marked by “+” indicating what has been added or “-” for removed.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
           - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” but take into account how they interact with the whole file.
-          - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE[[RELEVANT_CONTEXT_PATCH_JUSTIFICATION_SUFFIX]]. If no real issues exist, return an empty reviews list.
-          [[RELEVANT_CONTEXT_TWO_SPACE]]
+          - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE, and TOOL_EVIDENCE. If no real issues exist, return an empty reviews list.
+          - If TOOL_EVIDENCE is empty, ignore it.
       security_review_file: |-
         You are a thorough security engineer specializing in PHP.
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
           - Review the security implications of the FILE.
-          - Only produce findings that are fully justified by FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]]. If no real issues exist, return an empty reviews list.
-          [[RELEVANT_CONTEXT_TWO_SPACE]]
+          - Only produce findings that are fully justified by FILE and TOOL_EVIDENCE. If no real issues exist, return an empty reviews list.
+          - If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
           - Look for potential security issues such as:
@@ -853,11 +886,11 @@ plugins:
       validation_review: |-
         You will be given:
         SNIPPET: The relevant PHP code snippet.
-        RELEVANT CONTEXT: Additional details or commentary on the snippet.
+        TOOL_EVIDENCE: Additional details or commentary on the snippet.
         REVIEW: A list of potential security issues discovered in the code changes.
 
         Your task is to:
-        1. Carefully examine each item in the REVIEW. Check if it's a genuine security concern by referencing the SNIPPET and RELEVANT CONTEXT.
+        1. Carefully examine each item in the REVIEW. Check if it's a genuine security concern by referencing the SNIPPET and TOOL_EVIDENCE.
         2. Remove any issues that are false positives or are already mitigated in the code (e.g., prepared statements for SQL, escaping for output).
         3. Keep only the issues that definitely represent real security risks.
         4. If an issue is missing details, add the necessary clarifications or background.
@@ -882,32 +915,32 @@ plugins:
     prompts:
       security_review: |-
         You are a thorough security engineer specializing in JavaScript (including Node.js and browser contexts).
-        Always tie your identified issues directly to the evidence in FILE_CHANGES[[RELEVANT_CONTEXT_PATCH_EVIDENCE_SUFFIX]],
+        Always tie your identified issues directly to the evidence in FILE_CHANGES, TOOL_EVIDENCE,
         and ORIGINAL_FILE. Do not introduce new security conclusions that are not supported
-        by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE_CHANGES - a set of code changes with lines marked by “+” indicating what has been added or “-” for removed.
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
-        [[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
+        3. ORIGINAL_FILE - The original file before being modified. Use this to understand how changes affect the code. (this may be empty).
 
         Your tasks are:
         1. Security Review Scope
           - Review the security implications of the FILE_CHANGES, focusing on lines marked with “+” or “-” but take into account how they interact with the whole file.
-          - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE[[RELEVANT_CONTEXT_PATCH_JUSTIFICATION_SUFFIX]]. If no real issues exist, return an empty reviews list.
-          [[RELEVANT_CONTEXT_TWO_SPACE]]
+          - Only produce findings that are fully justified by FILE_CHANGES, ORIGINAL_FILE, and TOOL_EVIDENCE. If no real issues exist, return an empty reviews list.
+          - If TOOL_EVIDENCE is empty, ignore it.
       security_review_file: |-
         You are a thorough security engineer specializing in JavaScript (including Node.js and browser contexts).
-        Always tie your identified issues directly to the evidence in FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]].
-        Do not introduce new security conclusions that are not supported by the specific changes[[RELEVANT_CONTEXT_CHANGES_PROVIDED_SUFFIX]] provided.
+        Always tie your identified issues directly to the evidence in FILE and TOOL_EVIDENCE.
+        Do not introduce new security conclusions that are not supported by the specific changes or TOOL_EVIDENCE provided.
         You will be given:
         1. FILE - A source code file
-        [[RELEVANT_CONTEXT_INPUT_CHANGES]]
+        2. TOOL_EVIDENCE - optional additional evidence collected via tools such as sed, cat, grep, find_name, and rag_search. If empty, ignore it.
 
         Your tasks are:
         1. Security Review Scope
           - Review the security implications of the FILE.
-          - Only produce findings that are fully justified by FILE[[RELEVANT_CONTEXT_FILE_EVIDENCE_SUFFIX]]. If no real issues exist, return an empty reviews list.
-          [[RELEVANT_CONTEXT_TWO_SPACE]]
+          - Only produce findings that are fully justified by FILE and TOOL_EVIDENCE. If no real issues exist, return an empty reviews list.
+          - If TOOL_EVIDENCE is empty, ignore it.
       security_review_checks: |-
         2. What to Check
           - Look for potential security issues such as:
@@ -923,11 +956,11 @@ plugins:
       validation_review: |-
         You will be given:
         SNIPPET: The relevant JavaScript code snippet.
-        RELEVANT CONTEXT: Additional details or commentary on the snippet.
+        TOOL_EVIDENCE: Additional details or commentary on the snippet.
         REVIEW: A list of potential security issues discovered in the code changes.
 
         Your task is to:
-        1. Carefully examine each item in the REVIEW. Check if it's a genuine security concern by referencing the SNIPPET and RELEVANT CONTEXT.
+        1. Carefully examine each item in the REVIEW. Check if it's a genuine security concern by referencing the SNIPPET and TOOL_EVIDENCE.
         2. Remove any issues that are false positives or are already mitigated in the code (e.g., sanitization libraries like DOMPurify).
         3. Keep only the issues that definitely represent real security risks.
         4. If an issue is missing details, add the necessary clarifications or background.

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -44,14 +44,12 @@ def test_build_review_system_prompt_replaces_placeholder():
     assert schema_section in prompt
 
 
-def test_build_review_system_prompt_preserves_legacy_context_prompt():
+def test_build_review_system_prompt_includes_tool_evidence_language():
     language_prompts = {
         "security_review_file": (
-            "Use FILE and RELEVANT_CONTEXT.\n"
-            "2. RELEVANT_CONTEXT - information about what these changes do.\n"
-            "[[REVIEW_SCHEMA_FIELDS]]"
+            "Use FILE and TOOL_EVIDENCE.\n" "[[REVIEW_SCHEMA_FIELDS]]"
         ),
-        "security_review_checks": "- If RELEVANT_CONTEXT is empty, ignore it.",
+        "security_review_checks": "- If TOOL_EVIDENCE is empty, ignore it.",
     }
     schema_section = '- "issue": description'
     prompt = build_review_system_prompt(
@@ -61,86 +59,11 @@ def test_build_review_system_prompt_preserves_legacy_context_prompt():
         custom_prompt_text=None,
         custom_guidance_precedence="",
         schema_prompt_section=schema_section,
+        tool_guidance="Use rag_search for broader semantic context.",
     )
 
-    expected = (
-        "Use FILE and RELEVANT_CONTEXT.\n"
-        "2. RELEVANT_CONTEXT - information about what these changes do.\n"
-        '- "issue": description \n '
-        "- If RELEVANT_CONTEXT is empty, ignore it. \n Reporting instructions."
-    )
-    assert prompt == expected
-
-
-def test_build_review_system_prompt_omits_relevant_context_when_disabled():
-    language_prompts = {
-        "security_review_file": (
-            "Use FILE and RELEVANT_CONTEXT.\n"
-            "2. RELEVANT_CONTEXT - information about what these changes do.\n"
-            "3. ORIGINAL_FILE - original contents.\n"
-            "Only produce findings justified by FILE and RELEVANT_CONTEXT.\n"
-            "[[REVIEW_SCHEMA_FIELDS]]"
-        ),
-        "security_review_checks": "- If RELEVANT_CONTEXT is empty, ignore it.",
-    }
-    schema_section = '- "issue": description'
-    prompt = build_review_system_prompt(
-        language_prompts,
-        "security_review_file",
-        report_prompt="Reporting instructions.",
-        custom_prompt_text=None,
-        custom_guidance_precedence="",
-        schema_prompt_section=schema_section,
-        include_relevant_context=False,
-    )
-
-    assert "2. RELEVANT_CONTEXT" not in prompt
-    assert "RELEVANT_CONTEXT" not in prompt
-    assert "2. ORIGINAL_FILE" in prompt
-
-
-def test_build_review_system_prompt_replaces_context_placeholders():
-    language_prompts = {
-        "security_review_file": (
-            "1. FILE - source\n"
-            "[[RELEVANT_CONTEXT_INPUT_CHANGES]]\n"
-            "[[ORIGINAL_FILE_INDEX_DOT]] ORIGINAL_FILE - old\n"
-            "[[REVIEW_SCHEMA_FIELDS]]"
-        ),
-        "security_review_checks": "[[RELEVANT_CONTEXT]]",
-    }
-    schema_section = '- "issue": description'
-
-    with_context = build_review_system_prompt(
-        language_prompts,
-        "security_review_file",
-        report_prompt="Reporting instructions.",
-        custom_prompt_text=None,
-        custom_guidance_precedence="",
-        schema_prompt_section=schema_section,
-    )
-    without_context = build_review_system_prompt(
-        language_prompts,
-        "security_review_file",
-        report_prompt="Reporting instructions.",
-        custom_prompt_text=None,
-        custom_guidance_precedence="",
-        schema_prompt_section=schema_section,
-        include_relevant_context=False,
-    )
-
-    assert (
-        "2. RELEVANT_CONTEXT - information about what these changes do." in with_context
-    )
-    assert "- If it is empty, ignore it." in with_context
-    assert "3. ORIGINAL_FILE - old" in with_context
-    assert "[[RELEVANT_CONTEXT_" not in with_context
-    assert (
-        "RELEVANT_CONTEXT - information about what these changes do."
-        not in without_context
-    )
-    assert "- If it is empty, ignore it." not in without_context
-    assert "2. ORIGINAL_FILE - old" in without_context
+    assert "TOOL_EVIDENCE" in prompt
+    assert "Use rag_search for broader semantic context." in prompt
 
 
 def test_sanitize_review_payload_fills_missing_fields():

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -3,26 +3,37 @@
 
 from metis.engine.graphs.ask import AskGraph
 from metis.engine.graphs.review import (
+    review_node_collect_baseline_context,
+    review_node_collect_tool_evidence,
     review_node_build_prompt,
     review_node_llm,
     review_node_parse,
 )
-from metis.engine.graphs.review_tools import build_review_langchain_tools
+from metis.engine.graphs.review_tools import (
+    build_review_langchain_tools,
+    run_review_tool_phase,
+)
+from metis.engine.graphs.review_retrieval import (
+    assess_review_context_quality,
+    compute_review_obligation_coverage,
+)
 from metis.engine.graphs.triage.llm import _build_user_prompt, triage_node_llm
 from metis.engine.graphs.triage.retrieval import triage_node_retrieve
 
 
 class _Doc:
-    def __init__(self, text):
+    def __init__(self, text, source="doc.txt"):
         self.page_content = text
+        self.metadata = {"source": source}
 
 
 class DummyRetriever:
-    def __init__(self, label):
+    def __init__(self, label, source="doc.txt"):
         self._label = label
+        self._source = source
 
     def get_relevant_documents(self, q):
-        return [_Doc(f"{self._label} context for: {q}")]
+        return [_Doc(f"{self._label} context for: {q}", source=self._source)]
 
 
 def test_ask_graph_returns_code_and_docs():
@@ -177,6 +188,377 @@ def test_review_node_llm_omits_context_section_in_no_index_mode():
     )
 
     assert "CONTEXT:" not in captured["body_text"]
+
+
+def test_review_node_llm_includes_baseline_context_and_evidence_frame():
+    captured = {}
+
+    class _DummyNode:
+        def invoke(self, payload):
+            captured.update(payload)
+            return {"reviews": []}
+
+    state = {
+        "file_path": "foo.py",
+        "snippet": "print('hello')",
+        "mode": "file",
+        "system_prompt": "prompt",
+        "baseline_context": "[foo.py]\ncallers validate input",
+        "review_evidence_frame": "[OBLIGATION_COVERAGE]\n- callers or wrappers: covered",
+        "tool_evidence": "[SUMMARY]\nextra",
+    }
+
+    review_node_llm(
+        state,
+        structured_node=_DummyNode(),
+        fallback_node=None,
+    )
+
+    assert "BASELINE_CONTEXT:" in captured["body_text"]
+    assert "REVIEW_EVIDENCE_FRAME:" in captured["body_text"]
+    assert "TOOL_EVIDENCE:" in captured["body_text"]
+
+
+def test_review_node_collect_baseline_context_builds_hybrid_context():
+    state = {
+        "file_path": "src/auth.py",
+        "relative_file": "src/auth.py",
+        "snippet": "def check_token(user_token):\n    return validate_token(user_token)\n",
+        "mode": "file",
+        "retriever_code": DummyRetriever("src/auth.py check_token validate_token"),
+        "retriever_docs": DummyRetriever("security docs validate_token contract"),
+        "use_retrieval_context": True,
+    }
+
+    out = review_node_collect_baseline_context(state)
+
+    assert "Candidate symbols:" in out["baseline_context_query"]
+    assert out["baseline_context"]
+    assert "[OBLIGATION_COVERAGE]" in out["review_evidence_frame"]
+    assert "code=" in out["baseline_context_quality"]
+
+
+def test_review_node_collect_baseline_context_drops_low_signal_retrieval():
+    class _StaticRetriever:
+        def __init__(self, text, source):
+            self._text = text
+            self._source = source
+
+        def get_relevant_documents(self, _query):
+            return [_Doc(self._text, source=self._source)]
+
+    state = {
+        "file_path": "src/auth.py",
+        "relative_file": "src/auth.py",
+        "snippet": "def check_token(user_token):\n    return validate_token(user_token)\n",
+        "mode": "file",
+        "retriever_code": _StaticRetriever("completely unrelated prose", "other.txt"),
+        "retriever_docs": _StaticRetriever("more unrelated prose", "docs.txt"),
+        "use_retrieval_context": True,
+    }
+
+    out = review_node_collect_baseline_context(state)
+
+    assert out["baseline_context"] == ""
+    assert "low-signal" in out["baseline_context_quality"]
+
+
+def test_review_context_quality_accepts_symbolic_overlap_without_filename():
+    accepted, quality = assess_review_context_quality(
+        "[CODE_RAG]\ncheck_token callers validate_token guard user token\n[DOCS_RAG]\nauthorization boundary",
+        file_path="src/auth.py",
+        symbols=["check_token", "validate_token"],
+        focus_terms=["auth", "validate", "token"],
+    )
+
+    assert accepted is True
+    assert "query-tokens=" in quality or "obligations=" in quality
+
+
+def test_review_tool_phase_blocks_rag_in_first_stage():
+    class _Toolbox:
+        def has(self, name):
+            return name in {"sed", "cat", "grep", "find_name", "rag_search"}
+
+        def sed(self, path, start_line, end_line):
+            return ""
+
+        def cat(self, path):
+            return ""
+
+        def grep(self, pattern, path):
+            return ""
+
+        def find_name(self, name, max_results=20):
+            return []
+
+        def rag_search(self, query, *, retriever_code=None, retriever_docs=None):
+            raise AssertionError("rag_search should be blocked in stage 1")
+
+    class _ToolModel:
+        def __init__(self):
+            self.turn = 0
+
+        def invoke(self, _messages):
+            self.turn += 1
+            if self.turn == 1:
+                return type(
+                    "Msg",
+                    (),
+                    {
+                        "tool_calls": [
+                            {
+                                "name": "rag_search",
+                                "id": "tool-1",
+                                "args": {"query": "what validates auth.py"},
+                            }
+                        ],
+                        "content": "",
+                    },
+                )()
+            return type("Msg", (), {"tool_calls": [], "content": "done"})()
+
+    class _ChatModel:
+        def bind_tools(self, _tools):
+            return _ToolModel()
+
+    tools, tools_by_name = build_review_langchain_tools(_Toolbox())
+    out = run_review_tool_phase(
+        chat_model=_ChatModel(),
+        tools=tools,
+        tools_by_name=tools_by_name,
+        system_prompt="prompt",
+        body_text="body",
+    )
+
+    assert "disabled in review stage 1" in out["tool_evidence"]
+    assert "[RETRIEVAL_NOTES]" in out["tool_evidence"]
+
+
+def test_review_tool_phase_shapes_and_rejects_low_signal_rag():
+    captured = {}
+
+    class _Toolbox:
+        def has(self, name):
+            return name in {"sed", "cat", "grep", "find_name", "rag_search"}
+
+        def sed(self, path, start_line, end_line):
+            return "local"
+
+        def cat(self, path):
+            return "local"
+
+        def grep(self, pattern, path):
+            return "lookup"
+
+        def find_name(self, name, max_results=20):
+            return []
+
+        def rag_search(self, query, *, retriever_code=None, retriever_docs=None):
+            captured["query"] = query
+            return "[CODE_RAG]\ncompletely unrelated prose\n\n[DOCS_RAG]\nmore unrelated prose"
+
+    class _ToolModel:
+        def __init__(self):
+            self.turn = 0
+
+        def invoke(self, _messages):
+            self.turn += 1
+            if self.turn == 1:
+                return type(
+                    "Msg",
+                    (),
+                    {
+                        "tool_calls": [
+                            {
+                                "name": "cat",
+                                "id": "tool-1",
+                                "args": {"path": "src/auth.py"},
+                            }
+                        ],
+                        "content": "",
+                    },
+                )()
+            if self.turn == 2:
+                return type(
+                    "Msg",
+                    (),
+                    {
+                        "tool_calls": [
+                            {
+                                "name": "grep",
+                                "id": "tool-2",
+                                "args": {"pattern": "validate_token", "path": "src"},
+                            }
+                        ],
+                        "content": "",
+                    },
+                )()
+            if self.turn == 3:
+                return type(
+                    "Msg",
+                    (),
+                    {
+                        "tool_calls": [
+                            {
+                                "name": "rag_search",
+                                "id": "tool-3",
+                                "args": {"query": "what validates this"},
+                            }
+                        ],
+                        "content": "",
+                    },
+                )()
+            return type("Msg", (), {"tool_calls": [], "content": "done"})()
+
+    class _ChatModel:
+        def bind_tools(self, _tools):
+            return _ToolModel()
+
+    tools, tools_by_name = build_review_langchain_tools(_Toolbox())
+    out = run_review_tool_phase(
+        chat_model=_ChatModel(),
+        tools=tools,
+        tools_by_name=tools_by_name,
+        system_prompt="prompt",
+        body_text="body",
+        review_search_context={
+            "file_path": "src/auth.py",
+            "mode": "file",
+            "symbols": ["check_token", "validate_token"],
+            "focus_terms": ["auth", "validate"],
+            "baseline_query": "baseline question",
+            "uncovered_obligations": [
+                "callers or wrappers",
+                "trust or privilege boundary",
+            ],
+        },
+    )
+
+    assert "Missing obligations:" in captured["query"]
+    assert "src/auth.py" in captured["query"]
+    assert "[RAG_REJECTED]" in out["tool_evidence"]
+    assert "[RAG_CONTEXT]" in out["tool_evidence"]
+
+
+def test_review_tool_phase_emits_typed_obligation_sections():
+    class _Toolbox:
+        def has(self, name):
+            return name in {"sed", "cat", "grep", "find_name"}
+
+        def sed(self, path, start_line, end_line):
+            return ""
+
+        def cat(self, path):
+            return "caller wrapper validate auth boundary unresolved gap"
+
+        def grep(self, pattern, path):
+            return ""
+
+        def find_name(self, name, max_results=20):
+            return []
+
+    class _ToolModel:
+        def __init__(self):
+            self.turn = 0
+
+        def invoke(self, _messages):
+            self.turn += 1
+            if self.turn == 1:
+                return type(
+                    "Msg",
+                    (),
+                    {
+                        "tool_calls": [
+                            {
+                                "name": "cat",
+                                "id": "tool-1",
+                                "args": {"path": "src/auth.py"},
+                            }
+                        ],
+                        "content": "",
+                    },
+                )()
+            return type("Msg", (), {"tool_calls": [], "content": "done"})()
+
+    class _ChatModel:
+        def bind_tools(self, _tools):
+            return _ToolModel()
+
+    tools, tools_by_name = build_review_langchain_tools(_Toolbox())
+    out = run_review_tool_phase(
+        chat_model=_ChatModel(),
+        tools=tools,
+        tools_by_name=tools_by_name,
+        system_prompt="prompt",
+        body_text="body",
+        review_search_context={
+            "file_path": "src/auth.py",
+            "mode": "file",
+            "symbols": ["check_token"],
+            "focus_terms": ["auth", "validate"],
+            "baseline_query": "baseline question",
+            "uncovered_obligations": ["callers or wrappers"],
+        },
+    )
+
+    assert "[RELATED_CALLERS]" in out["tool_evidence"]
+    assert "[VALIDATION_GUARDS]" in out["tool_evidence"]
+    assert "[TRUST_BOUNDARY]" in out["tool_evidence"]
+    assert "[UNRESOLVED]" in out["tool_evidence"]
+
+
+def test_review_node_collect_tool_evidence_updates_coverage_frame():
+    class _Toolbox:
+        def without(self, *_names):
+            return self
+
+        def has(self, _name):
+            return True
+
+    class _ToolChat:
+        def bind_tools(self, _tools):
+            return self
+
+        def invoke(self, _messages):
+            return type(
+                "Msg",
+                (),
+                {"tool_calls": [], "content": "Callers validate auth boundary none"},
+            )()
+
+    state = {
+        "file_path": "src/auth.py",
+        "relative_file": "src/auth.py",
+        "snippet": "def check_token(user_token):\n    return validate_token(user_token)\n",
+        "mode": "file",
+        "use_retrieval_context": True,
+        "baseline_context": "[src/auth.py]\nvalidate_token checks auth",
+        "baseline_context_quality": "code=accepted, docs=empty",
+    }
+
+    out = review_node_collect_tool_evidence(
+        state,
+        chat_model=_ToolChat(),
+        toolbox=_Toolbox(),
+        tool_system_prompt="prompt",
+        tool_system_prompt_no_rag="prompt",
+    )
+
+    assert "[OBLIGATION_COVERAGE]" in out["review_evidence_frame"]
+    assert "[MISSING_OBLIGATIONS]" in out["review_evidence_frame"]
+
+
+def test_review_obligation_coverage_prefers_typed_sections():
+    coverage = compute_review_obligation_coverage(
+        "[RELATED_CALLERS]\ncheck_token wrapper\n\n[VALIDATION_GUARDS]\nvalidate token guard\n\n[TRUST_BOUNDARY]\nauth privilege boundary",
+        symbols=["check_token", "validate_token"],
+        focus_terms=["auth", "validate"],
+    )
+
+    assert coverage["callers or wrappers"] is True
+    assert coverage["validation / sanitization / authorization checks"] is True
+    assert coverage["trust or privilege boundary"] is True
 
 
 def test_triage_user_prompt_omits_rag_context_in_no_index_mode():

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -3,12 +3,13 @@
 
 from metis.engine.graphs.ask import AskGraph
 from metis.engine.graphs.review import (
-    review_node_retrieve,
     review_node_build_prompt,
     review_node_llm,
     review_node_parse,
 )
+from metis.engine.graphs.review_tools import build_review_langchain_tools
 from metis.engine.graphs.triage.llm import _build_user_prompt, triage_node_llm
+from metis.engine.graphs.triage.retrieval import triage_node_retrieve
 
 
 class _Doc:
@@ -43,23 +44,18 @@ def test_review_nodes_pipeline_parses():
     state = {
         "file_path": "a/file.c",
         "snippet": "int main(){}",
-        "retriever_code": DummyRetriever("code"),
-        "retriever_docs": DummyRetriever("docs"),
-        "context_prompt": "Use file: {file_path}",
+        "retriever_code": object(),
+        "retriever_docs": object(),
     }
 
-    # Step 1: retrieve context
-    s1 = review_node_retrieve(state)
-    assert "context" in s1
-
-    # Step 2: build prompt
+    # Step 1: build prompt
     language_prompts = {
         "security_review_file": "Do a security review [[REVIEW_SCHEMA_FIELDS]]",
         "security_review_checks": "Checks...",
         "validation_review": "Validate...",
     }
     s2 = review_node_build_prompt(
-        s1,
+        state,
         language_prompts=language_prompts,
         default_prompt_key="security_review_file",
         report_prompt="",
@@ -69,7 +65,7 @@ def test_review_nodes_pipeline_parses():
     )
     assert "system_prompt" in s2
 
-    # Step 3: run LLM review (stub)
+    # Step 2: run LLM review (stub)
     class _DummyNode:
         def __init__(self, payload):
             self._payload = payload
@@ -99,28 +95,62 @@ def test_review_nodes_pipeline_parses():
     assert "parsed_reviews" in s3
     assert s3["parsed_reviews"]
 
-    # Step 4: parse
+    # Step 3: parse
     s4 = review_node_parse(s3)
     assert s4.get("parsed_reviews") and isinstance(s4["parsed_reviews"], list)
 
 
-def test_review_node_retrieve_no_index_skips_retrievers():
-    class _BoomRetriever:
-        def get_relevant_documents(self, _query):
-            raise AssertionError("retriever should not be called")
+def test_review_langchain_tools_hide_rag_when_retrieval_disabled():
+    class _Toolbox:
+        def has(self, name):
+            return name in {"sed", "cat", "grep", "find_name"}
+
+        def sed(self, path, start_line, end_line):
+            return ""
+
+        def cat(self, path):
+            return ""
+
+        def grep(self, pattern, path):
+            return ""
+
+        def find_name(self, name, max_results=20):
+            return []
+
+    tools, _ = build_review_langchain_tools(_Toolbox())
+
+    assert {tool.name for tool in tools} == {"sed", "cat", "grep", "find_name"}
+
+
+def test_triage_node_retrieve_uses_shared_rag_tool():
+    captured = {}
+
+    class _Toolbox:
+        def has(self, name):
+            return name == "rag_search"
+
+        def rag_search(self, query, *, retriever_code=None, retriever_docs=None):
+            captured["query"] = query
+            captured["retriever_code"] = retriever_code
+            captured["retriever_docs"] = retriever_docs
+            return "[CODE_RAG]\ncode\n\n[DOCS_RAG]\ndocs"
 
     state = {
-        "file_path": "a/file.c",
-        "snippet": "int main(){}",
-        "retriever_code": _BoomRetriever(),
-        "retriever_docs": _BoomRetriever(),
-        "context_prompt": "ignored",
-        "use_retrieval_context": False,
+        "finding_rule_id": "R1",
+        "finding_file_path": "a.c",
+        "finding_line": 1,
+        "finding_message": "msg",
+        "finding_snippet": "code",
+        "retriever_code": object(),
+        "retriever_docs": object(),
+        "use_retrieval_context": True,
     }
 
-    out = review_node_retrieve(state)
+    out = triage_node_retrieve(state, toolbox=_Toolbox())
 
-    assert out["context"] == ""
+    assert "[CODE_RAG]" in out["context"]
+    assert captured["retriever_code"] is state["retriever_code"]
+    assert captured["retriever_docs"] is state["retriever_docs"]
 
 
 def test_review_node_llm_omits_context_section_in_no_index_mode():

--- a/tests/test_static_tools.py
+++ b/tests/test_static_tools.py
@@ -17,11 +17,13 @@ def _build_runner(tmp_path):
 
 
 def test_cat_fallback_reads_file(tmp_path):
-    source = tmp_path / "a.txt"
+    codebase = tmp_path / "src" / "metis" / "sarif"
+    codebase.mkdir(parents=True)
+    source = codebase / "a.txt"
     source.write_text("line1\nline2\n", encoding="utf-8")
 
-    runner = _build_runner(tmp_path)
-    out = runner.cat("a.txt")
+    runner = _build_runner(codebase)
+    out = runner.cat("src/metis/sarif/a.txt")
     assert out == "line1\nline2\n"
 
 
@@ -47,15 +49,16 @@ def test_find_name_fallback_finds_matching_files(tmp_path):
 
 
 def test_grep_fallback_searches_recursively(tmp_path):
-    (tmp_path / "src").mkdir()
-    (tmp_path / "src" / "a.c").write_text("alpha\nbeta\n", encoding="utf-8")
-    (tmp_path / "src" / "b.c").write_text("gamma\nbeta42\n", encoding="utf-8")
+    codebase = tmp_path / "src" / "metis" / "sarif"
+    codebase.mkdir(parents=True)
+    (codebase / "a.c").write_text("alpha\nbeta\n", encoding="utf-8")
+    (codebase / "b.c").write_text("gamma\nbeta42\n", encoding="utf-8")
 
-    runner = _build_runner(tmp_path)
+    runner = _build_runner(codebase)
     out = runner.grep(r"beta", "src")
     lines = out.splitlines()
-    assert "src/a.c:2:beta" in lines
-    assert "src/b.c:2:beta42" in lines
+    assert "a.c:2:beta" in lines
+    assert "b.c:2:beta42" in lines
 
 
 def test_grep_fallback_invalid_pattern_raises(tmp_path):
@@ -70,26 +73,28 @@ def test_grep_can_force_python_regex_even_when_shell_grep_exists(tmp_path, monke
     (tmp_path / "src" / "a.c").write_text("foo\t(\n", encoding="utf-8")
 
     runner = StaticToolRunner(codebase_path=str(tmp_path))
-    runner._has_grep = False
+    runner._has_grep = True
 
     def _unexpected_run(*args, **kwargs):
-        raise AssertionError("shell grep should not run when _has_grep=False")
+        raise AssertionError("shell grep should not run for risky patterns")
 
     monkeypatch.setattr(subprocess, "run", _unexpected_run)
 
-    out = runner.grep(r"foo[[:space:]]*\(", "src")
+    out = runner.grep(r"foo\b\s*\(", "src")
 
     assert out.splitlines() == ["src/a.c:1:foo\t("]
 
 
 def test_shell_grep_forces_filename_prefix_for_single_file(tmp_path):
-    source = tmp_path / "a.c"
+    codebase = tmp_path / "src" / "metis" / "sarif"
+    codebase.mkdir(parents=True)
+    source = codebase / "a.c"
     source.write_text("alpha\nbeta\n", encoding="utf-8")
 
-    runner = StaticToolRunner(codebase_path=str(tmp_path))
+    runner = StaticToolRunner(codebase_path=str(codebase))
     runner._has_grep = True
 
-    out = runner.grep("beta", "a.c")
+    out = runner.grep("beta", "src/metis/sarif/a.c")
 
     assert len(out.splitlines()) == 1
     assert (
@@ -102,6 +107,9 @@ def test_describe_tool_reports_grep_backend(tmp_path):
     runner = StaticToolRunner(codebase_path=str(tmp_path))
     runner._has_grep = True
     assert runner.describe_tool("grep") == {"backend": "shell_grep"}
+    assert runner.describe_call("grep", pattern=r"foo\b", path="a.c") == {
+        "backend": "python_regex"
+    }
 
     runner = StaticToolRunner(codebase_path=str(tmp_path))
     runner._has_grep = False

--- a/tests/test_static_tools.py
+++ b/tests/test_static_tools.py
@@ -27,6 +27,23 @@ def test_cat_fallback_reads_file(tmp_path):
     assert out == "line1\nline2\n"
 
 
+def test_cat_fallback_reads_repo_relative_path_from_nested_codebase(tmp_path):
+    codebase = tmp_path / "src" / "metis" / "sarif"
+    codebase.mkdir(parents=True)
+    source = tmp_path / "src" / "metis" / "cli" / "utils.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("print('ok')\n", encoding="utf-8")
+
+    runner = StaticToolRunner(
+        codebase_path=str(codebase),
+        workspace_root=str(tmp_path),
+    )
+    runner._has_cat = False
+
+    out = runner.cat("src/metis/cli/utils.py")
+    assert out == "print('ok')\n"
+
+
 def test_sed_fallback_slices_lines(tmp_path):
     source = tmp_path / "a.txt"
     source.write_text("1\n2\n3\n4\n5\n", encoding="utf-8")
@@ -46,6 +63,23 @@ def test_find_name_fallback_finds_matching_files(tmp_path):
     runner = _build_runner(tmp_path)
     out = runner.find_name("target.c")
     assert out == ["lib/target.c", "src/target.c"]
+
+
+def test_find_name_fallback_searches_workspace_root_when_codebase_is_nested(tmp_path):
+    codebase = tmp_path / "src" / "metis" / "sarif"
+    codebase.mkdir(parents=True)
+    target = tmp_path / "src" / "metis" / "cli" / "utils.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x", encoding="utf-8")
+
+    runner = StaticToolRunner(
+        codebase_path=str(codebase),
+        workspace_root=str(tmp_path),
+    )
+    runner._has_find = False
+
+    out = runner.find_name("utils.py")
+    assert out == ["src/metis/cli/utils.py"]
 
 
 def test_grep_fallback_searches_recursively(tmp_path):

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -11,25 +11,71 @@ def test_tool_definitions_expose_named_tools():
     defs = get_tool_definitions()
     names = {tool.name for tool in defs}
 
-    assert names == {"grep", "find_name", "cat", "sed"}
-    assert all(tool.domains == ("triage_evidence",) for tool in defs)
+    assert names == {"grep", "find_name", "cat", "sed", "rag_search"}
+    assert all(tool.domains == ("code_evidence", "triage_evidence") for tool in defs)
 
 
 def test_build_toolbox_for_policy_exposes_list_and_invocation(tmp_path):
-    (tmp_path / "src").mkdir()
-    (tmp_path / "src" / "a.c").write_text("alpha\nbeta\n", encoding="utf-8")
+    codebase = tmp_path / "src" / "metis" / "sarif"
+    codebase.mkdir(parents=True)
+    (codebase / "a.c").write_text("alpha\nbeta\n", encoding="utf-8")
 
     toolbox = build_toolbox(
-        policy="triage_evidence", codebase_path=str(tmp_path), max_chars=200
+        policy="code_evidence", codebase_path=str(codebase), max_chars=200
     )
 
-    assert toolbox.list_tools() == ("cat", "find_name", "grep", "sed")
+    assert toolbox.list_tools() == ("cat", "find_name", "grep", "rag_search", "sed")
     assert toolbox.has("grep") is True
     assert any(
-        line.endswith("src/a.c:2:beta")
-        for line in toolbox.grep("beta", "src").splitlines()
+        line.endswith("a.c:2:beta") for line in toolbox.grep("beta", "src").splitlines()
     )
     assert toolbox.describe("grep") == {"backend": "shell_grep"}
+    assert toolbox.describe_call("grep", pattern=r"beta\b", path="src") == {
+        "backend": "python_regex"
+    }
+
+
+def test_build_toolbox_rag_search_exposes_code_and_docs_sections(tmp_path):
+    toolbox = build_toolbox(policy="code_evidence", codebase_path=str(tmp_path))
+
+    class _Doc:
+        def __init__(self, text, source):
+            self.page_content = text
+            self.metadata = {"source": source}
+
+    class _Retriever:
+        def __init__(self, label):
+            self._label = label
+
+        def get_relevant_documents(self, query):
+            return [_Doc(f"{self._label} hit for {query}", f"{self._label}.txt")]
+
+    output = toolbox.rag_search(
+        "memory safety",
+        retriever_code=_Retriever("code"),
+        retriever_docs=_Retriever("docs"),
+    )
+
+    assert "[CODE_RAG]" in output
+    assert "[DOCS_RAG]" in output
+    assert "memory safety" in output
+
+
+def test_build_toolbox_rag_search_gracefully_handles_missing_retrievers(tmp_path):
+    toolbox = build_toolbox(policy="code_evidence", codebase_path=str(tmp_path))
+
+    output = toolbox.rag_search("bounds checks")
+
+    assert "retrieval unavailable" in output
+
+
+def test_toolbox_without_hides_named_tool(tmp_path):
+    toolbox = build_toolbox(policy="code_evidence", codebase_path=str(tmp_path))
+
+    hidden = toolbox.without("rag_search")
+
+    assert hidden.has("rag_search") is False
+    assert "rag_search" not in hidden.list_tools()
 
 
 def test_build_toolbox_rejects_unknown_policy(tmp_path):
@@ -68,10 +114,10 @@ def test_validate_registry_rejects_missing_operation(tmp_path):
 def test_validate_policy_map_rejects_unknown_tool_name():
     defs = get_tool_definitions()
     with pytest.raises(ValueError, match="references unknown tool"):
-        registry._validate_policy_map(defs, {"triage_evidence": ("missing_tool",)})
+        registry._validate_policy_map(defs, {"code_evidence": ("missing_tool",)})
 
 
 def test_validate_policy_map_rejects_duplicate_tool_name():
     defs = get_tool_definitions()
     with pytest.raises(ValueError, match="contains duplicate tool"):
-        registry._validate_policy_map(defs, {"triage_evidence": ("grep", "grep")})
+        registry._validate_policy_map(defs, {"code_evidence": ("grep", "grep")})

--- a/tests/test_triage_runtime.py
+++ b/tests/test_triage_runtime.py
@@ -18,7 +18,7 @@ def test_triage_runtime_builds_graph_with_domain_toolbox(engine, monkeypatch):
 
     assert graph.toolbox is sentinel
     assert captured == {
-        "policy": "triage_evidence",
+        "policy": "code_evidence",
         "codebase_path": engine.codebase_path,
         "timeout_seconds": engine.triage_tool_timeout_seconds,
     }


### PR DESCRIPTION
- add shared `rag_search` to the `code_evidence` toolbox with graceful degradation
- switch review from passive retrieval to on-demand tool-driven RAG
- hide `rag_search` when `--ignore-index` disables retrieval
- improve security-focused RAG guidance for review tool usage
- simplify review prompt/runtime plumbing by removing legacy RELEVANT_CONTEXT handling