### PR TITLE
fix(triage): Prevent triage grep drift across environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN uv sync --no-dev --no-editable
 
 FROM python:3.13-slim-trixie@sha256:47b6eb1efcabc908e264051140b99d08ebb37fd2b0bf62273e2c9388911490c1 AS runtime
 
-RUN groupadd -r metisuser && useradd -r -g metisuser metisuser
+RUN groupadd -r metisuser && useradd -r -m -d /home/metisuser -g metisuser metisuser
 
 WORKDIR /app
 

--- a/src/metis/cli/triage_cli.py
+++ b/src/metis/cli/triage_cli.py
@@ -115,8 +115,11 @@ def _make_triage_progress_callback(args, progress, task):
 
 def _make_triage_debug_callback(args):
     log_level = str(getattr(args, "log_level", "") or "").upper()
-    if log_level != "DEBUG" or not bool(getattr(args, "verbose", False)):
+    if log_level != "DEBUG":
         return None
+
+    def _debug_print(message, **kwargs):
+        print_console(message, quiet=False, **kwargs)
 
     def _clip(value, limit=900):
         text = str(value or "")
@@ -132,68 +135,56 @@ def _make_triage_debug_callback(args):
     def _callback(event):
         kind = event.get("event")
         if kind == "retrieval":
