### PR TITLE
refactor(tools): move index behind engine tool

### DIFF
--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -13,12 +13,12 @@ from metis.usage import UsageRuntime
 from metis.vector_store.base import BaseVectorStore
 
 from .graphs import AskGraph, ReviewGraph
-from .index_context_service import IndexContextService
 from .options import TriageOptions, coerce_triage_options
 from .reachability.service import TreeSitterReachabilityService
 from .repository import EngineRepository
 from .review_service import ReviewService
 from .runtime import EngineConfig, EngineState
+from .tools.engine import build_engine_tools
 from .tools.selection import parse_engine_tools
 from .triage_constants import DEFAULT_TRIAGE_SIMILARITY_TOP_K
 from .triage_service import TriageService
@@ -127,13 +127,13 @@ class MetisEngine:
         )
         self._state = EngineState()
         self.repository = EngineRepository(self._config, self._state)
-        self.index_context = IndexContextService(
+        self.tools = build_engine_tools(
             self._config,
             self._state,
             self.repository,
             normalize_top_k=self._normalize_top_k,
         )
-        self.indexing = self.index_context.indexing
+        self.index_context = self.tools.index
         self.reachability = TreeSitterReachabilityService(
             config=self._config,
             repository=self.repository,
@@ -143,7 +143,7 @@ class MetisEngine:
         self.review = ReviewService(
             self._config,
             self.repository,
-            get_query_engines=lambda: self.index_context.get_query_engines(),
+            get_query_engines=lambda: self.tools.index.get_query_engines(),
             review_graph_factory=lambda: self._get_review_graph(),
             reachability_service=self.reachability,
             reachability_settings=self.reachability_settings,
@@ -231,10 +231,14 @@ class MetisEngine:
             triage_checkpoint_every=self.triage_checkpoint_every,
             triage_tool_timeout_seconds=self.triage_tool_timeout_seconds,
             normalize_top_k=self._normalize_top_k,
-            create_query_engines=self.index_context.create_query_engines,
+            create_query_engines=self.tools.index.create_query_engines,
             get_plugin_for_extension=self._get_plugin_for_extension,
             usage_hooks=self.usage_runtime.hooks,
         )
+
+    @property
+    def indexing(self):
+        return self.tools.index.indexing
 
     def _get_review_graph(self):
         if self._state.review_graph is None:
@@ -278,7 +282,7 @@ class MetisEngine:
         return self.repository.get_plugin_for_extension(extension)
 
     def ask_question(self, question):
-        qe_code, qe_docs = self.index_context.get_query_engines()
+        qe_code, qe_docs = self.tools.index.get_query_engines()
         logger.info("Querying codebase for your question...")
         req = {
             "question": question,
@@ -297,10 +301,10 @@ class MetisEngine:
         return parsed
 
     def _create_query_engines(self, top_k: int):
-        return self.index_context.create_query_engines(top_k)
+        return self.tools.index.create_query_engines(top_k)
 
     def _init_and_get_query_engines(self):
-        return self.index_context.get_query_engines()
+        return self.tools.index.get_query_engines()
 
     def triage_sarif_payload(
         self,
@@ -351,6 +355,6 @@ class MetisEngine:
         )
 
     def close(self):
-        self.index_context.clear_query_cache()
+        self.tools.index.clear_query_cache()
         self._triage_service.close()
-        self.index_context.close()
+        self.tools.close()

--- a/src/metis/engine/index_context_service.py
+++ b/src/metis/engine/index_context_service.py
@@ -14,6 +14,9 @@ from .runtime import EngineConfig, EngineState
 
 
 class IndexContextService:
+    name = "index"
+    enabled = True
+
     def __init__(
         self,
         config: EngineConfig,

--- a/src/metis/engine/tools/engine.py
+++ b/src/metis/engine/tools/engine.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from ..repository import EngineRepository
+from ..runtime import EngineConfig, EngineState
+from .index import IndexTool, build_index_tool
+
+
+@dataclass(frozen=True, slots=True)
+class EngineTools:
+    index: IndexTool
+
+    def close(self) -> None:
+        self.index.close()
+
+
+def build_engine_tools(
+    config: EngineConfig,
+    state: EngineState,
+    repository: EngineRepository,
+    *,
+    normalize_top_k: Callable[[Any, int], int],
+) -> EngineTools:
+    return EngineTools(
+        index=build_index_tool(
+            config,
+            state,
+            repository,
+            normalize_top_k=normalize_top_k,
+        )
+    )

--- a/src/metis/engine/tools/handle.py
+++ b/src/metis/engine/tools/handle.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from metis.exceptions import ToolDisabledError
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True)
+class ToolHandle(Generic[T]):
+    name: str
+    implementation: T | None
+
+    @property
+    def enabled(self) -> bool:
+        return self.implementation is not None
+
+    def require(self) -> T:
+        if self.implementation is None:
+            raise ToolDisabledError(self.name)
+        return self.implementation
+
+    def close(self) -> None:
+        if self.implementation is None:
+            return
+        close = getattr(self.implementation, "close", None)
+        if callable(close):
+            close()

--- a/src/metis/engine/tools/index.py
+++ b/src/metis/engine/tools/index.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ..index_context_service import IndexContextService
+from ..repository import EngineRepository
+from ..runtime import EngineConfig, EngineState
+from .handle import ToolHandle
+from .selection import INDEX_TOOL, tool_enabled
+
+
+class IndexTool:
+    name = INDEX_TOOL
+
+    def __init__(self, handle: ToolHandle[IndexContextService]):
+        self._handle = handle
+
+    @property
+    def enabled(self) -> bool:
+        return self._handle.enabled
+
+    @property
+    def indexing(self):
+        return self._handle.require().indexing
+
+    def create_query_engines(self, top_k: int):
+        return self._handle.require().create_query_engines(top_k)
+
+    def get_query_engines(self):
+        return self._handle.require().get_query_engines()
+
+    def clear_query_cache(self) -> None:
+        if self.enabled:
+            self._handle.require().clear_query_cache()
+
+    def close(self) -> None:
+        self._handle.close()
+
+
+def build_index_tool(
+    config: EngineConfig,
+    state: EngineState,
+    repository: EngineRepository,
+    *,
+    normalize_top_k: Callable[[Any, int], int],
+) -> IndexTool:
+    if not tool_enabled(config.enabled_tools, INDEX_TOOL):
+        handle: ToolHandle[IndexContextService] = ToolHandle(INDEX_TOOL, None)
+        return IndexTool(handle)
+
+    service = IndexContextService(
+        config,
+        state,
+        repository,
+        normalize_top_k=normalize_top_k,
+    )
+    return IndexTool(ToolHandle(INDEX_TOOL, service))

--- a/src/metis/exceptions.py
+++ b/src/metis/exceptions.py
@@ -23,6 +23,15 @@ class QueryEngineInitError(Exception):
         super().__init__("Failed to initialize query engines.")
 
 
+class ToolDisabledError(Exception):
+    """Exception raised when a disabled engine tool is used."""
+
+    def __init__(self, tool_name: str):
+        super().__init__(
+            f"Tool '{tool_name}' is disabled. Enable it with --tools {tool_name}."
+        )
+
+
 class ParsingError(Exception):
     """Exception raised when parsing fails."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def engine(dummy_backend, dummy_llm):
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
 

--- a/tests/test_engine_chroma.py
+++ b/tests/test_engine_chroma.py
@@ -29,6 +29,7 @@ def test_chroma_backend_indexing(tmp_path):
         "response_mode": "compact",
         "code_embedding_model": "test-code-embed",
         "docs_embedding_model": "test-docs-embed",
+        "enabled_tools": {"index"},
     }
 
     embed = MockEmbedding(embed_dim=8)

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -6,7 +6,11 @@ import tempfile
 import threading
 from unittest.mock import Mock
 from metis.engine import MetisEngine
-from metis.exceptions import PluginNotFoundError, QueryEngineInitError
+from metis.exceptions import (
+    PluginNotFoundError,
+    QueryEngineInitError,
+    ToolDisabledError,
+)
 from metis.usage import UsageRuntime
 
 
@@ -40,6 +44,7 @@ def test_init_and_get_query_engines_raises_on_missing_backend():
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
     with pytest.raises(QueryEngineInitError):
         engine._init_and_get_query_engines()
@@ -98,6 +103,7 @@ def test_init_and_get_query_engines_is_thread_safe():
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
     results = []
@@ -132,6 +138,7 @@ def test_engine_passes_usage_callback_manager_to_embed_models():
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
     assert llm_provider.get_embed_model_code.call_args.kwargs == {
@@ -158,6 +165,7 @@ def test_create_query_engines_passes_usage_callback_manager():
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
     engine._create_query_engines(5)
@@ -189,6 +197,7 @@ def test_review_graph_uses_usage_callbacks(monkeypatch):
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
     captured = {}
@@ -254,6 +263,7 @@ def test_engine_exposes_focused_services_without_compat_aliases():
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
     engine.review.review_code = Mock(return_value=iter([{"file": "a.py"}]))
@@ -263,6 +273,7 @@ def test_engine_exposes_focused_services_without_compat_aliases():
 
     assert engine.repository is not None
     assert engine.index_context is not None
+    assert engine.tools.index is engine.index_context
     assert engine.review is not None
     assert engine.indexing is not None
     assert engine.indexing is engine.index_context.indexing
@@ -290,6 +301,7 @@ def test_close_clears_query_cache_and_closes_backend():
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
     assert engine._init_and_get_query_engines() == ("code-qe", "docs-qe")
@@ -303,3 +315,36 @@ def test_close_clears_query_cache_and_closes_backend():
 
     assert engine._init_and_get_query_engines() == ("code-qe", "docs-qe")
     assert backend.get_query_engines.call_count == 2
+
+
+def test_disabled_index_tool_blocks_required_index_access():
+    backend = Mock()
+    backend.init = Mock()
+    backend.get_query_engines = Mock(return_value=("code-qe", "docs-qe"))
+    backend.close = Mock()
+    llm_provider = Mock()
+    llm_provider.get_embed_model_code.return_value = Mock()
+    llm_provider.get_embed_model_docs.return_value = Mock()
+
+    engine = MetisEngine(
+        vector_backend=backend,
+        llm_provider=llm_provider,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+        enabled_tools=set(),
+    )
+
+    assert engine.tools.index.enabled is False
+    with pytest.raises(ToolDisabledError):
+        engine._init_and_get_query_engines()
+    with pytest.raises(ToolDisabledError):
+        engine.indexing.count_index_items()
+
+    engine.close()
+
+    backend.init.assert_not_called()
+    backend.get_query_engines.assert_not_called()
+    backend.close.assert_not_called()

--- a/tests/test_metisignore.py
+++ b/tests/test_metisignore.py
@@ -18,6 +18,7 @@ def _build_engine(tmp_path, dummy_backend, dummy_llm):
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -183,6 +183,7 @@ def test_index_codebase_records_embedding_usage(tmp_path):
         llama_query_model="gpt-test",
         similarity_top_k=3,
         response_mode="compact",
+        enabled_tools={"index"},
     )
 
     with engine.usage_command("index") as command:


### PR DESCRIPTION
Moves indexing behind the new engine tool boundary: index, ask, and update now use an enabled index tool, while disabled index access fails with ToolDisabledError.