### PR TITLE
refactor(rag): route retrieval through index tool availability

### DIFF
--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -145,6 +145,7 @@ class MetisEngine:
             self.repository,
             get_query_engines=lambda: self.tools.index.get_query_engines(),
             review_graph_factory=lambda: self._get_review_graph(),
+            retrieval_available=lambda: self.tools.index.enabled,
             reachability_service=self.reachability,
             reachability_settings=self.reachability_settings,
         )
@@ -232,6 +233,7 @@ class MetisEngine:
             triage_tool_timeout_seconds=self.triage_tool_timeout_seconds,
             normalize_top_k=self._normalize_top_k,
             create_query_engines=self.tools.index.create_query_engines,
+            retrieval_available=lambda: self.tools.index.enabled,
             get_plugin_for_extension=self._get_plugin_for_extension,
             usage_hooks=self.usage_runtime.hooks,
         )

--- a/src/metis/engine/review_service.py
+++ b/src/metis/engine/review_service.py
@@ -34,6 +34,7 @@ class ReviewService:
         repository: EngineRepository,
         get_query_engines: Callable[[], tuple[Any, Any]],
         review_graph_factory: Callable[[], Any],
+        retrieval_available: Callable[[], bool] | None = None,
         reachability_service=None,
         reachability_settings: dict[str, Any] | None = None,
     ):
@@ -41,6 +42,7 @@ class ReviewService:
         self._repository = repository
         self._get_query_engines = get_query_engines
         self._review_graph_factory = review_graph_factory
+        self._retrieval_available = retrieval_available or (lambda: True)
         self._reachability_backend = (
             ReachabilityReviewBackend(
                 config,
@@ -52,8 +54,22 @@ class ReviewService:
             else None
         )
 
+    def _effective_options(
+        self,
+        options: ReviewOptions | None = None,
+        *,
+        use_retrieval_context: bool | None = None,
+    ) -> ReviewOptions:
+        options = coerce_review_options(
+            options,
+            use_retrieval_context=use_retrieval_context,
+        )
+        if options.use_retrieval_context and not self._retrieval_available():
+            return ReviewOptions(use_retrieval_context=False)
+        return options
+
     def get_code_files(self, options: ReviewOptions | None = None):
-        options = coerce_review_options(options)
+        options = self._effective_options(options)
         return self._repository.get_code_files(
             include_suffixed_sources=not options.use_retrieval_context
         )
@@ -121,7 +137,7 @@ class ReviewService:
         use_retrieval_context: bool | None = None,
         progress_callback=None,
     ):
-        options = coerce_review_options(
+        options = self._effective_options(
             options,
             use_retrieval_context=use_retrieval_context,
         )
@@ -170,7 +186,7 @@ class ReviewService:
         *,
         use_retrieval_context: bool | None = None,
     ):
-        options = coerce_review_options(
+        options = self._effective_options(
             options,
             use_retrieval_context=use_retrieval_context,
         )
@@ -259,7 +275,7 @@ class ReviewService:
         use_retrieval_context: bool | None = None,
         progress_callback=None,
     ) -> Iterator[dict | None]:
-        options = coerce_review_options(
+        options = self._effective_options(
             options,
             use_retrieval_context=use_retrieval_context,
         )
@@ -350,7 +366,7 @@ class ReviewService:
         *,
         use_retrieval_context: bool | None = None,
     ):
-        options = coerce_review_options(
+        options = self._effective_options(
             options,
             use_retrieval_context=use_retrieval_context,
         )

--- a/src/metis/engine/triage_service.py
+++ b/src/metis/engine/triage_service.py
@@ -30,6 +30,7 @@ class TriageService(TriageServiceRuntimeMixin, TriageServiceExecutionMixin):
         normalize_top_k: Callable[[Any, int], int],
         create_query_engines: Callable[[int], tuple[Any, Any]],
         get_plugin_for_extension: Callable[[str], Any],
+        retrieval_available: Callable[[], bool] | None = None,
         usage_hooks: UsageHooks | None = None,
     ):
         self.codebase_path = codebase_path
@@ -42,6 +43,7 @@ class TriageService(TriageServiceRuntimeMixin, TriageServiceExecutionMixin):
         self.triage_tool_timeout_seconds = int(triage_tool_timeout_seconds)
         self._normalize_top_k = normalize_top_k
         self._create_query_engines = create_query_engines
+        self._retrieval_available = retrieval_available or (lambda: True)
         self._get_plugin_for_extension = get_plugin_for_extension
         self._usage_hooks = usage_hooks
 

