### PR TITLE
docs: ollama: recommend llama3.1:8b chat model

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -1,11 +1,24 @@
 # Ollama Provider
 
-Metis can talk directly to [Ollama](https://github.com/ollama/ollama) through its OpenAI-compatible API, letting you run chat and embedding models locally with minimal configuration. Ollama listens on `http://localhost:11434` by default, accepts OpenAI-format requests, and supports the `/v1/responses`, `/v1/chat/completions`, `/v1/completions`, `/v1/models`, and `/v1/embeddings` endpoints.
+Metis can talk directly to [Ollama](https://github.com/ollama/ollama) through its OpenAI-compatible API, letting you run chat and embedding models locally with minimal configuration.
+
+Ollama listens on `http://localhost:11434` by default, accepts OpenAI-format requests, and supports the following endpoints:
+- `/v1/responses`
+- `/v1/chat/completions`
+- `/v1/completions`
+- `/v1/models`
+- `/v1/embeddings`
 
 ## Prerequisites
 
 1. Install Ollama on the machine that will host the models.
-2. Pull at least one chat model (for example `ollama pull llama3.1:8b`) and one embedding model (for example `ollama pull nomic-embed-text:v1.5`).
+2. Pull at least one chat model and one embedding model
+   - Chat model examples
+     - e.g. for 8GB system, `ollama pull llama3.1:8b`
+     - e.g. for 16GB system, `ollama pull qwen3.5:9b`
+     - e.g. for 24GB system, `ollama pull qwen3.6:35b-a3b`
+   - Embedding model example
+     - e.g. `ollama pull nomic-embed-text:v1.5`
 3. Ensure the Ollama service is running. On macOS it auto-starts; on Linux run `ollama serve`. If the service runs on a different host, set `OLLAMA_HOST` (e.g. `0.0.0.0:11434`) so Metis can reach it over the network.
 
 ## Configuration

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -5,7 +5,7 @@ Metis can talk directly to [Ollama](https://github.com/ollama/ollama) through it
 ## Prerequisites
 
 1. Install Ollama on the machine that will host the models.
-2. Pull at least one chat model (for example `ollama pull llama3.2`) and one embedding model (for example `ollama pull nomic-embed-text:v1.5`).
+2. Pull at least one chat model (for example `ollama pull llama3.1:8b`) and one embedding model (for example `ollama pull nomic-embed-text:v1.5`).
 3. Ensure the Ollama service is running. On macOS it auto-starts; on Linux run `ollama serve`. If the service runs on a different host, set `OLLAMA_HOST` (e.g. `0.0.0.0:11434`) so Metis can reach it over the network.
 
 ## Configuration
@@ -16,7 +16,7 @@ Add or adjust the `llm_provider` block in your `metis.yaml`:
 llm_provider:
   name: "ollama"
   base_url: "http://localhost:11434/v1"
-  model: "llama3.2"
+  model: "llama3.1:8b"
   code_embedding_model: "nomic-embed-text:v1.5"
   docs_embedding_model: "nomic-embed-text:v1.5"
 ```

--- a/examples/ollama/metis_ollama_example.yaml
+++ b/examples/ollama/metis_ollama_example.yaml
@@ -23,7 +23,7 @@ metis_engine:
 llm_provider:
   name: "ollama"
   base_url: "http://YOUR-OLLAMA-HOST:11434/v1"
-  model: "YOUR-CHAT-MODEL"
+  model: "llama3.1:8b"
   code_embedding_model: "nomic-embed-text:v1.5"
   docs_embedding_model: "nomic-embed-text:v1.5"
 

--- a/examples/ollama/metis_ollama_example.yaml
+++ b/examples/ollama/metis_ollama_example.yaml
@@ -22,8 +22,11 @@ metis_engine:
 
 llm_provider:
   name: "ollama"
-  base_url: "http://YOUR-OLLAMA-HOST:11434/v1"
-  model: "llama3.1:8b"
+  base_url: "http://localhost:11434/v1"
+  # Models recommendation depends on hardware capabilities
+  model: "llama3.1:8b" # for 8GB system
+#  model: "qwen3.5:9b" # for 16GB system
+#  model: "qwen3.6:35b-a3b" # for 24GB system
   code_embedding_model: "nomic-embed-text:v1.5"
   docs_embedding_model: "nomic-embed-text:v1.5"
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -300,7 +300,7 @@ def test_load_runtime_config_reports_missing_ollama_provider_keys(tmp_path):
         """
 llm_provider:
   name: ollama
-  model: llama3
+  model: llama3.1:8b
   code_embedding_model: ""
 """,
         encoding="utf-8",
@@ -322,7 +322,7 @@ def test_load_runtime_config_keeps_ollama_api_key_optional(tmp_path):
         """
 llm_provider:
   name: ollama
-  model: llama3
+  model: llama3.1:8b
   code_embedding_model: nomic-embed-text:v1.5
   docs_embedding_model: nomic-embed-text:v1.5
 """,


### PR DESCRIPTION
llama3.2 and llama3.1 are simply not drop-in replacement. llama3.1 is a 8B parameters model, while llama3.2 is a 3B parameters model. In metis use-case, llama3.1:8b is the more capable model, able to run on 8GB RAM laptop.
Use explicitely the model tag (8b) to avoid any confusion. Fix the test to use the same model as recommended in the doc.

Note: for users with more hardware capabilities (memory: 16 GB RAM or 8GB VRAM GPU),
      qwen3.5:9b is a better choice.