### PR TITLE
fix(config): Fix CLI version handling and validate provider configuration

### DIFF
--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -383,7 +383,16 @@ def main():
         )
         exit(1)
     if args.version:
-        COMMANDS["version"].invoke(None, [], args)
+        COMMANDS["version"].invoke(
+            None,
+            [],
+            args,
+            CommandRuntime(
+                command="version",
+                command_args=[],
+                use_retrieval_context=False,
+            ),
+        )
         return
 
     configure_logger(logger, args)

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -7,13 +7,153 @@ import yaml
 
 from importlib.resources import files, as_file
 from pathlib import Path
+from typing import TypedDict
 
 logger = logging.getLogger("metis")
+
+
+class _ApiKeySources(TypedDict):
+    required: bool
+    config_keys: tuple[str, ...]
+    config_env_keys: tuple[str, ...]
+    env_vars: tuple[str, ...]
+
+
+_LLM_PROVIDER_DISPLAY_NAMES: dict[str, str] = {
+    "openai": "OpenAI",
+    "azure_openai": "Azure OpenAI",
+    "vllm": "vLLM",
+    "ollama": "Ollama",
+}
+
+_LLM_PROVIDER_REQUIRED_KEYS: dict[str, tuple[str, ...]] = {
+    "openai": (
+        "model",
+        "code_embedding_model",
+        "docs_embedding_model",
+    ),
+    "azure_openai": (
+        "azure_endpoint",
+        "azure_api_version",
+        "engine",
+        "chat_deployment_model",
+        "code_embedding_model",
+        "docs_embedding_model",
+        "code_embedding_deployment",
+        "docs_embedding_deployment",
+    ),
+    "vllm": (
+        "base_url",
+        "model",
+        "code_embedding_model",
+        "docs_embedding_model",
+    ),
+    "ollama": (
+        "model",
+        "code_embedding_model",
+        "docs_embedding_model",
+    ),
+}
+
+_LLM_PROVIDER_API_KEY_SOURCES: dict[str, _ApiKeySources] = {
+    "openai": {
+        "required": True,
+        "config_keys": (),
+        "config_env_keys": (),
+        "env_vars": ("OPENAI_API_KEY",),
+    },
+    "azure_openai": {
+        "required": True,
+        "config_keys": (),
+        "config_env_keys": (),
+        "env_vars": ("AZURE_OPENAI_API_KEY",),
+    },
+    "vllm": {
+        "required": False,
+        "config_keys": ("api_key",),
+        "config_env_keys": ("api_key_env",),
+        "env_vars": ("VLLM_API_KEY",),
+    },
+    "ollama": {
+        "required": False,
+        "config_keys": ("api_key",),
+        "config_env_keys": ("api_key_env",),
+        "env_vars": (),
+    },
+}
 
 
 def load_yaml(path):
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def _missing_required_keys(config: dict, keys: tuple[str, ...]) -> list[str]:
+    missing = []
+    for key in keys:
+        value = config.get(key)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            missing.append(key)
+    return missing
+
+
+def _validate_llm_provider_config(provider_name: str, provider_config: dict) -> None:
+    required_keys = _LLM_PROVIDER_REQUIRED_KEYS.get(provider_name)
+    if not required_keys:
+        return
+    missing_keys = _missing_required_keys(provider_config, required_keys)
+    if not missing_keys:
+        return
+
+    display_name = _LLM_PROVIDER_DISPLAY_NAMES.get(provider_name, provider_name)
+    missing = ", ".join(f"llm_provider.{key}" for key in missing_keys)
+    required = ", ".join(f"llm_provider.{key}" for key in required_keys)
+    raise ValueError(
+        f"{display_name} provider requires additional metis.yaml configuration. "
+        f"Missing: {missing}. Required keys: {required}."
+    )
+
+
+def _resolve_llm_api_key(provider_name: str, provider_config: dict) -> str:
+    sources = _LLM_PROVIDER_API_KEY_SOURCES.get(provider_name)
+    if sources is None:
+        return ""
+
+    for config_key in sources["config_keys"]:
+        value = provider_config.get(config_key)
+        if isinstance(value, str) and value.strip():
+            return value
+
+    for config_env_key in sources["config_env_keys"]:
+        env_var = provider_config.get(config_env_key)
+        if isinstance(env_var, str) and env_var.strip():
+            value = os.environ.get(env_var)
+            if value:
+                return value
+
+    for env_var in sources["env_vars"]:
+        value = os.environ.get(env_var)
+        if value:
+            return value
+
+    if sources["required"]:
+        display_name = _LLM_PROVIDER_DISPLAY_NAMES.get(provider_name, provider_name)
+        source_descriptions = [
+            f"{env_var} environment variable" for env_var in sources["env_vars"]
+        ]
+        source_descriptions.extend(
+            f"llm_provider.{key}" for key in sources["config_keys"]
+        )
+        source_descriptions.extend(
+            f"environment variable named by llm_provider.{key}"
+            for key in sources["config_env_keys"]
+        )
+        sources_text = " or ".join(source_descriptions)
+        raise RuntimeError(
+            f"{sources_text} is required for {display_name} provider but not set."
+        )
+
+    return ""
 
 
 def load_runtime_config(config_path=None, enable_psql=False):
