### PR TITLE
feat(rag): use LangChain retrievers for indexed answers

### DIFF
--- a/src/metis/vector_store/base.py
+++ b/src/metis/vector_store/base.py
@@ -3,6 +3,8 @@
 
 from abc import ABC, abstractmethod
 
+from langchain_core.documents import Document
+
 
 class BaseVectorStore(ABC):
     @abstractmethod
@@ -45,11 +47,6 @@ class BaseVectorStore(ABC):
         return llm_class(**filtered_kwargs)
 
 
-class _Doc:
-    def __init__(self, text: str):
-        self.page_content = text
-
-
 class QueryEngineRetriever:
     """
     Adapter that wraps a LlamaIndex QueryEngine and exposes a
@@ -64,4 +61,4 @@ class QueryEngineRetriever:
         return str(getattr(res, "response", res))
 
     def get_relevant_documents(self, query: str):
-        return [_Doc(self._query_text(query))]
+        return [Document(page_content=self._query_text(query))]

--- a/src/metis/vector_store/chroma_store.py
+++ b/src/metis/vector_store/chroma_store.py
@@ -6,11 +6,13 @@ from threading import RLock
 
 from chromadb import PersistentClient
 from chromadb.config import Settings
-from llama_index.core import StorageContext, VectorStoreIndex
+from llama_index.core import StorageContext
 from llama_index.vector_stores.chroma import ChromaVectorStore
 
 from metis.exceptions import QueryEngineInitError, VectorStoreInitError
-from metis.vector_store.base import BaseVectorStore, QueryEngineRetriever
+from metis.vector_store.base import BaseVectorStore
+from metis.vector_store.retrievers import ChromaCollectionRetriever
+from metis.vector_store.retrievers import QueryAnswerRetriever
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,8 @@ class ChromaStore(BaseVectorStore):
                 )
                 code_collection = client.get_or_create_collection("code")
                 docs_collection = client.get_or_create_collection("docs")
+                self.collection_code = code_collection
+                self.collection_docs = docs_collection
 
                 self.vector_store_code = ChromaVectorStore(
                     chroma_collection=code_collection,
@@ -73,40 +77,27 @@ class ChromaStore(BaseVectorStore):
         callbacks=None,
     ):
         try:
-            index_code = VectorStoreIndex.from_vector_store(
-                self.vector_store_code,
-                storage_context=self.storage_context_code,
-                embed_model=self.embed_model_code,
-                callback_manager=callback_manager,
-            )
-            index_docs = VectorStoreIndex.from_vector_store(
-                self.vector_store_docs,
-                storage_context=self.storage_context_docs,
-                embed_model=self.embed_model_docs,
-                callback_manager=callback_manager,
-            )
-
-            llm_code = self._build_llm(
-                llm_provider,
-                callback_manager=callback_manager,
-                callbacks=callbacks,
-            )
-            llm_docs = self._build_llm(
-                llm_provider,
-                callback_manager=callback_manager,
-                callbacks=callbacks,
-            )
-
             top_k = similarity_top_k or self.query_config.get("similarity_top_k", 5)
-            mode = response_mode or self.query_config.get("response_mode", "compact")
-
-            qe_code = index_code.as_query_engine(
-                llm=llm_code, similarity_top_k=top_k, response_mode=mode
+            chat_model_kwargs = {"callbacks": callbacks} if callbacks else {}
+            retriever_code = QueryAnswerRetriever(
+                ChromaCollectionRetriever(
+                    self.collection_code,
+                    self.embed_model_code,
+                    k=top_k,
+                ),
+                llm_provider,
+                chat_model_kwargs=chat_model_kwargs,
             )
-            qe_docs = index_docs.as_query_engine(
-                llm=llm_docs, similarity_top_k=top_k, response_mode=mode
+            retriever_docs = QueryAnswerRetriever(
+                ChromaCollectionRetriever(
+                    self.collection_docs,
+                    self.embed_model_docs,
+                    k=top_k,
+                ),
+                llm_provider,
+                chat_model_kwargs=chat_model_kwargs,
             )
-            return (QueryEngineRetriever(qe_code), QueryEngineRetriever(qe_docs))
+            return (retriever_code, retriever_docs)
         except Exception as e:
             logger.error(f"Error creating Chroma query engines: {e}")
             raise QueryEngineInitError()
@@ -126,6 +117,8 @@ class ChromaStore(BaseVectorStore):
         for attr in (
             "vector_store_code",
             "vector_store_docs",
+            "collection_code",
+            "collection_docs",
             "storage_context_code",
             "storage_context_docs",
         ):

--- a/src/metis/vector_store/pgvector_store.py
+++ b/src/metis/vector_store/pgvector_store.py
@@ -8,7 +8,8 @@ from metis.exceptions import (
     QueryEngineInitError,
     VectorSchemaError,
 )
-from metis.vector_store.base import BaseVectorStore, QueryEngineRetriever
+from metis.vector_store.base import BaseVectorStore
+from metis.vector_store.retrievers import LlamaIndexNodeRetriever, QueryAnswerRetriever
 from llama_index.vector_stores.postgres import PGVectorStore
 from sqlalchemy.engine.url import make_url
 
@@ -102,28 +103,22 @@ class PGVectorStoreImpl(BaseVectorStore):
                 callback_manager=callback_manager,
             )
 
-            llm_code = self._build_llm(
+            chat_model_kwargs = {"callbacks": callbacks} if callbacks else {}
+            retriever_code = QueryAnswerRetriever(
+                LlamaIndexNodeRetriever(
+                    index_code.as_retriever(similarity_top_k=similarity_top_k)
+                ),
                 llm_provider,
-                callback_manager=callback_manager,
-                callbacks=callbacks,
+                chat_model_kwargs=chat_model_kwargs,
             )
-            llm_docs = self._build_llm(
+            retriever_docs = QueryAnswerRetriever(
+                LlamaIndexNodeRetriever(
+                    index_docs.as_retriever(similarity_top_k=similarity_top_k)
+                ),
                 llm_provider,
-                callback_manager=callback_manager,
-                callbacks=callbacks,
+                chat_model_kwargs=chat_model_kwargs,
             )
-
-            qe_code = index_code.as_query_engine(
-                llm=llm_code,
-                similarity_top_k=similarity_top_k,
-                response_mode=response_mode,
-            )
-            qe_docs = index_docs.as_query_engine(
-                llm=llm_docs,
-                similarity_top_k=similarity_top_k,
-                response_mode=response_mode,
-            )
-            return (QueryEngineRetriever(qe_code), QueryEngineRetriever(qe_docs))
+            return (retriever_code, retriever_docs)
         except Exception as e:
             logger.error(f"Error creating PG query engines: {e}")
             raise QueryEngineInitError()

--- a/src/metis/vector_store/retrievers.py
+++ b/src/metis/vector_store/retrievers.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.documents import Document
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+
+
+class QueryAnswerRetriever:
+    """Adapt raw vector retrieval into the existing query-answer contract."""
+
+    def __init__(
+        self,
+        retriever: Any,
+        llm_provider: Any,
+        *,
+        chat_model_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        self._retriever = retriever
+        self._llm_provider = llm_provider
+        self._chat_model_kwargs = dict(chat_model_kwargs or {})
+
+    def get_relevant_documents(self, query: str) -> list[Document]:
+        answer = self._query_text(query)
+        return [Document(page_content=answer)] if answer else []
+
+    def invoke(self, query: str) -> list[Document]:
+        return self.get_relevant_documents(query)
+
+    def _query_text(self, query: str) -> str:
+        context = self._retrieve_context(query)
+        if not context.strip():
+            return ""
+        chat = self._llm_provider.get_chat_model(**self._chat_model_kwargs)
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You synthesize retrieval results for downstream codebase "
+                    "questions and security review prompts. Use only the retrieved "
+                    "context. Preserve concrete names, files, APIs, behavior, and "
+                    "security-relevant facts. If the context is incomplete, include "
+                    "the relevant facts that are present and state only the specific "
+                    "gap.",
+                ),
+                (
+                    "user",
+                    "Request:\n{query}\n\nRetrieved context:\n{context}\n\n"
+                    "Synthesize the relevant answer or context.",
+                ),
+            ]
+        )
+        return (
+            (prompt | chat | StrOutputParser())
+            .invoke({"query": query, "context": context})
+            .strip()
+        )
+
+    def _retrieve_context(self, query: str) -> str:
+        documents = _retrieve_documents(self._retriever, query)
+        return "\n\n".join(
+            getattr(document, "page_content", str(document))
+            for document in (documents or [])
+        )
+
+
+class ChromaCollectionRetriever:
+    def __init__(self, collection: Any, embed_model: Any, *, k: int):
+        self._collection = collection
+        self._embed_model = embed_model
+        self._k = k
+
+    def get_relevant_documents(self, query: str) -> list[Document]:
+        embedding = _embed_query(self._embed_model, query)
+        result = self._collection.query(
+            query_embeddings=[embedding],
+            n_results=self._k,
+            include=["documents", "metadatas"],
+        )
+        documents = _first_result_list(result.get("documents"))
+        metadatas = _first_result_list(result.get("metadatas"))
+        out: list[Document] = []
+        for idx, text in enumerate(documents):
+            if not text:
+                continue
+            metadata = metadatas[idx] if idx < len(metadatas) else {}
+            out.append(
+                Document(
+                    page_content=str(text),
+                    metadata=metadata if isinstance(metadata, dict) else {},
+                )
+            )
+        return out
+
+    def invoke(self, query: str) -> list[Document]:
+        return self.get_relevant_documents(query)
+
+
+class LlamaIndexNodeRetriever:
+    def __init__(self, retriever: Any):
+        self._retriever = retriever
+
+    def get_relevant_documents(self, query: str) -> list[Document]:
+        nodes = self._retriever.retrieve(query)
+        return [_document_from_node(node) for node in nodes or []]
+
+    def invoke(self, query: str) -> list[Document]:
+        return self.get_relevant_documents(query)
+
+
+def _retrieve_documents(retriever: Any, query: str):
+    get_relevant_documents = getattr(retriever, "get_relevant_documents", None)
+    if callable(get_relevant_documents):
+        return get_relevant_documents(query)
+    invoke = getattr(retriever, "invoke", None)
+    if callable(invoke):
+        return invoke(query)
+    retrieve = getattr(retriever, "retrieve", None)
+    if callable(retrieve):
+        return retrieve(query)
+    return []
+
+
+def _embed_query(embed_model: Any, query: str) -> list[float]:
+    get_query_embedding = getattr(embed_model, "get_query_embedding", None)
+    if callable(get_query_embedding):
+        return list(get_query_embedding(query))
+    embed_query = getattr(embed_model, "embed_query", None)
+    if callable(embed_query):
+        return list(embed_query(query))
+    raise TypeError("Embedding model does not support query embeddings.")
+
+
+def _first_result_list(value: Any) -> list[Any]:
+    if not value:
+        return []
+    if isinstance(value, list) and value and isinstance(value[0], list):
+        return list(value[0])
+    if isinstance(value, list):
+        return list(value)
+    return []
+
+
+def _document_from_node(node: Any) -> Document:
+    source = getattr(node, "node", node)
+    get_content = getattr(source, "get_content", None)
+    if callable(get_content):
+        text = str(get_content())
+    else:
+        text = str(getattr(source, "text", source))
+    metadata = getattr(source, "metadata", None)
+    return Document(
+        page_content=text,
+        metadata=metadata if isinstance(metadata, dict) else {},
+    )

--- a/tests/test_vector_store_retrievers.py
+++ b/tests/test_vector_store_retrievers.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from langchain_core.documents import Document
+from langchain_core.runnables import RunnableLambda
+
+from metis.vector_store.retrievers import ChromaCollectionRetriever
+from metis.vector_store.retrievers import QueryAnswerRetriever
+
+
+class _FakeProvider:
+    def __init__(self):
+        self.kwargs = None
+
+    def get_chat_model(self, **kwargs):
+        self.kwargs = kwargs
+        return RunnableLambda(lambda _prompt: "synthesized answer")
+
+
+def test_query_answer_retriever_returns_synthesized_single_document():
+    class _RawRetriever:
+        def get_relevant_documents(self, query):
+            assert query == "what is this?"
+            return [
+                Document(page_content="chunk one"),
+                Document(page_content="chunk two"),
+            ]
+
+    provider = _FakeProvider()
+    retriever = QueryAnswerRetriever(
+        _RawRetriever(),
+        provider,
+        chat_model_kwargs={"callbacks": ["cb"]},
+    )
+
+    docs = retriever.get_relevant_documents("what is this?")
+
+    assert [doc.page_content for doc in docs] == ["synthesized answer"]
+    assert provider.kwargs == {"callbacks": ["cb"]}
+
+
+def test_query_answer_retriever_returns_no_document_without_context():
+    class _RawRetriever:
+        def get_relevant_documents(self, _query):
+            return []
+
+    retriever = QueryAnswerRetriever(_RawRetriever(), _FakeProvider())
+
+    assert retriever.get_relevant_documents("missing") == []
+
+
+def test_chroma_collection_retriever_queries_collection_with_embedding():
+    class _Embedding:
+        def get_query_embedding(self, query):
+            assert query == "lookup"
+            return [1.0, 2.0]
+
+    class _Collection:
+        def __init__(self):
+            self.query_kwargs = None
+
+        def query(self, **kwargs):
+            self.query_kwargs = kwargs
+            return {
+                "documents": [["code chunk"]],
+                "metadatas": [[{"file_name": "a.py"}]],
+            }
+
+    collection = _Collection()
+    retriever = ChromaCollectionRetriever(collection, _Embedding(), k=3)
+
+    docs = retriever.get_relevant_documents("lookup")
+
+    assert docs == [Document(page_content="code chunk", metadata={"file_name": "a.py"})]
+    assert collection.query_kwargs == {
+        "query_embeddings": [[1.0, 2.0]],
+        "n_results": 3,
+        "include": ["documents", "metadatas"],
+    }


### PR DESCRIPTION
Replace query-engine adapters with LangChain retriever wrappers for code and docs retrieval.