### PR TITLE
pre-commit: add more checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,3 @@ jobs:
         run: |
           uv pip install pre-commit
           uv run pre-commit run --all-files --show-diff-on-failure
-
-      - name: Run Bandit
-        run: |
-          uv pip install bandit
-          uv run bandit -r . -x "./.venv/*","./tests" --severity-level medium

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,24 @@
-repos:
-  - repo: https://github.com/psf/black
-    rev: 25.11.0
-    hooks:
-      - id: black
+default_language_version:
+  python: python3.12
 
+repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.5
+    rev: v0.15.15
     hooks:
-      - id: ruff
+      - id: ruff-check
+        args: ["--fix", "--exit-non-zero-on-fix"]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      - id: check-builtin-literals
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-toml
       - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
@@ -20,6 +26,16 @@ repos:
     rev: v2.23.0
     hooks:
       - id: pyproject-fmt
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        additional_dependencies:
+          - "bandit[toml]"
+        args:
+          - "--configfile=pyproject.toml"
+          - "--severity-level=medium"
 
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ optional-dependencies.dev = [
   "metis[test]",
 ]
 optional-dependencies.lint = [
-  "black>=26.5.1",
+  "bandit>=1.9.4",
   "mypy>=2.1.0",
   "pre-commit>=4.6.0",
   "ruff>=0.15.15",
@@ -72,6 +72,9 @@ package-data."metis.cli" = [ "report_template.html" ]
 package-data."metis.plugins" = [ "plugins.yaml" ]
 package-data."metis.schemas" = [ "*.json" ]
 package-data.metis = [ "metis.yaml" ]
+
+[tool.ruff]
+lint.isort.force-single-line = true
 
 [tool.pyproject-fmt]
 keep_full_version = true

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -563,7 +563,7 @@ def pretty_print_reviews(results, quiet=False):
             print_console(f"\n[bold blue]File: {escape(file)}[/bold blue]", quiet)
             for idx, r in enumerate(reviews, 1):
                 print_console(
-                    f" [yellow]Identified issue {idx}:[/yellow] [bold]{escape(r.get('issue','-'))}[/bold]",
+                    f" [yellow]Identified issue {idx}:[/yellow] [bold]{escape(r.get('issue', '-'))}[/bold]",
                     quiet,
                 )
                 if r.get("code_snippet"):

--- a/src/metis/providers/azure_openai.py
+++ b/src/metis/providers/azure_openai.py
@@ -60,7 +60,6 @@ class AzureOpenAIEmbeddingAdapter(BaseEmbedding):
 
 
 class AzureOpenAIProvider(LLMProvider):
-
     def __init__(self, config: AzureOpenAIProviderConfig) -> None:
         self.api_key = config["llm_api_key"]
         self.azure_endpoint = config["azure_endpoint"]

--- a/src/metis/providers/base.py
+++ b/src/metis/providers/base.py
@@ -83,7 +83,6 @@ QueryModelKwargs = Mapping[str, object]
 
 
 class LLMProvider(ABC):
-
     def __init__(self, config: ProviderRuntimeConfig) -> None:
         pass
 

--- a/src/metis/providers/ollama.py
+++ b/src/metis/providers/ollama.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 class OllamaProvider(OpenAICompatibleProvider):
-
     def __init__(self, config):
         super().__init__(config)
         if not self.base_url:

--- a/src/metis/providers/openai_compatible.py
+++ b/src/metis/providers/openai_compatible.py
@@ -25,7 +25,6 @@ _ALLOWED_OPENAI_EMBED_MODELS = {member.value for member in OpenAIEmbeddingModelT
 
 
 class OpenAICompatibleProvider(LLMProvider):
-
     def __init__(self, config: OpenAICompatibleProviderConfig) -> None:
         self.config = config
         self.api_key = config.get("llm_api_key")

--- a/src/metis/providers/vllm.py
+++ b/src/metis/providers/vllm.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 class VLLMProvider(OpenAICompatibleProvider):
-
     def __init__(self, config):
         super().__init__(config)
         if not self.base_url:

--- a/src/metis/utils.py
+++ b/src/metis/utils.py
@@ -150,7 +150,6 @@ def find_snippet_line(snippet, file_lines, threshold=0.80):
     norm_snippet = normalize_lines(snippet_lines)
 
     for i in range(len(file_lines) - snippet_len + 1):
-
         window = file_lines[i : i + snippet_len]
         norm_window = normalize_lines(window)
 


### PR DESCRIPTION
Use ruff as a linter and formatter (ruff-check and ruff-format).
Upgrade ruff version 0.4.15 -> 0.15.5.
Drop black, replaced by ruff-formatter.
Add more pre-commit checks (check-builtin-literals, check-case-conflict,
 check-docstring-first, check-toml, check-yaml, debug-statements,
 detect-private-key).
Add bandit to precommit checks instead of github workflows only.
Update pyproject.toml:
 - drop black
 - add bandit
 - add ruf tool sectioni (lint.isort.force-single-line)
pre-commit automatic fixes (src/metis/*.py))