--- a/src/metis/engine/triage_service_exec.py
+++ b/src/metis/engine/triage_service_exec.py
@@ -20,6 +20,26 @@ logger = logging.getLogger("metis")
 
 
 class TriageServiceExecutionMixin:
+    def _effective_triage_options(
+        self,
+        options: TriageOptions | None = None,
+        *,
+        include_triaged: bool | None = None,
+        use_retrieval_context: bool | None = None,
+    ) -> TriageOptions:
+        options = coerce_triage_options(
+            options,
+            include_triaged=include_triaged,
+            use_retrieval_context=use_retrieval_context,
+        )
+        retrieval_available = getattr(self, "_retrieval_available", lambda: True)
+        if options.use_retrieval_context and not retrieval_available():
+            return TriageOptions(
+                include_triaged=options.include_triaged,
+                use_retrieval_context=False,
+            )
+        return options
+
     def _invoke_callback(self, callback, *args, **kwargs) -> None:
         if not callable(callback):
             return
@@ -210,7 +230,7 @@ class TriageServiceExecutionMixin:
         include_triaged: bool | None = None,
         use_retrieval_context: bool | None = None,
     ) -> dict:
-        options = coerce_triage_options(
+        options = self._effective_triage_options(
             options,
             include_triaged=include_triaged,
             use_retrieval_context=use_retrieval_context,
@@ -251,7 +271,7 @@ class TriageServiceExecutionMixin:
         include_triaged: bool | None = None,
         use_retrieval_context: bool | None = None,
     ) -> str:
-        options = coerce_triage_options(
+        options = self._effective_triage_options(
             options,
             include_triaged=include_triaged,
             use_retrieval_context=use_retrieval_context,

--- a/tests/test_engine_review.py
+++ b/tests/test_engine_review.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from metis.engine import MetisEngine
 from metis.engine.review_validation import (
     parse_review_validation_response,
     rescue_filtered_duplicate_cluster_representatives,
@@ -318,6 +319,32 @@ def test_review_file_default_skips_query_engine_init(engine, monkeypatch, tmp_pa
 
     assert result["reviews"] == []
     engine.vector_backend.get_query_engines.assert_not_called()
+
+
+def test_review_file_disables_retrieval_when_index_tool_disabled(
+    dummy_backend, dummy_llm, monkeypatch, tmp_path
+):
+    sample = tmp_path / "sample.py"
+    sample.write_text("print('hello')\n", encoding="utf-8")
+
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=dummy_backend,
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+        enabled_tools=frozenset(),
+    )
+    dummy_backend.get_query_engines.reset_mock()
+    monkeypatch.setattr(engine, "_get_review_graph", lambda: _DummyReviewGraph(None))
+
+    result = engine.review.review_file(str(sample))
+
+    assert result["reviews"] == []
+    dummy_backend.get_query_engines.assert_not_called()
 
 
 def test_review_patch_default_skips_query_engine_init(engine, monkeypatch, tmp_path):

--- a/tests/test_sarif_triage.py
+++ b/tests/test_sarif_triage.py
@@ -242,6 +242,46 @@ def test_triage_payload_no_index_skips_query_engine_init(engine, monkeypatch):
     assert result["properties"]["metisTriaged"] is True
 
 
+def test_triage_payload_disables_retrieval_when_index_tool_disabled(
+    dummy_backend, dummy_llm, monkeypatch
+):
+    from metis.engine import MetisEngine
+
+    payload = {
+        "version": "2.1.0",
+        "runs": [{"results": [{"message": {"text": "A"}, "ruleId": "R1"}]}],
+    }
+    engine = MetisEngine(
+        codebase_path="./tests/data",
+        vector_backend=dummy_backend,
+        llm_provider=dummy_llm,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        response_mode="compact",
+        enabled_tools=frozenset(),
+    )
+
+    class _DummyGraph:
+        def triage(self, request):
+            assert request["use_retrieval_context"] is False
+            assert request["retriever_code"] is None
+            assert request["retriever_docs"] is None
+            return {"status": "valid", "reason": "confirmed"}
+
+    monkeypatch.setattr(
+        engine._triage_service, "_get_thread_triage_graph", lambda: _DummyGraph()
+    )
+    engine._triage_service.max_workers = 1
+
+    out = engine.triage_sarif_payload(payload)
+
+    result = out["runs"][0]["results"][0]
+    assert result["properties"]["metisTriaged"] is True
+    dummy_backend.get_query_engines.assert_not_called()
+
+
 def test_triage_payload_raises_when_query_engine_init_fails(engine, monkeypatch):
     payload = {
         "version": "2.1.0",


### PR DESCRIPTION
Keep review and triage working without index, and only attach retrieval context when the index tool is enabled.