### PR TITLE
add reasoning effort config support

### DIFF
--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -8,7 +8,6 @@ import yaml
 from importlib.resources import files, as_file
 from pathlib import Path
 
-
 logger = logging.getLogger("metis")
 
 
@@ -143,6 +142,12 @@ def load_runtime_config(config_path=None, enable_psql=False):
     runtime["llama_query_model"] = query_cfg.get("model") or runtime.get("model", "")
     runtime["llama_query_temperature"] = query_cfg.get("temperature", 0.0)
     runtime["llama_query_max_tokens"] = query_cfg.get("max_tokens", 500)
+    runtime["llama_query_reasoning_effort"] = (
+        query_cfg.get("reasoning_effort")
+        or query_cfg.get("reasoning_level")
+        or llm_cfg.get("reasoning_effort")
+        or llm_cfg.get("reasoning_level")
+    )
     runtime["similarity_top_k"] = query_cfg.get("similarity_top_k", 5)
     runtime["triage_similarity_top_k"] = query_cfg.get("triage_similarity_top_k", 3)
     runtime["response_mode"] = query_cfg.get("response_mode", "compact")

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -22,6 +22,9 @@ metis_engine:
 llm_provider:
   name: "openai"
   model: "gpt-5.4"
+  # Optional for reasoning-capable OpenAI models: none, minimal, low, medium,
+  # high, or xhigh depending on model support. Can be overridden under query.
+  # reasoning_effort: "medium"
   code_embedding_model: "text-embedding-3-large"
   docs_embedding_model: "text-embedding-3-large"
 

--- a/src/metis/providers/azure_openai.py
+++ b/src/metis/providers/azure_openai.py
@@ -70,6 +70,7 @@ class AzureOpenAIProvider(LLMProvider):
 
         self.temperature = float(config.get("llama_query_temperature", 0.0))
         self.max_tokens = int(config.get("llama_query_max_tokens", 512))
+        self.reasoning_effort = config.get("llama_query_reasoning_effort")
 
         self.model_token_param = config.get(
             "model_token_param", "max_completion_tokens"
@@ -120,6 +121,8 @@ class AzureOpenAIProvider(LLMProvider):
         }
         if callbacks is not None:
             params["callbacks"] = callbacks
+        if self.reasoning_effort:
+            params["reasoning_effort"] = self.reasoning_effort
         if "response_format" in kwargs:
             if kwargs["response_format"] is not None:
                 params["response_format"] = kwargs["response_format"]

--- a/src/metis/providers/openai_compatible.py
+++ b/src/metis/providers/openai_compatible.py
@@ -33,6 +33,7 @@ class OpenAICompatibleProvider(LLMProvider):
         self.query_model = config.get("llama_query_model") or config.get("model")
         self.temperature = config.get("llama_query_temperature", 0.0)
         self.max_tokens = config.get("llama_query_max_tokens", 512)
+        self.reasoning_effort = config.get("llama_query_reasoning_effort")
         self.context_window = config.get("llama_query_context_window") or config.get(
             "max_token_length"
         )
@@ -117,6 +118,8 @@ class OpenAICompatibleProvider(LLMProvider):
             params["default_headers"] = self.default_headers
         if callbacks is not None:
             params["callbacks"] = callbacks
