### PR TITLE
fix(config): support OpenAI custom base URL

### DIFF
--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -649,5 +649,5 @@ def build_chroma_backend(args, runtime, embed_model_code, embed_model_docs):
         persist_dir=args.chroma_dir,
         embed_model_code=embed_model_code,
         embed_model_docs=embed_model_docs,
-        query_config=runtime.get("query", {}),
+        query_config=runtime,
     )

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -200,6 +200,8 @@ def load_runtime_config(config_path=None, enable_psql=False):
     llm_api_key = _resolve_llm_api_key(llm_provider_name, llm_cfg)
     if llm_provider_name == "openai":
         runtime["llm_api_key"] = llm_api_key
+        runtime["openai_api_base"] = llm_cfg.get("base_url", "")
+        runtime["openai_default_headers"] = llm_cfg.get("default_headers", {})
         runtime["model"] = llm_cfg.get("model", "")
     elif llm_provider_name == "azure_openai":
         runtime["llm_api_key"] = llm_api_key

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -71,6 +71,30 @@ query:
     assert runtime["llama_query_reasoning_effort"] == "low"
 
 
+def test_load_runtime_config_reads_openai_base_url_and_headers(tmp_path, monkeypatch):
+    config_path = tmp_path / "metis.yaml"
+    base_url = "https://example.test/openai/v1"
+    config_path.write_text(
+        f"""
+llm_provider:
+  name: openai
+  base_url: {base_url}
+  default_headers:
+    X-Test-Header: test
+  model: gpt-test
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-large
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["openai_api_base"] == base_url
+    assert runtime["openai_default_headers"] == {"X-Test-Header": "test"}
+
+
 def test_load_runtime_config_reads_provider_reasoning_effort(tmp_path, monkeypatch):
     config_path = tmp_path / "metis.yaml"
     config_path.write_text(

--- a/tests/test_engine_chroma.py
+++ b/tests/test_engine_chroma.py
@@ -5,7 +5,9 @@ import pytest
 import os
 from unittest.mock import patch
 from metis.engine import MetisEngine
+from metis.cli.utils import build_chroma_backend
 from metis.vector_store.chroma_store import ChromaStore
+from metis.providers.openai import OpenAIProvider
 from llama_index.core.settings import Settings
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 
@@ -80,3 +82,50 @@ def test_chroma_store_forces_rust_bindings(tmp_path):
 
     settings = client_ctor.call_args.kwargs["settings"]
     assert settings.chroma_api_impl == "chromadb.api.rust.RustBindingsAPI"
+
+
+def test_build_chroma_backend_receives_full_runtime_config(tmp_path):
+    base_url = "https://example.test/openai/v1"
+    runtime = {
+        "openai_api_base": base_url,
+        "similarity_top_k": 7,
+        "response_mode": "tree_summarize",
+    }
+    embed = MockEmbedding(embed_dim=8)
+
+    class _Args:
+        chroma_dir = str(tmp_path / "chroma_test")
+
+    backend = build_chroma_backend(_Args(), runtime, embed, embed)
+
+    assert backend.query_config is runtime
+    assert backend.query_config["openai_api_base"] == base_url
+
+
+def test_chroma_llm_uses_openai_provider_base_url(tmp_path):
+    base_url = "https://example.test/openai/v1"
+    runtime = {
+        "llm_api_key": "test-key",
+        "openai_api_base": base_url,
+        "openai_default_headers": {"X-Test-Header": "test"},
+        "model": "gpt-test",
+        "llama_query_model": "gpt-test",
+        "llama_query_temperature": 0.0,
+        "llama_query_max_tokens": 256,
+        "max_token_length": 32768,
+        "code_embedding_model": "text-embedding-3-large",
+        "docs_embedding_model": "text-embedding-3-large",
+    }
+    embed = MockEmbedding(embed_dim=8)
+    backend = ChromaStore(
+        persist_dir=str(tmp_path / "chroma_test"),
+        embed_model_code=embed,
+        embed_model_docs=embed,
+        query_config=runtime,
+    )
+
+    llm = backend._build_llm(OpenAIProvider(runtime))
+
+    assert llm.api_base == base_url
+    assert llm.default_headers == {"X-Test-Header": "test"}
+    assert llm.context_window == 32768


### PR DESCRIPTION
The OpenAI provider accepted a base_url in YAML, but load_runtime_config dropped it when flattening llm_provider settings. As a result, provider construction silently fell back to the default OpenAI endpoint.

Pass base_url and default_headers through the OpenAI runtime config. Also pass the flattened runtime config into Chroma so query settings and provider endpoint settings are available on the Chroma path.