@@ -56,20 +196,12 @@ def load_runtime_config(config_path=None, enable_psql=False):
 
     llm_provider_name = cfg.get("llm_provider", {}).get("name", "").lower()
     runtime["llm_provider_name"] = llm_provider_name
+    _validate_llm_provider_config(llm_provider_name, llm_cfg)
+    llm_api_key = _resolve_llm_api_key(llm_provider_name, llm_cfg)
     if llm_provider_name == "openai":
-        llm_api_key = os.environ.get("OPENAI_API_KEY")
-        if not llm_api_key:
-            raise RuntimeError(
-                "OPENAI_API_KEY environment variable is required for OpenAI provider but not set."
-            )
         runtime["llm_api_key"] = llm_api_key
         runtime["model"] = llm_cfg.get("model", "")
     elif llm_provider_name == "azure_openai":
-        llm_api_key = os.environ.get("AZURE_OPENAI_API_KEY")
-        if not llm_api_key:
-            raise RuntimeError(
-                "AZURE_OPENAI_API_KEY environment variable is required for Azure OpenAI provider but not set."
-            )
         runtime["llm_api_key"] = llm_api_key
         runtime["azure_endpoint"] = llm_cfg.get("azure_endpoint", "")
         runtime["azure_api_version"] = llm_cfg.get("azure_api_version", "")
@@ -86,20 +218,12 @@ def load_runtime_config(config_path=None, enable_psql=False):
         )
         runtime["supports_temperature"] = llm_cfg.get("supports_temperature", False)
     elif llm_provider_name == "vllm":
-        runtime["llm_api_key"] = llm_cfg.get("api_key")
-        api_key_env = llm_cfg.get("api_key_env")
-        if not runtime["llm_api_key"] and api_key_env:
-            runtime["llm_api_key"] = os.environ.get(api_key_env)
-        if not runtime["llm_api_key"]:
-            runtime["llm_api_key"] = os.environ.get("VLLM_API_KEY")
+        runtime["llm_api_key"] = llm_api_key
         runtime["openai_api_base"] = llm_cfg.get("base_url", "")
         runtime["openai_default_headers"] = llm_cfg.get("default_headers", {})
         runtime["model"] = llm_cfg.get("model", "")
     elif llm_provider_name == "ollama":
-        runtime["llm_api_key"] = llm_cfg.get("api_key") or ""
-        api_key_env = llm_cfg.get("api_key_env")
-        if not runtime["llm_api_key"] and api_key_env:
-            runtime["llm_api_key"] = os.environ.get(api_key_env, "")
+        runtime["llm_api_key"] = llm_api_key
         runtime["openai_api_base"] = llm_cfg.get(
             "base_url", "http://localhost:11434/v1"
         )

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from contextlib import nullcontext
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -226,3 +227,15 @@ def test_run_non_interactive_keeps_quiet_without_verbose():
     assert exit_code == 1
     assert farewell is None
     assert args.quiet is True
+
+
+def test_main_version_does_not_require_runtime_config(monkeypatch, capsys):
+    def fail_load_runtime_config(*_args, **_kwargs):
+        raise AssertionError("runtime config should not be loaded for --version")
+
+    monkeypatch.setattr(sys, "argv", ["metis", "--version"])
+    monkeypatch.setattr(entry, "load_runtime_config", fail_load_runtime_config)
+
+    entry.main()
+
+    assert "Metis" in capsys.readouterr().out

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,6 +4,8 @@
 from metis.configuration import load_metis_config
 from metis.configuration import load_runtime_config
 
+import pytest
+
 
 def test_load_metis_config_uses_yml_when_yaml_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -110,3 +112,231 @@ query:
     runtime = load_runtime_config(config_path)
 
     assert runtime["llama_query_reasoning_effort"] == "high"