+        if self.reasoning_effort:
+            params["reasoning_effort"] = self.reasoning_effort
 
         for optional_key in (
             "timeout",
@@ -161,6 +164,8 @@ class OpenAICompatibleProvider(LLMProvider):
             params["default_headers"] = self.default_headers
         if callback_manager is not None:
             params["callback_manager"] = callback_manager
+        if self.reasoning_effort:
+            params["reasoning_effort"] = self.reasoning_effort
         if self._should_use_openai_like():
             params["context_window"] = self._resolve_context_window()
             params.setdefault("is_chat_model", True)

--- a/tests/test_azure_provider.py
+++ b/tests/test_azure_provider.py
@@ -75,3 +75,13 @@ def test_provider_uses_explicit_callbacks_without_mutation():
     assert query_kwargs["llm"].callbacks == [callback]
     assert query_kwargs["callback_manager"] is callback_manager
     assert code_embeddings.callback_manager is not callback_manager
+
+
+def test_provider_passes_reasoning_effort_to_chat_model():
+    config = _config()
+    config["llama_query_reasoning_effort"] = "medium"
+    provider = AzureOpenAIProvider(config)
+
+    llm = provider.get_chat_model()
+
+    assert llm.reasoning_effort == "medium"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from metis.configuration import load_metis_config
+from metis.configuration import load_runtime_config
 
 
 def test_load_metis_config_uses_yml_when_yaml_missing(tmp_path, monkeypatch):
@@ -21,3 +22,91 @@ def test_load_metis_config_prefers_yaml_over_yml(tmp_path, monkeypatch):
     config = load_metis_config()
 
     assert config == {"selected": "yaml"}
+
+
+def test_load_runtime_config_reads_query_reasoning_effort(tmp_path, monkeypatch):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: openai
+  model: gpt-test
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+metis_engine:
+  max_workers: 2
+query:
+  reasoning_effort: high
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["llama_query_reasoning_effort"] == "high"
+
+
+def test_load_runtime_config_accepts_query_reasoning_level_alias(tmp_path, monkeypatch):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: openai
+  model: gpt-test
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+query:
+  reasoning_level: low
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["llama_query_reasoning_effort"] == "low"
+
+
+def test_load_runtime_config_reads_provider_reasoning_effort(tmp_path, monkeypatch):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: openai
+  model: gpt-test
+  reasoning_effort: xhigh
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+query:
+  max_tokens: 1000
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["llama_query_reasoning_effort"] == "xhigh"
+
+
+def test_load_runtime_config_query_reasoning_overrides_provider(tmp_path, monkeypatch):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: openai
+  model: gpt-test
+  reasoning_effort: low
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+query:
+  reasoning_effort: high
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["llama_query_reasoning_effort"] == "high"

--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from langchain_openai import ChatOpenAI
+
+from metis.providers.openai_compatible import OpenAICompatibleProvider
+
+
+def _config(**overrides):
+    config = {
+        "llm_api_key": "test-key",
+        "model": "gpt-test",
+        "llama_query_model": "gpt-test",
+        "llama_query_temperature": 0.0,
+        "llama_query_max_tokens": 256,
+        "code_embedding_model": "text-embedding-3-large",
+        "docs_embedding_model": "text-embedding-3-large",
+    }
+    config.update(overrides)
+    return config
+
+
+def test_chat_model_uses_configured_reasoning_effort():
+    provider = OpenAICompatibleProvider(_config(llama_query_reasoning_effort="high"))
+
+    llm = provider.get_chat_model()
+
+    assert isinstance(llm, ChatOpenAI)
+    assert llm.reasoning_effort == "high"
+
+
+def test_query_model_kwargs_include_configured_reasoning_effort():
+    provider = OpenAICompatibleProvider(_config(llama_query_reasoning_effort="low"))
+
+    params = provider.get_query_model_kwargs()
+
+    assert params["reasoning_effort"] == "low"
+
+
+def test_reasoning_effort_is_omitted_when_unconfigured():
+    provider = OpenAICompatibleProvider(_config())
+
+    params = provider.get_query_model_kwargs()
+
+    assert "reasoning_effort" not in params


### PR DESCRIPTION
## Summary
- add `llm_provider.reasoning_effort` parsing from `metis.yaml`, with `query.reasoning_effort` as an override and `reasoning_level` as an alias in either section
- forward the resolved reasoning effort into OpenAI-compatible ChatOpenAI, LlamaIndex OpenAI/OpenAILike query kwargs, and AzureChatOpenAI
- document the optional provider-level setting in the packaged default `metis.yaml` and add provider/config regression tests

## Validation
- `uv run pytest`
- `uv run --extra lint ruff check src/metis/configuration.py src/metis/providers/openai_compatible.py src/metis/providers/azure_openai.py tests/test_configuration.py tests/test_openai_compatible_provider.py tests/test_azure_provider.py`
- `uv run --extra lint black --target-version py313 --check src/metis/configuration.py src/metis/providers/openai_compatible.py src/metis/providers/azure_openai.py tests/test_configuration.py tests/test_openai_compatible_provider.py tests/test_azure_provider.py`