-            print_console(
-                "[bright_black]-- triage debug: retrieval query --[/bright_black]",
-                args.quiet,
+            _debug_print(
+                "[bright_black]-- triage debug: retrieval query --[/bright_black]"
             )
-            print_console(
-                f"[bright_black]query {_summarize_text(event.get('query'))} (omitted)[/bright_black]",
-                args.quiet,
+            _debug_print(
+                f"[bright_black]query {_summarize_text(event.get('query'))} (omitted)[/bright_black]"
             )
             context_text = str(event.get("context") or "")
-            print_console(
-                f"[bright_black]-- triage debug: rag context chars={len(context_text)} (omitted) --[/bright_black]",
-                args.quiet,
+            _debug_print(
+                f"[bright_black]-- triage debug: rag context chars={len(context_text)} (omitted) --[/bright_black]"
             )
             return
         if kind == "model_input":
             stage = event.get("stage", "unknown")
-            print_console(
-                f"[bright_black]-- triage debug: model input ({escape(str(stage))}) --[/bright_black]",
-                args.quiet,
+            _debug_print(
+                f"[bright_black]-- triage debug: model input ({escape(str(stage))}) --[/bright_black]"
             )
-            print_console("[bright_black]system:[/bright_black]", args.quiet)
-            print_console(escape(_clip(event.get("system_prompt"))), args.quiet)
             user_prompt = str(event.get("user_prompt") or "")
-            print_console(
-                f"[bright_black]user: chars={len(user_prompt)} (omitted)[/bright_black]",
-                args.quiet,
+            _debug_print(
+                f"[bright_black]user: chars={len(user_prompt)} (omitted)[/bright_black]"
             )
             return
         if kind == "tool_call":
             tool_name = str(event.get("tool_name", "unknown"))
-            print_console(
-                f"[bright_black]-- triage debug: tool {escape(tool_name)} --[/bright_black]",
-                args.quiet,
+            _debug_print(
+                f"[bright_black]-- triage debug: tool {escape(tool_name)} --[/bright_black]"
             )
-            print_console(escape(_clip(event.get("tool_args"))), args.quiet)
+            _debug_print(escape(_clip(event.get("tool_args"))))
             tool_output = event.get("tool_output")
             if isinstance(tool_output, str):
-                print_console(
-                    f"[bright_black]tool_output {_summarize_text(tool_output)} (omitted)[/bright_black]",
-                    args.quiet,
+                _debug_print(
+                    f"[bright_black]tool_output {_summarize_text(tool_output)} (omitted)[/bright_black]"
                 )
             else:
-                print_console(
-                    f"[bright_black]tool_output_type={escape(type(tool_output).__name__)}[/bright_black]",
-                    args.quiet,
+                _debug_print(
+                    f"[bright_black]tool_output_type={escape(type(tool_output).__name__)}[/bright_black]"
                 )
-                print_console(escape(_clip(tool_output)), args.quiet)
+                _debug_print(escape(_clip(tool_output)))
             return
         if kind == "model_output":
             status = event.get("decision_status", "")
             reason = event.get("decision_reason", "")
-            print_console(
-                f"[bright_black]-- triage debug: model output status={escape(str(status))} --[/bright_black]",
-                args.quiet,
+            _debug_print(
+                f"[bright_black]-- triage debug: model output status={escape(str(status))} --[/bright_black]"
             )
-            print_console(escape(_clip(reason)), args.quiet)
+            _debug_print(escape(_clip(reason)))
             return
         if kind == "status_adjudication":
-            print_console(
-                "[bright_black]-- triage debug: status adjudication --[/bright_black]",
-                args.quiet,
+            _debug_print(
+                "[bright_black]-- triage debug: status adjudication --[/bright_black]"
             )
-            print_console(escape(_clip(event)), args.quiet)
+            _debug_print(escape(_clip(event)))
 
     return _callback

--- a/src/metis/engine/analysis/c_family_helpers.py
+++ b/src/metis/engine/analysis/c_family_helpers.py
@@ -7,6 +7,16 @@ from pathlib import Path
 import re
 
 _IDENT_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
+_LOW_VALUE_C_FAMILY_PROBE_TERMS = {
+    "c",
+    "cc",
+    "cpp",
+    "cxx",
+    "h",
+    "hh",
+    "hpp",
+    "hxx",
+}
 
 
 def extract_code_like_symbols(*texts: str, limit: int = 12) -> list[str]:
@@ -30,10 +40,14 @@ def extract_c_family_seed_symbols(
     *,
     limit: int = 20,
 ) -> list[str]:
-    path_tokens = re.split(r"[^A-Za-z0-9_]+", file_path or "")
-    return extract_code_like_symbols(
-        snippet or "", rule_id or "", " ".join(path_tokens), limit=limit
-    )
+    return extract_code_like_symbols(snippet or "", limit=limit)
+
+
+def is_low_value_c_family_probe_term(term: str) -> bool:
+    text = str(term or "").strip().lower()
+    if not text:
+        return False
+    return text in _LOW_VALUE_C_FAMILY_PROBE_TERMS
 
 
 def parse_includes_from_text(text: str) -> list[str]:

--- a/src/metis/engine/analysis/c_family_macro.py
+++ b/src/metis/engine/analysis/c_family_macro.py
@@ -289,7 +289,10 @@ def collect_c_macro_definition_sections(
             unresolved.append(macro)
             continue
         resolved = False
-        define_pattern = rf"^\s*#\s*define\s+{re.escape(macro)}([^A-Za-z0-9_]|$)"
+        define_pattern = (
+            rf"^[[:space:]]*#[[:space:]]*define[[:space:]]+"
+            rf"{re.escape(macro)}([^A-Za-z0-9_]|$)"
+        )
         for path in candidate_paths:
             if len(sections) >= max_sections:
                 break
@@ -375,7 +378,7 @@ def _extract_include_candidates(
 ) -> list[str]:
     if not file_path or len(sections) >= max_sections:
         return []
-    include_pattern = r"^\s*#\s*include\s+[<\"][^>\"]+[>\"]"
+    include_pattern = r'^[[:space:]]*#[[:space:]]*include[[:space:]]+[<"][^>"]+[>"]'
     output = safe_tool_capture(
         tool_name="grep",
         tool_args={

--- a/src/metis/engine/graphs/triage/evidence.py
+++ b/src/metis/engine/graphs/triage/evidence.py
@@ -4,12 +4,16 @@
 from __future__ import annotations
 
 import os
+import re
 
 from metis.engine.analysis.c_family_macro import (
     is_c_family_file_path,
     is_c_macro_like_symbol,
 )
-from metis.engine.analysis.c_family_helpers import extract_c_family_seed_symbols
+from metis.engine.analysis.c_family_helpers import (
+    extract_c_family_seed_symbols,
+    is_low_value_c_family_probe_term,
+)
 
 from . import constants as C
 from ..types import TriageState
@@ -29,6 +33,7 @@ from .evidence_analyzer import (
     _collect_analyzer_sections,
     _finalize_evidence_pack_state,
 )
+from .debug import _emit_debug
 from .obligations import (
     compute_obligation_coverage,
     derive_obligations,
@@ -55,40 +60,52 @@ def _derive_line_symbols(
     is_metis_source: bool,
     max_symbol_terms: int,
 ) -> list[str]:
+    snippet_text = state.get("finding_snippet", "") or ""
     explanation_text = state.get("finding_explanation", "") if is_metis_source else ""
     term_source = " ".join(
         [
             state.get("finding_message", "") or "",
-            state.get("finding_snippet", "") or "",
+            snippet_text,
             explanation_text or "",
         ]
     )
     line_terms = _extract_call_like_identifiers(
-        "\n".join([exact_line_context, state.get("finding_snippet", "") or ""]),
+        "\n".join([exact_line_context, snippet_text]),
         limit=12,
     )
-    symbol_candidates = _extract_symbol_candidates(
-        exact_line_context,
-        " ".join(treesitter_scope_symbols),
-        state.get("finding_snippet", "") or "",
-        state.get("finding_rule_id", "") or "",
-        os.path.basename(file_path or ""),
-        limit=12,
-    )
+    snippet_candidates = _extract_symbol_candidates(snippet_text, limit=12)
+    exact_candidates = _extract_symbol_candidates(exact_line_context, limit=12)
     prose_terms = _extract_terms(term_source, limit=12)
 
     out: list[str] = []
     seen: set[str] = set()
-    for term in line_terms + treesitter_scope_symbols + symbol_candidates + prose_terms:
+    for term in (
+        line_terms
+        + treesitter_scope_symbols
+        + snippet_candidates
+        + prose_terms
+        + exact_candidates
+    ):
         if not term or term in seen:
             continue
         if len(term) > 64:
+            continue
+        if not _is_probe_term(term, file_path=file_path):
             continue
         seen.add(term)
         out.append(term)
         if len(out) >= max_symbol_terms:
             break
     return out
+
+
+def _is_probe_term(term: str, *, file_path: str) -> bool:
+    text = str(term or "").strip()
+    if not text:
+        return False
+    if is_c_family_file_path(file_path) and is_low_value_c_family_probe_term(text):
+        return False
+    return bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]{1,127}$", text))
 
 
 def _filter_resolved_macro_unresolved_hops(
@@ -117,6 +134,17 @@ def _filter_resolved_macro_unresolved_hops(
         if not drop:
             kept.append(text)
     return kept
+
+
+def _section_labels(sections: list[str]) -> list[str]:
+    labels: list[str] = []
+    for section in sections:
+        if not str(section).startswith("["):
+            continue
+        raw = str(section)[1:].split("]", 1)[0].strip()
+        if raw:
+            labels.append(raw)
+    return labels
 
 
 def triage_node_collect_evidence(state: TriageState, *, toolbox) -> TriageState:
@@ -275,5 +303,13 @@ def triage_node_collect_evidence(state: TriageState, *, toolbox) -> TriageState:
     state["evidence_obligations"] = obligations
     state["obligation_coverage"] = obligation_coverage
     state["evidence_gate_missing"] = evidence_gate_missing
+    _emit_debug(
+        state,
+        "evidence_gate",
+        obligations=obligations,
+        obligation_coverage=obligation_coverage,
+        missing=evidence_gate_missing,
+        section_labels=_section_labels(sections),
+    )
 
     return _finalize_evidence_pack_state(state, sections)

--- a/src/metis/engine/graphs/triage/evidence_text.py
+++ b/src/metis/engine/graphs/triage/evidence_text.py
@@ -66,6 +66,16 @@ def _token_pattern(term: str) -> str:
     return rf"(^|[^A-Za-z0-9_]){escaped}([^A-Za-z0-9_]|$)"
 
 
+def _call_pattern(term: str) -> str:
+    escaped = re.escape(term)
+    return rf"(^|[^A-Za-z0-9_]){escaped}[[:space:]]*\("
+
+
+def _assignment_pattern(term: str) -> str:
+    escaped = re.escape(term)
+    return rf"(^|[^A-Za-z0-9_]){escaped}[[:space:]]*="
+
+
 def _limit_output(text: str, *, max_lines: int = 120, max_chars: int = 5000) -> str:
     lines = (text or "").splitlines()
     if len(lines) > max_lines:

--- a/src/metis/engine/graphs/triage/evidence_tools.py
+++ b/src/metis/engine/graphs/triage/evidence_tools.py
@@ -17,7 +17,9 @@ from . import constants as C
 from .debug import _emit_debug
 from ..types import TriageState
 from .evidence_text import (
+    _assignment_pattern,
     _extend_hits,
+    _call_pattern,
     _limit_output,
     _parse_grep_hits,
     _token_pattern,
@@ -67,6 +69,22 @@ def _safe_tool_capture(
     return output
 
 
+def _tool_debug_args(toolbox, tool_name: str, **tool_args) -> dict:
+    out = dict(tool_args)
+    describe = getattr(toolbox, "describe", None)
+    if not callable(describe):
+        return out
+    try:
+        details = describe(tool_name)
+    except Exception:
+        return out
+    if not isinstance(details, dict):
+        return out
+    for key, value in details.items():
+        out.setdefault(key, value)
+    return out
+
+
 def _collect_file_context(
     state: TriageState,
     sections: list[str],
@@ -88,7 +106,13 @@ def _collect_file_context(
         state,
         sections,
         tool_name="sed",
-        tool_args={"path": file_path, "start_line": start, "end_line": end},
+        tool_args=_tool_debug_args(
+            toolbox,
+            "sed",
+            path=file_path,
+            start_line=start,
+            end_line=end,
+        ),
         section_label=f"FILE_WINDOW {file_path}:{start}-{end}",
         error_label="FILE_WINDOW_ERROR",
         max_lines=C.DEFAULT_CAPTURE_MAX_LINES,
@@ -100,7 +124,13 @@ def _collect_file_context(
         state,
         sections,
         tool_name="sed",
-        tool_args={"path": file_path, "start_line": line, "end_line": line},
+        tool_args=_tool_debug_args(
+            toolbox,
+            "sed",
+            path=file_path,
+            start_line=line,
+            end_line=line,
+        ),
         section_label=f"REPORTED_LINE {file_path}:{line}",
         error_label="REPORTED_LINE_ERROR",
         max_lines=C.REPORTED_LINE_MAX_LINES,
@@ -356,7 +386,7 @@ def _collect_macro_definition_sections(
             state,
             sections,
             tool_name=tool_name,
-            tool_args=tool_args,
+            tool_args=_tool_debug_args(toolbox, tool_name, **tool_args),
             section_label=section_label,
             max_lines=max_lines,
             max_chars=max_chars,
@@ -426,6 +456,7 @@ def _gather_symbol_definition_hits(
     local_path = (
         file_path if file_path else (fallback_paths[0] if fallback_paths else ".")
     )
+    fallback_paths = [path for path in fallback_paths if path != local_path]
 
     def _probe_symbol(symbol: str, path: str, mode: str) -> bool:
         if len(sections) >= max_sections or len(followup_hits) >= max_followup_hits:
@@ -433,8 +464,8 @@ def _gather_symbol_definition_hits(
         hit_found = False
         probes = (
             _token_pattern(symbol),
-            rf"(^|[^A-Za-z0-9_]){re.escape(symbol)}\\s*\\(",
-            rf"(^|[^A-Za-z0-9_]){re.escape(symbol)}\\s*=",
+            _call_pattern(symbol),
+            _assignment_pattern(symbol),
         )
         for probe in probes:
             if len(sections) >= max_sections or len(followup_hits) >= max_followup_hits:
@@ -443,7 +474,13 @@ def _gather_symbol_definition_hits(
                 state,
                 sections,
                 tool_name="grep",
-                tool_args={"pattern": probe, "path": path, "mode": mode},
+                tool_args=_tool_debug_args(
+                    toolbox,
+                    "grep",
+                    pattern=probe,
+                    path=path,
+                    mode=mode,
+                ),
                 section_label=f"SYMBOL_GREP {symbol} IN {path} ({mode})",
                 max_lines=C.RELATED_GREP_MAX_LINES,
                 max_chars=C.RELATED_GREP_MAX_CHARS,
@@ -512,7 +549,13 @@ def _collect_hit_context_sections(
             state,
             sections,
             tool_name="sed",
-            tool_args={"path": path, "start_line": start, "end_line": end},
+            tool_args=_tool_debug_args(
+                toolbox,
+                "sed",
+                path=path,
+                start_line=start,
+                end_line=end,
+            ),
             section_label=f"HIT_CONTEXT {path}:{start}-{end}",
             error_label=f"HIT_CONTEXT_ERROR {path}:{hit_line}",
             max_lines=C.HIT_CONTEXT_MAX_LINES,

--- a/src/metis/engine/tools/base.py
+++ b/src/metis/engine/tools/base.py
@@ -46,6 +46,22 @@ class ToolBox:
             raise ValueError(f"Unknown tool: {name}") from exc
         return tool(*args, **kwargs)
 
+    def describe(self, name: str) -> dict[str, Any]:
+        try:
+            tool = self._tools[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown tool: {name}") from exc
+        provider = getattr(tool, "__self__", None)
+        if provider is None:
+            return {}
+        describe_tool = getattr(provider, "describe_tool", None)
+        if not callable(describe_tool):
+            return {}
+        details = describe_tool(name)
+        if not isinstance(details, dict):
+            return {}
+        return dict(details)
+
     def grep(self, pattern: str, path: str) -> str:
         return self.run("grep", pattern, path)
 

--- a/src/metis/engine/tools/static_tools.py
+++ b/src/metis/engine/tools/static_tools.py
@@ -11,9 +11,19 @@ import subprocess
 from typing import Sequence
 
 
+_PYTHON_REGEX_REWRITES = (
+    ("[[:space:]]", r"\s"),
+    ("[[:blank:]]", r"[ \t]"),
+)
+
+
 class StaticToolRunner:
     def __init__(
-        self, *, codebase_path: str, timeout_seconds: int = 8, max_chars: int = 16000
+        self,
+        *,
+        codebase_path: str,
+        timeout_seconds: int = 8,
+        max_chars: int = 16000,
     ):
         self.codebase_path = Path(codebase_path).resolve()
         self.timeout_seconds = timeout_seconds
@@ -22,6 +32,21 @@ class StaticToolRunner:
         self._has_find = shutil.which("find") is not None
         self._has_cat = shutil.which("cat") is not None
         self._has_sed = shutil.which("sed") is not None
+
+    def describe_tool(self, name: str) -> dict[str, str]:
+        if name == "grep":
+            backend = "shell_grep" if self._has_grep else "python_regex"
+            return {"backend": backend}
+        if name == "find_name":
+            backend = "shell_find" if self._has_find else "python_walk"
+            return {"backend": backend}
+        if name == "cat":
+            backend = "shell_cat" if self._has_cat else "python_read"
+            return {"backend": backend}
+        if name == "sed":
+            backend = "shell_sed" if self._has_sed else "python_slice"
+            return {"backend": backend}
+        return {}
 
     def _resolve_path(self, raw_path: str) -> Path:
         candidate = (self.codebase_path / raw_path).resolve()
@@ -72,12 +97,15 @@ class StaticToolRunner:
         target = self._resolve_path(path)
         if self._has_grep:
             return self._run(
-                ["grep", "-REn", "--", pattern, str(target)],
+                ["grep", "-HREn", "--", pattern, str(target)],
                 ok_returncodes=(0, 1),
             )
 
         try:
-            regex = re.compile(pattern)
+            translated = pattern
+            for source, replacement in _PYTHON_REGEX_REWRITES:
+                translated = translated.replace(source, replacement)
+            regex = re.compile(translated)
         except re.error as exc:
             raise ValueError(f"Invalid grep pattern: {exc}") from exc
 

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -211,3 +211,18 @@ def test_execute_command_rejects_inline_ignore_index_flag_before_index_gating(
     assert result is None
     assert any("--ignore-index can only be used" in message for message in captured)
     assert not any("Index missing" in message for message in captured)
+
+
+def test_run_non_interactive_keeps_quiet_without_verbose():
+    args = SimpleNamespace(
+        command="triage data.sarif",
+        verbose=False,
+        quiet=True,
+        log_level="DEBUG",
+    )
+
+    exit_code, farewell = entry.run_non_interactive(SimpleNamespace(), args)
+
+    assert exit_code == 1
+    assert farewell is None
+    assert args.quiet is True

--- a/tests/test_cli_triage.py
+++ b/tests/test_cli_triage.py
@@ -4,7 +4,7 @@
 from types import SimpleNamespace
 
 import json
-
+from metis.cli import triage_cli
 from metis.cli.command_runtime import CommandRuntime
 from metis.cli.commands import _build_triaged_sarif_payload, run_triage
 from metis.cli.utils import save_output
@@ -269,3 +269,30 @@ def test_save_output_json_matches_triage_annotations_by_identity(tmp_path):
     assert issues[0]["metisTriageStatus"] == "valid"
     assert issues[1]["issue"] == "Issue B"
     assert issues[1]["metisTriageStatus"] == "invalid"
+
+
+def test_triage_debug_callback_enabled_without_verbose():
+    args = SimpleNamespace(log_level="DEBUG", verbose=False, quiet=True)
+
+    callback = triage_cli._make_triage_debug_callback(args)
+
+    assert callable(callback)
+
+
+def test_triage_debug_callback_ignores_quiet(monkeypatch):
+    args = SimpleNamespace(log_level="DEBUG", verbose=False, quiet=True)
+    calls = []
+
+    monkeypatch.setattr(
+        triage_cli,
+        "print_console",
+        lambda message, quiet=False, **kwargs: calls.append((str(message), quiet)),
+    )
+
+    callback = triage_cli._make_triage_debug_callback(args)
+    callback(
+        {"event": "model_output", "decision_status": "valid", "decision_reason": "ok"}
+    )
+
+    assert calls
+    assert all(quiet is False for _message, quiet in calls)

--- a/tests/test_static_tools.py
+++ b/tests/test_static_tools.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import subprocess
 
 from metis.engine.tools.static_tools import StaticToolRunner
 
@@ -62,3 +63,46 @@ def test_grep_fallback_invalid_pattern_raises(tmp_path):
     runner = _build_runner(tmp_path)
     with pytest.raises(ValueError, match="Invalid grep pattern"):
         runner.grep("(", ".")
+
+
+def test_grep_can_force_python_regex_even_when_shell_grep_exists(tmp_path, monkeypatch):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "a.c").write_text("foo\t(\n", encoding="utf-8")
+
+    runner = StaticToolRunner(codebase_path=str(tmp_path))
+    runner._has_grep = False
+
+    def _unexpected_run(*args, **kwargs):
+        raise AssertionError("shell grep should not run when _has_grep=False")
+
+    monkeypatch.setattr(subprocess, "run", _unexpected_run)
+
+    out = runner.grep(r"foo[[:space:]]*\(", "src")
+
+    assert out.splitlines() == ["src/a.c:1:foo\t("]
+
+
+def test_shell_grep_forces_filename_prefix_for_single_file(tmp_path):
+    source = tmp_path / "a.c"
+    source.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    runner = StaticToolRunner(codebase_path=str(tmp_path))
+    runner._has_grep = True
+
+    out = runner.grep("beta", "a.c")
+
+    assert len(out.splitlines()) == 1
+    assert (
+        out.splitlines()[0].endswith("/a.c:2:beta")
+        or out.splitlines()[0] == "a.c:2:beta"
+    )
+
+
+def test_describe_tool_reports_grep_backend(tmp_path):
+    runner = StaticToolRunner(codebase_path=str(tmp_path))
+    runner._has_grep = True
+    assert runner.describe_tool("grep") == {"backend": "shell_grep"}
+
+    runner = StaticToolRunner(codebase_path=str(tmp_path))
+    runner._has_grep = False
+    assert runner.describe_tool("grep") == {"backend": "python_regex"}

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -29,6 +29,7 @@ def test_build_toolbox_for_policy_exposes_list_and_invocation(tmp_path):
         line.endswith("src/a.c:2:beta")
         for line in toolbox.grep("beta", "src").splitlines()
     )
+    assert toolbox.describe("grep") == {"backend": "shell_grep"}
 
 
 def test_build_toolbox_rejects_unknown_policy(tmp_path):

--- a/tests/test_triage_graph.py
+++ b/tests/test_triage_graph.py
@@ -5,6 +5,7 @@ import pytest
 
 from metis.engine.graphs.triage import TriageGraph
 from metis.engine.graphs.schemas import TriageDecisionModel
+from metis.engine.analysis.c_family_helpers import extract_c_family_seed_symbols
 
 
 class _App:
@@ -24,6 +25,17 @@ def _build_graph():
         toolbox=object(),
         plugin_config={},
     )
+
+
+def test_extract_c_family_seed_symbols_ignores_file_path_tokens():
+    out = extract_c_family_seed_symbols(
+        "foo(x);",
+        "missingIncludeSystem",
+        "src/main.c",
+    )
+    assert "foo" in out
+    assert "main" not in out
+    assert "c" not in out
 
 
 def test_triage_schema_allows_inconclusive_with_unresolved_hops():

--- a/tests/test_triage_treesitter.py
+++ b/tests/test_triage_treesitter.py
@@ -56,15 +56,20 @@ class _ToolRunner:
     def find_name(self, _name, max_results=20):
         return []
 
+    def describe(self, name):
+        return {"backend": f"test_{name}"}
+
 
 class _CaptureToolRunner(_ToolRunner):
     def __init__(self):
         super().__init__()
         self.grep_paths = []
+        self.grep_patterns = []
 
     def grep(self, pattern, path):
         self.grep_calls += 1
         self.grep_paths.append(path)
+        self.grep_patterns.append(pattern)
         return ""
 
 
@@ -225,6 +230,25 @@ def test_triage_collect_evidence_metis_appends_explanation_section():
     assert "reasoning: foo reaches sink" in evidence_pack
 
 
+def test_triage_collect_evidence_uses_portable_grep_patterns():
+    runner = _CaptureToolRunner()
+    state = {
+        "finding_message": "Possible issue around foo",
+        "finding_file_path": "src/main.c",
+        "finding_line": 20,
+        "finding_rule_id": "R1",
+        "finding_snippet": "foo(x);",
+        "triage_analyzer": _WeakAnalyzer(),
+        "triage_codebase_path": ".",
+    }
+
+    triage_node_collect_evidence(state, toolbox=runner)
+
+    assert any("[[:space:]]*\\(" in pattern for pattern in runner.grep_patterns)
+    assert any("[[:space:]]*=" in pattern for pattern in runner.grep_patterns)
+    assert all("\\s*" not in pattern for pattern in runner.grep_patterns)
+
+
 def test_triage_collect_evidence_resolves_macro_definition_with_tools():
     runner = _MacroExpandRunner()
     state = {
@@ -263,3 +287,81 @@ def test_triage_collect_evidence_resolves_macro_definition_via_find_name():
         in evidence_pack
     )
     assert "[MACRO_RESOLUTION]\nPROJECT_STACK_ALLOC -> alloca" in evidence_pack
+
+
+def test_triage_collect_evidence_emits_evidence_gate_debug_event():
+    runner = _ToolRunner()
+    events = []
+    state = {
+        "finding_message": "Possible issue around foo and bar",
+        "finding_file_path": "src/main.c",
+        "finding_line": 20,
+        "finding_rule_id": "R1",
+        "finding_snippet": "foo(x); bar(y);",
+        "triage_analyzer": _WeakAnalyzer(),
+        "triage_codebase_path": ".",
+        "debug_callback": events.append,
+    }
+
+    out = triage_node_collect_evidence(state, toolbox=runner)
+
+    assert out["evidence_gate_missing"] == ["OBLIGATION_MISSING:use_site"]
+    gate_events = [event for event in events if event.get("event") == "evidence_gate"]
+    assert len(gate_events) == 1
+    assert gate_events[0]["missing"] == ["OBLIGATION_MISSING:use_site"]
+    assert "FILE_WINDOW src/main.c:14-26" in gate_events[0]["section_labels"]
+    assert "SYMBOL_GREP foo IN src/main.c (local)" in gate_events[0]["section_labels"]
+
+
+def test_triage_debug_tool_calls_include_backend():
+    runner = _ToolRunner()
+    events = []
+    state = {
+        "finding_message": "Possible issue around foo and bar",
+        "finding_file_path": "src/main.c",
+        "finding_line": 20,
+        "finding_rule_id": "R1",
+        "finding_snippet": "foo(x); bar(y);",
+        "triage_analyzer": _WeakAnalyzer(),
+        "triage_codebase_path": ".",
+        "debug_callback": events.append,
+    }
+
+    triage_node_collect_evidence(state, toolbox=runner)
+
+    grep_event = next(
+        event
+        for event in events
+        if event.get("event") == "tool_call" and event.get("tool_name") == "grep"
+    )
+    assert grep_event["tool_args"]["backend"] == "test_grep"
+
+
+def test_triage_collect_evidence_skips_duplicate_fallback_probe_for_local_file():
+    runner = _ToolRunner()
+    events = []
+    state = {
+        "finding_message": "Possible issue around foo",
+        "finding_file_path": "src/main.c",
+        "finding_line": 20,
+        "finding_rule_id": "R1",
+        "finding_snippet": "foo(x);",
+        "triage_analyzer": _WeakAnalyzer(),
+        "triage_codebase_path": ".",
+        "debug_callback": events.append,
+    }
+
+    triage_node_collect_evidence(state, toolbox=runner)
+
+    symbol_grep_events = [
+        event
+        for event in events
+        if event.get("event") == "tool_call"
+        and event.get("tool_name") == "grep"
+        and event.get("tool_args", {}).get("path") == "src/main.c"
+    ]
+    assert symbol_grep_events
+    assert all(
+        event.get("tool_args", {}).get("mode") != "fallback"
+        for event in symbol_grep_events
+    )


### PR DESCRIPTION
- Made triage grep probes portable by replacing \s-style regexes with POSIX-compatible [[:space:]] patterns.
- Removed file-path and rule-id noise from C/C++ seed-symbol extraction to avoid probes like c, main, and R1.
- Added evidence-gate debug output with obligation coverage, missing obligations, and collected section labels.
- Stopped printing the triage system prompt in CLI debug output.