+
+
+def test_load_runtime_config_reports_missing_openai_provider_keys(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: openai
+  model: ""
+  code_embedding_model: text-embedding-3-large
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_runtime_config(config_path)
+
+    message = str(exc_info.value)
+    assert "OpenAI provider requires additional metis.yaml configuration" in message
+    assert "Missing: llm_provider.model" in message
+    assert "llm_provider.docs_embedding_model" in message
+    assert "Required keys:" in message
+
+
+def test_load_runtime_config_reports_missing_openai_api_key(tmp_path, monkeypatch):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: openai
+  model: gpt-test
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        load_runtime_config(config_path)
+
+    assert "OPENAI_API_KEY environment variable is required for OpenAI provider" in str(
+        exc_info.value
+    )
+
+
+def test_load_runtime_config_reports_missing_azure_openai_provider_keys(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: azure_openai
+  azure_endpoint: https://example.openai.azure.com/
+  azure_api_version: ""
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_runtime_config(config_path)
+
+    message = str(exc_info.value)
+    assert (
+        "Azure OpenAI provider requires additional metis.yaml configuration" in message
+    )
+    assert "Missing: llm_provider.azure_api_version" in message
+    assert "llm_provider.engine" in message
+    assert "llm_provider.chat_deployment_model" in message
+    assert "llm_provider.code_embedding_deployment" in message
+    assert "llm_provider.docs_embedding_deployment" in message
+    assert "Required keys:" in message
+
+
+def test_load_runtime_config_reports_missing_azure_openai_api_key(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: azure_openai
+  azure_endpoint: https://example.openai.azure.com/
+  azure_api_version: "2024-02-01"
+  engine: chat-deployment
+  chat_deployment_model: gpt-4o-mini
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+  code_embedding_deployment: code-embedding-deployment
+  docs_embedding_deployment: docs-embedding-deployment
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        load_runtime_config(config_path)
+
+    assert (
+        "AZURE_OPENAI_API_KEY environment variable is required for Azure OpenAI provider"
+        in str(exc_info.value)
+    )
+
+
+def test_load_runtime_config_reports_missing_vllm_provider_keys(tmp_path):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: vllm
+  model: test-model
+  docs_embedding_model: text-embedding-3-large
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        load_runtime_config(config_path)
+
+    message = str(exc_info.value)
+    assert "vLLM provider requires additional metis.yaml configuration" in message
+    assert "Missing: llm_provider.base_url" in message
+    assert "llm_provider.code_embedding_model" in message
+    assert "Required keys:" in message
+
+
+def test_load_runtime_config_resolves_vllm_api_key_from_configured_env(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: vllm
+  base_url: http://localhost:8000/v1
+  api_key_env: CUSTOM_VLLM_KEY
+  model: test-model
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CUSTOM_VLLM_KEY", "vllm-key")
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["llm_api_key"] == "vllm-key"
+
+
+def test_load_runtime_config_reports_missing_ollama_provider_keys(tmp_path):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: ollama
+  model: llama3
+  code_embedding_model: ""
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        load_runtime_config(config_path)
+
+    message = str(exc_info.value)
+    assert "Ollama provider requires additional metis.yaml configuration" in message
+    assert "Missing: llm_provider.code_embedding_model" in message
+    assert "llm_provider.docs_embedding_model" in message
+    assert "Required keys:" in message
+
+
+def test_load_runtime_config_keeps_ollama_api_key_optional(tmp_path):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: ollama
+  model: llama3
+  code_embedding_model: all-minilm
+  docs_embedding_model: all-minilm
+""",
+        encoding="utf-8",
+    )
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["llm_api_key"] == ""
+
+
+def test_load_runtime_config_accepts_complete_azure_provider_config(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider:
+  name: azure_openai
+  azure_endpoint: https://example.openai.azure.com/
+  azure_api_version: "2024-02-01"
+  engine: chat-deployment
+  chat_deployment_model: gpt-4o-mini
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+  code_embedding_deployment: code-embedding-deployment
+  docs_embedding_deployment: docs-embedding-deployment
+query:
+  max_tokens: 1000
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["azure_endpoint"] == "https://example.openai.azure.com/"
+    assert runtime["azure_api_version"] == "2024-02-01"
+    assert runtime["engine"] == "chat-deployment"
+    assert runtime["chat_deployment_model"] == "gpt-4o-mini"
+    assert runtime["code_embedding_deployment"] == "code-embedding-deployment"
+    assert runtime["docs_embedding_deployment"] == "docs-embedding-deployment"


### PR DESCRIPTION
  - Fix `metis --version` so it invokes the command dispatcher with the required runtime object without loading runtime provider config.
  - Add provider-specific required YAML key validation for OpenAI, Azure OpenAI, vLLM, and Ollama.
  - Add API key source validation/resolution for configured providers.
  - Require API keys for OpenAI and Azure OpenAI while preserving optional key behavior for vLLM and Ollama.
  - Add regression tests for version handling, missing provider keys, missing OpenAI/Azure API keys, vLLM env-key resolution, Ollama optional keys, and complete Azure config loading.