### PR TITLE
docs: ollama: recommend nomic-embed-text:v1.5 embedding model

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -5,7 +5,7 @@ Metis can talk directly to [Ollama](https://github.com/ollama/ollama) through it
 ## Prerequisites
 
 1. Install Ollama on the machine that will host the models.
-2. Pull at least one chat model (for example `ollama pull llama3.2`) and one embedding model (for example `ollama pull all-minilm`).
+2. Pull at least one chat model (for example `ollama pull llama3.2`) and one embedding model (for example `ollama pull nomic-embed-text:v1.5`).
 3. Ensure the Ollama service is running. On macOS it auto-starts; on Linux run `ollama serve`. If the service runs on a different host, set `OLLAMA_HOST` (e.g. `0.0.0.0:11434`) so Metis can reach it over the network.
 
 ## Configuration
@@ -17,12 +17,12 @@ llm_provider:
   name: "ollama"
   base_url: "http://localhost:11434/v1"
   model: "llama3.2"
-  code_embedding_model: "all-minilm"
-  docs_embedding_model: "all-minilm"
+  code_embedding_model: "nomic-embed-text:v1.5"
+  docs_embedding_model: "nomic-embed-text:v1.5"
 ```
 
 - `base_url` can point to a remote host.
-- Use the embedded model ids exposed by `ollama list` or `ollama show <model>`. The OpenAI-compatible `embeddings.create` call works with models such as `all-minilm`.
+- Use the embedded model ids exposed by `ollama list` or `ollama show <model>`. The OpenAI-compatible `embeddings.create` call works with models such as `nomic-embed-text:v1.5`.
 - `metis_engine.max_token_length` should not exceed the model’s context window. Adjust it (and optionally `query.max_tokens`) to match the model you are using.
 
 ## Metis usage

--- a/examples/ollama/metis_ollama_example.yaml
+++ b/examples/ollama/metis_ollama_example.yaml
@@ -24,8 +24,8 @@ llm_provider:
   name: "ollama"
   base_url: "http://YOUR-OLLAMA-HOST:11434/v1"
   model: "YOUR-CHAT-MODEL"
-  code_embedding_model: "YOUR-EMBEDDING-MODEL"
-  docs_embedding_model: "YOUR-EMBEDDING-MODEL"
+  code_embedding_model: "nomic-embed-text:v1.5"
+  docs_embedding_model: "nomic-embed-text:v1.5"
 
 query:
   similarity_top_k: 5

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -323,8 +323,8 @@ def test_load_runtime_config_keeps_ollama_api_key_optional(tmp_path):
 llm_provider:
   name: ollama
   model: llama3
-  code_embedding_model: all-minilm
-  docs_embedding_model: all-minilm
+  code_embedding_model: nomic-embed-text:v1.5
+  docs_embedding_model: nomic-embed-text:v1.5
 """,
         encoding="utf-8",
     )


### PR DESCRIPTION
nomic-embed-text:v1.5 is a much better embedding model than all-minlm: 137M parameters, 274 MB on disk, 8192 tokens context window, runs on CPU, with 62.39 average score across retrieval, classification, clustering, and STS tasks.
The only advantage in favor of all-minilm is its size, 46 MB.