### PR TITLE
feat(tools): add engine tool selection

### DIFF
--- a/src/metis/cli/command_registry.py
+++ b/src/metis/cli/command_registry.py
@@ -8,6 +8,8 @@ from typing import Callable, Literal
 from prompt_toolkit.completion import WordCompleter
 from rich.markup import escape
 
+from metis.engine.tools.selection import INDEX_TOOL
+
 from .command_runtime import CommandRuntime
 from .commands import (
     run_ask,
@@ -24,7 +26,6 @@ from .utils import print_console
 
 
 InvocationMode = Literal["none", "path", "question", "index", "args", "meta"]
-IndexPolicy = Literal["none", "required", "optional"]
 
 
 @dataclass(frozen=True)
@@ -34,7 +35,8 @@ class CommandSpec:
     invocation_mode: InvocationMode = "none"
     include_target_in_display_name: bool = False
     prepares_output_file: bool = False
-    index_policy: IndexPolicy = "none"
+    required_tools: tuple[str, ...] = ()
+    optional_tools: tuple[str, ...] = ()
     supports_triage: bool = False
 
     def usage_target(self, cmd_args: list[str]) -> str | None:
@@ -106,6 +108,7 @@ COMMANDS = {
         tracked=True,
         invocation_mode="index",
         prepares_output_file=True,
+        required_tools=(INDEX_TOOL,),
     ),
     "review_patch": CommandSpec(
         run_review,
@@ -113,7 +116,7 @@ COMMANDS = {
         invocation_mode="path",
         include_target_in_display_name=True,
         prepares_output_file=True,
-        index_policy="optional",
+        optional_tools=(INDEX_TOOL,),
         supports_triage=True,
     ),
     "review_code": CommandSpec(
@@ -121,14 +124,14 @@ COMMANDS = {
         tracked=True,
         invocation_mode="args",
         prepares_output_file=True,
-        index_policy="optional",
+        optional_tools=(INDEX_TOOL,),
         supports_triage=True,
     ),
     "update": CommandSpec(
         run_update,
         invocation_mode="path",
         prepares_output_file=True,
-        index_policy="required",
+        required_tools=(INDEX_TOOL,),
     ),
     "review_file": CommandSpec(
         run_file_review,
@@ -136,7 +139,7 @@ COMMANDS = {
         invocation_mode="path",
         include_target_in_display_name=True,
         prepares_output_file=True,
-        index_policy="optional",
+        optional_tools=(INDEX_TOOL,),
         supports_triage=True,
     ),
     "ask": CommandSpec(
@@ -144,7 +147,7 @@ COMMANDS = {
         tracked=True,
         invocation_mode="question",
         prepares_output_file=True,
-        index_policy="required",
+        required_tools=(INDEX_TOOL,),
     ),
     "triage": CommandSpec(
         run_triage,
@@ -152,7 +155,7 @@ COMMANDS = {
         invocation_mode="path",
         include_target_in_display_name=True,
         prepares_output_file=True,
-        index_policy="optional",
+        optional_tools=(INDEX_TOOL,),
     ),
     "help": CommandSpec(show_help, invocation_mode="meta"),
     "version": CommandSpec(show_version, invocation_mode="meta"),

--- a/src/metis/cli/commands.py
+++ b/src/metis/cli/commands.py
@@ -62,7 +62,7 @@ Options:
     --custom-prompt PATH       Custom prompt file (.md or .txt) to guide analysis.
     --triage                   Triage findings and annotate SARIF output for review commands.
     --include-triaged          Include findings already triaged by Metis.
-    --use-index                Experimental opt-in to legacy index-backed retrieval for review and triage.
+    --tools index|all|none     Enable optional engine addons.
     --ignore-index             Compatibility no-op retained for existing scripts.
     --project-schema SCHEMA    (Optional) Project identifier if postgresql is used.
     --chroma-dir DIR           (Optional) Directory to store ChromaDB data (default: ./chromadb).

--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -13,6 +13,7 @@ from prompt_toolkit.history import InMemoryHistory
 
 from metis.configuration import load_runtime_config
 from metis.engine import MetisEngine
+from metis.engine.tools.selection import INDEX_TOOL, parse_engine_tools, tool_enabled
 from metis.usage import UsageRuntime
 from metis.utils import read_file_content
 from metis.providers.registry import get_provider
@@ -89,6 +90,11 @@ def resolve_custom_prompt(args):
 
 
 def build_engine(args, runtime):
+    runtime = dict(runtime)
+    if getattr(args, "enabled_tools", None) is None:
+        _configure_enabled_tools(args, runtime)
+    runtime["enabled_tools"] = _enabled_tools_for_args(args)
+
     llm_provider_name = runtime.get("llm_provider_name", "openai")
     provider_cls = get_provider(llm_provider_name)
     llm_provider = provider_cls(cast(ProviderRuntimeConfig, runtime))
@@ -161,29 +167,55 @@ def finalize_cli_session_and_close(engine, args, farewell):
             close_fn()
 
 
-def _command_index_flags(args, cmd_args: list[str]) -> tuple[list[str], bool]:
+def _command_index_flags(cmd_args: list[str]) -> list[str]:
     filtered_args: list[str] = []
-    use_index = bool(getattr(args, "use_index", False))
     for arg in cmd_args:
         if arg == "--ignore-index":
             continue
-        if arg == "--use-index":
-            use_index = True
-            continue
         filtered_args.append(arg)
-    return filtered_args, use_index
+    return filtered_args
+
+
+def _enabled_tools_for_args(args) -> set[str]:
+    enabled_tools = getattr(args, "enabled_tools", None)
+    if enabled_tools is not None:
+        return parse_engine_tools(enabled_tools)
+    return parse_engine_tools(getattr(args, "tools", None))
+
+
+def _configure_enabled_tools(args, runtime) -> None:
+    raw_tools = args.tools if getattr(args, "tools", None) is not None else None
+    if raw_tools is None:
+        raw_tools = runtime.get("enabled_tools")
+    args.enabled_tools = parse_engine_tools(raw_tools)
+
+
+def _format_tool_list(tools: list[str]) -> str:
+    return ", ".join(f"'{tool}'" for tool in tools)
 
 
 def _prepare_command_runtime(cmd, cmd_args, args):
     spec = COMMANDS[cmd]
-    filtered_args, use_index = _command_index_flags(args, cmd_args)
+    filtered_args = _command_index_flags(cmd_args)
     if not spec.validate_options(cmd, args):
         return None
 
-    if spec.index_policy == "optional":
-        use_retrieval_context = use_index
-    else:
-        use_retrieval_context = spec.index_policy == "required"
+    enabled_tools = _enabled_tools_for_args(args)
+    missing_tools = [
+        tool for tool in spec.required_tools if not tool_enabled(enabled_tools, tool)
+    ]
+    if missing_tools:
+        tool_label = "tool" if len(missing_tools) == 1 else "tools"
+        enable_value = ",".join(missing_tools)
+        print_console(
+            f"[red]Error:[/red] Command '{escape(cmd)}' requires {tool_label} {_format_tool_list(missing_tools)}. Enable with --tools {escape(enable_value)}.",
+            args.quiet,
+        )
+        return None
+
+    use_retrieval_context = tool_enabled(enabled_tools, INDEX_TOOL) and (
+        INDEX_TOOL in spec.required_tools or INDEX_TOOL in spec.optional_tools
+    )
 
     return CommandRuntime(
         command=cmd,
@@ -196,12 +228,9 @@ def _interactive_command_uses_index(cmd, cmd_args, args) -> bool:
     spec = COMMANDS.get(cmd)
     if spec is None:
         return False
-    if spec.index_policy == "required":
-        return True
-    if spec.index_policy == "optional":
-        _filtered_args, use_index = _command_index_flags(args, cmd_args)
-        return use_index
-    return False
+    if not tool_enabled(_enabled_tools_for_args(args), INDEX_TOOL):
+        return False
+    return INDEX_TOOL in spec.required_tools or INDEX_TOOL in spec.optional_tools
 
 
 def execute_command(engine, cmd, cmd_args, args):
@@ -366,12 +395,18 @@ def main():
         help="Compatibility no-op retained for existing scripts.",
     )
     parser.add_argument(
-        "--use-index",
-        action="store_true",
-        help="Experimental opt-in to legacy index-backed retrieval for review and triage.",
+        "--tools",
+        type=str,
+        help="Comma-separated engine addons to enable, e.g. index or all.",
     )
 
     args = parser.parse_args()
+    try:
+        if args.tools is not None:
+            parse_engine_tools(args.tools)
+    except ValueError as exc:
+        print_console(f"[red]Error:[/red] {escape(str(exc))}", False)
+        raise SystemExit(1) from exc
 
     if args.output_files:
         if args.output_file:
@@ -401,6 +436,11 @@ def main():
 
     configure_logger(logger, args)
     runtime = load_runtime_config(enable_psql=(args.backend == "postgres"))
+    try:
+        _configure_enabled_tools(args, runtime)
+    except ValueError as exc:
+        print_console(f"[red]Error:[/red] {escape(str(exc))}", False)
+        raise SystemExit(1) from exc
     engine, vector_backend = build_engine(args, runtime)
     exit_code = 0
     farewell = None

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -281,6 +281,7 @@ def load_runtime_config(config_path=None, enable_psql=False):
     runtime["review_code_exclude_paths"] = engine_cfg.get(
         "review_code_exclude_paths", []
     )
+    runtime["enabled_tools"] = engine_cfg.get("tools")
     runtime.update(collect_reachability_config(cfg, engine_cfg))
 
     # Query config

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -19,6 +19,7 @@ from .reachability.service import TreeSitterReachabilityService
 from .repository import EngineRepository
 from .review_service import ReviewService
 from .runtime import EngineConfig, EngineState
+from .tools.selection import parse_engine_tools
 from .triage_constants import DEFAULT_TRIAGE_SIMILARITY_TOP_K
 from .triage_service import TriageService
 
@@ -74,6 +75,7 @@ class MetisEngine:
         self.metisignore_file = kwargs.get("metisignore_file") or ".metisignore"
         self.review_code_include_paths = kwargs.get("review_code_include_paths", [])
         self.review_code_exclude_paths = kwargs.get("review_code_exclude_paths", [])
+        self.enabled_tools = parse_engine_tools(kwargs.get("enabled_tools"))
         self.reachability_settings = coerce_reachability_settings(
             kwargs, default_workers=self.max_workers
         )
@@ -118,6 +120,7 @@ class MetisEngine:
             metisignore_file=self.metisignore_file,
             review_code_include_paths=list(self.review_code_include_paths),
             review_code_exclude_paths=list(self.review_code_exclude_paths),
+            enabled_tools=self.enabled_tools,
             code_exts=self.code_exts,
             ext_plugin_map=self.ext_plugin_map,
             ext_pattern_plugin_map=self.ext_pattern_plugin_map,

--- a/src/metis/engine/runtime.py
+++ b/src/metis/engine/runtime.py
@@ -31,6 +31,7 @@ class EngineConfig:
     metisignore_file: str | None
     review_code_include_paths: list[str]
     review_code_exclude_paths: list[str]
+    enabled_tools: set[str]
     code_exts: set[str] = field(default_factory=set)
     ext_plugin_map: dict[str, Any] = field(default_factory=dict)
     ext_pattern_plugin_map: list[tuple[str, Any]] = field(default_factory=list)

--- a/src/metis/engine/tools/selection.py
+++ b/src/metis/engine/tools/selection.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterable
+
+
+INDEX_TOOL = "index"
+KNOWN_ENGINE_TOOLS = (INDEX_TOOL,)
+DEFAULT_ENGINE_TOOLS: tuple[str, ...] = ()
+
+
+def format_known_engine_tools() -> str:
+    return ", ".join(sorted(KNOWN_ENGINE_TOOLS))
+
+
+def parse_engine_tools(value: object | None) -> set[str]:
+    if value is None:
+        return set(DEFAULT_ENGINE_TOOLS)
+
+    raw_items: list[str] = []
+    explicit_iterable = False
+    if isinstance(value, str):
+        raw_items.extend(value.split(","))
+    elif isinstance(value, Iterable):
+        explicit_iterable = True
+        for item in value:
+            raw_items.extend(str(item).split(","))
+    else:
+        raw_items.extend(str(value).split(","))
+
+    tools = [item.strip().lower() for item in raw_items if item.strip()]
+    if not tools:
+        return set() if explicit_iterable else set(DEFAULT_ENGINE_TOOLS)
+
+    if "none" in tools:
+        if len(tools) > 1:
+            raise ValueError("--tools none cannot be combined with other tools")
+        return set()
+
+    if "all" in tools:
+        if len(tools) > 1:
+            raise ValueError("--tools all cannot be combined with other tools")
+        return set(KNOWN_ENGINE_TOOLS)
+
+    unknown = sorted(set(tools) - set(KNOWN_ENGINE_TOOLS))
+    if unknown:
+        known = format_known_engine_tools()
+        raise ValueError(
+            f"Unknown tool(s): {', '.join(unknown)}. Known tools: {known}, all, none"
+        )
+    return set(tools)
+
+
+def tool_enabled(enabled_tools: Collection[str], name: str) -> bool:
+    return name in enabled_tools

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -11,11 +11,31 @@ from metis.cli import entry
 from metis.cli import command_registry
 
 
+def test_configure_enabled_tools_uses_config_when_cli_absent():
+    args = SimpleNamespace(tools=None)
+
+    entry._configure_enabled_tools(  # type: ignore[attr-defined]
+        args, {"enabled_tools": "index"}
+    )
+
+    assert args.enabled_tools == {"index"}
+
+
+def test_configure_enabled_tools_prefers_cli_over_config():
+    args = SimpleNamespace(tools="none")
+
+    entry._configure_enabled_tools(  # type: ignore[attr-defined]
+        args, {"enabled_tools": "index"}
+    )
+
+    assert args.enabled_tools == set()
+
+
 @pytest.mark.parametrize(
     "cmd", ["review_file", "review_code", "review_patch", "triage"]
 )
 def test_prepare_command_runtime_disables_index_by_default_for_supported_command(cmd):
-    args = SimpleNamespace(ignore_index=False, use_index=False, quiet=True)
+    args = SimpleNamespace(ignore_index=False, quiet=True)
 
     runtime = entry._prepare_command_runtime(  # type: ignore[attr-defined]
         cmd=cmd,
@@ -31,12 +51,18 @@ def test_prepare_command_runtime_disables_index_by_default_for_supported_command
 @pytest.mark.parametrize(
     "cmd", ["review_file", "review_code", "review_patch", "triage"]
 )
-def test_prepare_command_runtime_uses_index_when_requested_for_supported_command(cmd):
-    args = SimpleNamespace(ignore_index=False, use_index=False, quiet=True)
+def test_prepare_command_runtime_uses_index_when_tool_enabled_for_supported_command(
+    cmd,
+):
+    args = SimpleNamespace(
+        enabled_tools={"index"},
+        ignore_index=False,
+        quiet=True,
+    )
 
     runtime = entry._prepare_command_runtime(  # type: ignore[attr-defined]
         cmd=cmd,
-        cmd_args=["src/a.c", "--use-index"],
+        cmd_args=["src/a.c"],
         args=args,
     )
 
@@ -46,21 +72,100 @@ def test_prepare_command_runtime_uses_index_when_requested_for_supported_command
 
 
 @pytest.mark.parametrize(
+    "cmd", ["review_file", "review_code", "review_patch", "triage"]
+)
+def test_prepare_command_runtime_keeps_optional_retrieval_disabled_without_index_tool(
+    cmd,
+):
+    args = SimpleNamespace(
+        enabled_tools=set(),
+        ignore_index=False,
+        quiet=True,
+        codebase_path="src/metis",
+    )
+
+    runtime = entry._prepare_command_runtime(  # type: ignore[attr-defined]
+        cmd=cmd,
+        cmd_args=["src/a.c"],
+        args=args,
+    )
+
+    assert runtime is not None
+    assert runtime.command_args == ["src/a.c"]
+    assert runtime.use_retrieval_context is False
+
+
+@pytest.mark.parametrize("cmd", ["ask", "update", "index"])
+def test_prepare_command_runtime_rejects_required_index_by_default(monkeypatch, cmd):
+    args = SimpleNamespace(
+        ignore_index=False,
+        quiet=True,
+        codebase_path="src/metis",
+    )
+    captured = []
+    monkeypatch.setattr(
+        entry,
+        "print_console",
+        lambda message, *_args, **_kwargs: captured.append(str(message)),
+    )
+
+    runtime = entry._prepare_command_runtime(  # type: ignore[attr-defined]
+        cmd=cmd,
+        cmd_args=["why"],
+        args=args,
+    )
+
+    assert runtime is None
+    assert any("requires tool 'index'" in message for message in captured)
+
+
+@pytest.mark.parametrize("cmd", ["ask", "update", "index"])
+def test_prepare_command_runtime_rejects_required_index_when_tool_disabled(
+    monkeypatch, cmd
+):
+    args = SimpleNamespace(
+        enabled_tools=set(),
+        ignore_index=False,
+        quiet=True,
+        codebase_path="src/metis",
+    )
+    captured = []
+    monkeypatch.setattr(
+        entry,
+        "print_console",
+        lambda message, *_args, **_kwargs: captured.append(str(message)),
+    )
+
+    runtime = entry._prepare_command_runtime(  # type: ignore[attr-defined]
+        cmd=cmd,
+        cmd_args=["why"],
+        args=args,
+    )
+
+    assert runtime is None
+    assert any("requires tool 'index'" in message for message in captured)
+
+
+@pytest.mark.parametrize(
     ("cmd", "expected_use_retrieval"),
     [
-        ("review_file", False),
-        ("review_code", False),
-        ("review_patch", False),
-        ("triage", False),
+        ("review_file", True),
+        ("review_code", True),
+        ("review_patch", True),
+        ("triage", True),
         ("ask", True),
         ("update", True),
-        ("index", False),
+        ("index", True),
     ],
 )
 def test_prepare_command_runtime_accepts_inline_ignore_index_as_noop(
     cmd, expected_use_retrieval
 ):
-    args = SimpleNamespace(ignore_index=False, use_index=False, quiet=True)
+    args = SimpleNamespace(
+        enabled_tools={"index"},
+        ignore_index=False,
+        quiet=True,
+    )
 
     runtime = entry._prepare_command_runtime(  # type: ignore[attr-defined]
         cmd=cmd,
@@ -79,7 +184,6 @@ def test_execute_command_rejects_triage_flag_for_ask_before_index_gating(monkeyp
         triage=True,
         output_file=None,
         ignore_index=True,
-        use_index=False,
         non_interactive=True,
         codebase_path="src/metis",
     )
@@ -110,7 +214,6 @@ def test_execute_command_allows_interactive_triage_command_with_global_triage_fl
         triage=True,
         output_file=None,
         ignore_index=False,
-        use_index=False,
         non_interactive=False,
         codebase_path="src/metis",
         include_triaged=False,
@@ -143,11 +246,11 @@ def test_execute_command_allows_interactive_triage_command_with_global_triage_fl
 
 def test_execute_command_allows_interactive_ask_with_global_triage_flag(monkeypatch):
     args = SimpleNamespace(
+        enabled_tools={"index"},
         quiet=True,
         triage=True,
         output_file=None,
         ignore_index=False,
-        use_index=False,
         non_interactive=False,
         codebase_path="src/metis",
     )
@@ -186,11 +289,11 @@ def test_execute_command_accepts_global_ignore_index_as_noop(
     monkeypatch, cmd, cmd_args
 ):
     args = SimpleNamespace(
+        enabled_tools={"index"},
         quiet=True,
         triage=False,
         output_file=None,
         ignore_index=True,
-        use_index=False,
         codebase_path="src/metis",
     )
     calls = []
@@ -222,11 +325,11 @@ def test_execute_command_accepts_global_ignore_index_as_noop(
 @pytest.mark.parametrize("cmd", ["ask", "update"])
 def test_execute_command_accepts_inline_ignore_index_as_noop(monkeypatch, cmd):
     args = SimpleNamespace(
+        enabled_tools={"index"},
         quiet=True,
         triage=False,
         output_file=None,
         ignore_index=False,
-        use_index=False,
         codebase_path="src/metis",
     )
     calls = []

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -138,6 +138,8 @@ def test_noninteractive_verbose_command_prints_usage_and_persists_run(
             "metis",
             "--non-interactive",
             "--verbose",
+            "--tools",
+            "index",
             "--command",
             "ask explain",
             "--codebase-path",
@@ -166,6 +168,8 @@ def test_noninteractive_default_quiet_prints_answer_but_not_usage(
         [
             "metis",
             "--non-interactive",
+            "--tools",
+            "index",
             "--command",
             "ask explain",
             "--codebase-path",
@@ -226,7 +230,7 @@ def test_interactive_eof_finalizes_usage(monkeypatch, tmp_path):
     monkeypatch.setattr(entry, "prompt", _fake_prompt)
     monkeypatch.setattr(
         "sys.argv",
-        ["metis", "--codebase-path", str(tmp_path)],
+        ["metis", "--tools", "index", "--codebase-path", str(tmp_path)],
     )
 
     entry.main()

--- a/tests/test_engine_tools_selection.py
+++ b/tests/test_engine_tools_selection.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from metis.engine.tools.selection import (
+    DEFAULT_ENGINE_TOOLS,
+    KNOWN_ENGINE_TOOLS,
+    parse_engine_tools,
+)
+
+
+def test_parse_engine_tools_defaults_to_none():
+    assert parse_engine_tools(None) == set(DEFAULT_ENGINE_TOOLS)
+    assert parse_engine_tools("") == set(DEFAULT_ENGINE_TOOLS)
+    assert DEFAULT_ENGINE_TOOLS == ()
+
+
+def test_parse_engine_tools_accepts_comma_separated_values():
+    assert parse_engine_tools(" index ") == {"index"}
+    assert parse_engine_tools(["index"]) == {"index"}
+
+
+def test_parse_engine_tools_accepts_none_and_all_aliases():
+    assert parse_engine_tools("none") == set()
+    assert parse_engine_tools("all") == set(KNOWN_ENGINE_TOOLS)
+
+
+def test_parse_engine_tools_rejects_unknown_tools():
+    with pytest.raises(ValueError, match="Unknown tool"):
+        parse_engine_tools("index,unknown")
+
+
+def test_parse_engine_tools_rejects_mixed_none():
+    with pytest.raises(ValueError, match="cannot be combined"):
+        parse_engine_tools("none,index")


### PR DESCRIPTION
- No engine tools are enabled by default.

- --tools index enables the index addon for commands that need or can use retrieval.

- Commands declare required_tools and optional_tools instead of index-specific policy fields.