### PR TITLE
DO NOT MERGE: gpt 5.5 auto migration test

### DIFF
--- a/src/metis/engine/graphs/review.py
+++ b/src/metis/engine/graphs/review.py
@@ -203,6 +203,9 @@ class ReviewGraph:
         self.report_prompt = self.plugin_config.get("general_prompts", {}).get(
             "security_review_report", ""
         )
+        self.prompt_contract = self.plugin_config.get("general_prompts", {}).get(
+            "gpt55_prompt_contract", ""
+        )
         self.hardware_cwe_guidance = self.plugin_config.get("general_prompts", {}).get(
             "hardware_cwe_guidance", ""
         )
@@ -261,6 +264,7 @@ class ReviewGraph:
             custom_guidance_precedence=self.custom_guidance_precedence,
             schema_prompt_section=self._schema_prompt_section,
             hardware_cwe_guidance=self.hardware_cwe_guidance,
+            prompt_contract=self.prompt_contract,
         )
         review = partial(
             review_node_llm,

--- a/src/metis/engine/graphs/review.py
+++ b/src/metis/engine/graphs/review.py
@@ -121,6 +121,7 @@ def review_node_build_prompt(
     custom_guidance_precedence: str,
     schema_prompt_section: str,
     hardware_cwe_guidance: str = "",
+    prompt_contract: str = "",
 ) -> ReviewState:
     include_relevant_context = bool(state.get("use_retrieval_context", True))
     system = build_review_system_prompt(
@@ -131,6 +132,7 @@ def review_node_build_prompt(
         custom_guidance_precedence,
         schema_prompt_section,
         hardware_cwe_guidance,
+        prompt_contract=prompt_contract,
         include_relevant_context=include_relevant_context,
     )
     new_state: ReviewState = dict(state)

--- a/src/metis/engine/graphs/triage/graph.py
+++ b/src/metis/engine/graphs/triage/graph.py
@@ -7,6 +7,7 @@ from langgraph.cache.memory import InMemoryCache
 from langgraph.graph import END, StateGraph
 
 from ..schemas import TriageDecisionModel
+from ...helpers import prepend_prompt_contract
 from .adjudication import (
     adjudicate_status_deterministic,
     compose_final_reason,
@@ -32,12 +33,16 @@ class TriageGraph:
         self.llama_query_model = llama_query_model
         self.toolbox = toolbox
         general_prompts = (plugin_config or {}).get("general_prompts", {})
+        prompt_contract = general_prompts.get("gpt55_prompt_contract", "")
         self.triage_system_prompt = (
             general_prompts.get("triage_system_prompt")
             or "You triage static analysis findings. "
             "Only decide whether the finding is valid or invalid based on static code evidence. "
             "Treat the reported line as potentially inaccurate. "
             "Prefer inspecting nearby code first with sed/cat in the reported file."
+        )
+        self.triage_system_prompt = prepend_prompt_contract(
+            self.triage_system_prompt, prompt_contract
         )
         self.triage_decision_prompt = (
             general_prompts.get("triage_decision_prompt")

--- a/src/metis/engine/graphs/utils.py
+++ b/src/metis/engine/graphs/utils.py
@@ -5,7 +5,7 @@ import logging
 import re
 from typing import Annotated, Literal, get_args, get_origin
 
-from metis.engine.helpers import apply_custom_guidance
+from metis.engine.helpers import apply_custom_guidance, prepend_prompt_contract
 from .schemas import ReviewIssueModel
 
 logger = logging.getLogger("metis")
@@ -260,6 +260,7 @@ def build_review_system_prompt(
     custom_guidance_precedence,
     schema_prompt_section,
     hardware_cwe_guidance="",
+    prompt_contract="",
     include_relevant_context=True,
 ):
     """Compose the system prompt for a review in a single place."""
@@ -288,6 +289,7 @@ def build_review_system_prompt(
         base,
         include_relevant_context=include_relevant_context,
     )
+    base = prepend_prompt_contract(base, prompt_contract)
     base = apply_custom_guidance(
         base, custom_prompt_text, custom_guidance_precedence or ""
     )

--- a/src/metis/engine/helpers.py
+++ b/src/metis/engine/helpers.py
@@ -28,6 +28,13 @@ def summarize_changes(llm_provider, file_path, issues, summary_prompt, callbacks
         return ""
 
 
+def prepend_prompt_contract(base_prompt, prompt_contract):
+    """Prepend shared model-specific prompt instructions when configured."""
+    if not prompt_contract:
+        return base_prompt
+    return f"{prompt_contract.strip()}\n\n{base_prompt}"
+
+
 def prepare_nodes_iter(
     code_docs,
     doc_docs,

--- a/src/metis/engine/review_service.py
+++ b/src/metis/engine/review_service.py
@@ -17,7 +17,7 @@ from metis.utils import read_file_content
 
 from .diff_utils import process_diff_file
 from .graphs.types import ReviewRequest
-from .helpers import apply_custom_guidance, summarize_changes
+from .helpers import apply_custom_guidance, prepend_prompt_contract, summarize_changes
 from .options import ReviewOptions, coerce_review_options
 from .repository import EngineRepository
 from .runtime import EngineConfig
@@ -245,6 +245,12 @@ class ReviewService:
                 if not issues.strip():
                     continue
                 summary_prompt = language_prompts["snippet_security_summary"]
+                summary_prompt = prepend_prompt_contract(
+                    summary_prompt,
+                    self._config.plugin_config.get("general_prompts", {}).get(
+                        "gpt55_prompt_contract", ""
+                    ),
+                )
                 summary_prompt = apply_custom_guidance(
                     summary_prompt,
                     self._config.custom_prompt_text,

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -21,7 +21,7 @@ metis_engine:
 
 llm_provider:
   name: "openai"
-  model: "gpt-5.4"
+  model: "gpt-5.5"
   # Optional for reasoning-capable OpenAI models: none, minimal, low, medium,
   # high, or xhigh depending on model support. Can be overridden under query.
   # reasoning_effort: "medium"

--- a/src/metis/plugins/plugins.yaml
+++ b/src/metis/plugins/plugins.yaml
@@ -2,6 +2,12 @@ docs:
   supported_extensions:  [".md", ".html", ".txt", ".pdf", ".rst"]
 
 general_prompts:
+  gpt55_prompt_contract: |-
+    GPT-5.5 operating instructions:
+    - Follow the configured task exactly. Treat schema, JSON-only, and status-output requirements as mandatory.
+    - Ground every security conclusion in provided file, change, context, or tool evidence. If required evidence is missing, return no finding or inconclusive as the task specifies.
+    - Use internal reasoning to resolve ambiguity, but do not reveal hidden chain-of-thought. Put only concise, evidence-backed rationale in the requested fields.
+    - Prefer deterministic, compact outputs. Stop when the requested output is complete and do not add extra prose, issue classes, or recommendations outside the configured scope.
   custom_guidance_precedence: |-
     Instruction precedence: When 'Custom Guidance' conflicts with any default
     instructions or checks below, follow 'Custom Guidance'. If guidance excludes

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -24,6 +24,14 @@ def test_load_metis_config_prefers_yaml_over_yml(tmp_path, monkeypatch):
     assert config == {"selected": "yaml"}
 
 
+def test_packaged_config_defaults_to_gpt_5_5_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    runtime = load_runtime_config()
+
+    assert runtime["llama_query_model"] == "gpt-5.5"
+
+
 def test_load_runtime_config_reads_query_reasoning_effort(tmp_path, monkeypatch):
     config_path = tmp_path / "metis.yaml"
     config_path.write_text(

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -44,6 +44,25 @@ def test_build_review_system_prompt_replaces_placeholder():
     assert schema_section in prompt
 
 
+def test_build_review_system_prompt_prepends_prompt_contract():
+    language_prompts = {
+        "security_review_file": "Intro [[REVIEW_SCHEMA_FIELDS]]",
+        "security_review_checks": "Checklist items.",
+    }
+    schema_section = '- "issue": description'
+    prompt = build_review_system_prompt(
+        language_prompts,
+        "security_review_file",
+        report_prompt="Reporting instructions.",
+        custom_prompt_text=None,
+        custom_guidance_precedence="",
+        schema_prompt_section=schema_section,
+        prompt_contract="GPT-5.5 contract.",
+    )
+
+    assert prompt.startswith("GPT-5.5 contract.\n\nIntro")
+
+
 def test_build_review_system_prompt_preserves_legacy_context_prompt():
     language_prompts = {
         "security_review_file": (

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -66,8 +66,10 @@ def test_review_nodes_pipeline_parses():
         custom_prompt_text=None,
         custom_guidance_precedence="",
         schema_prompt_section='- "issue": desc',
+        prompt_contract="GPT-5.5 contract.",
     )
     assert "system_prompt" in s2
+    assert s2["system_prompt"].startswith("GPT-5.5 contract.")
 
     # Step 3: run LLM review (stub)
     class _DummyNode:

--- a/tests/test_triage_graph.py
+++ b/tests/test_triage_graph.py
@@ -118,6 +118,22 @@ def test_triage_graph_propagates_retrieval_context_flag(monkeypatch):
     assert app.last_input["use_retrieval_context"] is False
 
 
+def test_triage_graph_prepends_prompt_contract():
+    graph = TriageGraph(
+        llm_provider=object(),
+        llama_query_model="dummy",
+        toolbox=object(),
+        plugin_config={
+            "general_prompts": {
+                "gpt55_prompt_contract": "GPT-5.5 contract.",
+                "triage_system_prompt": "Triage prompt.",
+            }
+        },
+    )
+
+    assert graph.triage_system_prompt == "GPT-5.5 contract.\n\nTriage prompt."
+
+
 def test_triage_graph_fills_unresolved_hops_for_inconclusive(monkeypatch):
     g = _build_graph()
     monkeypatch.setattr(


### PR DESCRIPTION
https://developers.openai.com/api/docs/guides/latest-model
https://simonwillison.net/2026/Apr/25/gpt-5-5-prompting-guide/

OpenAI suggests that rewriting prompts to be gpt5.5 specific is worthwhile. I ran their recommended prompt and a variant to see what changes it would make. None of the language specific prompts are updated so I suspect this will make little difference to the evaluation results.

Codex prompts used

* `openai-docs migrate this project to gpt-5.5` (as suggested by OpenAI)
* `openai-docs find the configuration containing LLM prompots and migrate them to gpt-5.5` to try to provoke more updates to the prompts defined in the project.