### PR TITLE
refactor(indexing): move vector writes behind backend interface

### DIFF
--- a/src/metis/engine/indexing_service.py
+++ b/src/metis/engine/indexing_service.py
@@ -7,7 +7,7 @@ import logging
 import os
 
 import unidiff
-from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
+from llama_index.core import SimpleDirectoryReader
 from llama_index.core.schema import Document
 
 from metis.exceptions import ParsingError
@@ -134,20 +134,11 @@ class IndexingService:
         if not pending:
             return
         nodes_code, nodes_docs = pending
-        storage_context_code, storage_context_docs = (
-            self._config.vector_backend.get_storage_contexts()
-        )
-        VectorStoreIndex(
+        self._config.vector_backend.index_nodes(
             nodes_code,
-            storage_context=storage_context_code,
-            embed_model=self._config.embed_model_code,
-            **self._config.usage_runtime.hooks.embed_model_kwargs(),
-        )
-
-        VectorStoreIndex(
             nodes_docs,
-            storage_context=storage_context_docs,
-            embed_model=self._config.embed_model_docs,
+            embed_model_code=self._config.embed_model_code,
+            embed_model_docs=self._config.embed_model_docs,
             **self._config.usage_runtime.hooks.embed_model_kwargs(),
         )
         self._state.pending_nodes = None
@@ -159,20 +150,10 @@ class IndexingService:
         except Exception as e:
             raise ParsingError(f"Error parsing patch string: {e}")
         self._config.vector_backend.init()
-        storage_context_code, storage_context_docs = (
-            self._config.vector_backend.get_storage_contexts()
-        )
 
-        index_code = VectorStoreIndex.from_vector_store(
-            self._config.vector_backend.vector_store_code,
-            storage_context=storage_context_code,
-            embed_model=self._config.embed_model_code,
-            **self._config.usage_runtime.hooks.embed_model_kwargs(),
-        )
-        index_docs = VectorStoreIndex.from_vector_store(
-            self._config.vector_backend.vector_store_docs,
-            storage_context=storage_context_docs,
-            embed_model=self._config.embed_model_docs,
+        index_code, index_docs = self._config.vector_backend.get_index_handles(
+            embed_model_code=self._config.embed_model_code,
+            embed_model_docs=self._config.embed_model_docs,
             **self._config.usage_runtime.hooks.embed_model_kwargs(),
         )
 

--- a/src/metis/vector_store/base.py
+++ b/src/metis/vector_store/base.py
@@ -22,8 +22,27 @@ class BaseVectorStore(ABC):
         pass
 
     @abstractmethod
-    def get_storage_contexts(self):
-        """Return tuple of storage contexts (code, docs) for indexing."""
+    def index_nodes(
+        self,
+        nodes_code,
+        nodes_docs,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        """Write prepared code and docs nodes to the vector backend."""
+        pass
+
+    @abstractmethod
+    def get_index_handles(
+        self,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        """Return mutable index handles (code, docs) for patch updates."""
         pass
 
     def close(self):

--- a/src/metis/vector_store/chroma_store.py
+++ b/src/metis/vector_store/chroma_store.py
@@ -6,7 +6,7 @@ from threading import RLock
 
 from chromadb import PersistentClient
 from chromadb.config import Settings
-from llama_index.core import StorageContext
+from llama_index.core import StorageContext, VectorStoreIndex
 from llama_index.vector_stores.chroma import ChromaVectorStore
 
 from metis.exceptions import RetrieverInitError, VectorStoreInitError
@@ -120,6 +120,49 @@ class ChromaStore(BaseVectorStore):
         docs_collection = self._client.get_or_create_collection("docs")
         self._set_collections(code_collection, docs_collection)
         logger.info("Chroma vector collections reset.")
+
+    def index_nodes(
+        self,
+        nodes_code,
+        nodes_docs,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        VectorStoreIndex(
+            nodes_code,
+            storage_context=self.storage_context_code,
+            embed_model=embed_model_code,
+            **embed_model_kwargs,
+        )
+        VectorStoreIndex(
+            nodes_docs,
+            storage_context=self.storage_context_docs,
+            embed_model=embed_model_docs,
+            **embed_model_kwargs,
+        )
+
+    def get_index_handles(
+        self,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        index_code = VectorStoreIndex.from_vector_store(
+            self.vector_store_code,
+            storage_context=self.storage_context_code,
+            embed_model=embed_model_code,
+            **embed_model_kwargs,
+        )
+        index_docs = VectorStoreIndex.from_vector_store(
+            self.vector_store_docs,
+            storage_context=self.storage_context_docs,
+            embed_model=embed_model_docs,
+            **embed_model_kwargs,
+        )
+        return index_code, index_docs
 
     def get_storage_contexts(self):
         return self.storage_context_code, self.storage_context_docs

--- a/src/metis/vector_store/pgvector_store.py
+++ b/src/metis/vector_store/pgvector_store.py
@@ -123,6 +123,49 @@ class PGVectorStoreImpl(BaseVectorStore):
             logger.error(f"Error creating PG retrievers: {e}")
             raise RetrieverInitError()
 
+    def index_nodes(
+        self,
+        nodes_code,
+        nodes_docs,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        VectorStoreIndex(
+            nodes_code,
+            storage_context=self.storage_context_code,
+            embed_model=embed_model_code,
+            **embed_model_kwargs,
+        )
+        VectorStoreIndex(
+            nodes_docs,
+            storage_context=self.storage_context_docs,
+            embed_model=embed_model_docs,
+            **embed_model_kwargs,
+        )
+
+    def get_index_handles(
+        self,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        index_code = VectorStoreIndex.from_vector_store(
+            self.vector_store_code,
+            storage_context=self.storage_context_code,
+            embed_model=embed_model_code,
+            **embed_model_kwargs,
+        )
+        index_docs = VectorStoreIndex.from_vector_store(
+            self.vector_store_docs,
+            storage_context=self.storage_context_docs,
+            embed_model=embed_model_docs,
+            **embed_model_kwargs,
+        )
+        return index_code, index_docs
+
     def get_storage_contexts(self):
         return self.storage_context_code, self.storage_context_docs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,8 @@ def dummy_backend():
     backend.get_storage_contexts = Mock(
         return_value=(mock_storage_context, mock_storage_context)
     )
+    backend.index_nodes = Mock()
+    backend.get_index_handles = Mock(return_value=(Mock(), Mock()))
     backend.vector_store_code = mock_vector_store
     backend.vector_store_docs = mock_vector_store
 

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -280,6 +280,7 @@ def test_index_prepare_nodes_resets_backend_index_when_supported(monkeypatch):
     backend.init = Mock()
     backend.reset_index = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
+
     llm_provider = Mock()
     llm_provider.get_embed_model_code.return_value = Mock()
     llm_provider.get_embed_model_docs.return_value = Mock()
@@ -308,7 +309,39 @@ def test_index_prepare_nodes_resets_backend_index_when_supported(monkeypatch):
     backend.reset_index.assert_called_once()
 
 
-def test_close_clears_query_cache_and_closes_backend():
+def test_index_finalize_embeddings_delegates_node_writes_to_backend():
+    backend = Mock()
+    backend.init = Mock()
+    backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
+    backend.index_nodes = Mock()
+    llm_provider = Mock()
+    llm_provider.get_embed_model_code.return_value = Mock()
+    llm_provider.get_embed_model_docs.return_value = Mock()
+
+    engine = MetisEngine(
+        vector_backend=backend,
+        llm_provider=llm_provider,
+        max_workers=2,
+        max_token_length=2048,
+        llama_query_model="gpt-test",
+        similarity_top_k=3,
+        enabled_tools={"index"},
+    )
+    engine._state.pending_nodes = (["code-node"], ["docs-node"])
+
+    engine.indexing.index_finalize_embeddings()
+
+    backend.index_nodes.assert_called_once_with(
+        ["code-node"],
+        ["docs-node"],
+        embed_model_code=engine.get_embed_model_code(),
+        embed_model_docs=engine.get_embed_model_docs(),
+        callback_manager=engine.usage_runtime.hooks.callback_manager,
+    )
+    assert engine._state.pending_nodes is None
+
+
+def test_close_clears_retriever_cache_and_closes_backend():
     backend = Mock()
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from unittest.mock import Mock
 
-from llama_index.core import StorageContext
+from llama_index.core import StorageContext, VectorStoreIndex
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.vector_stores import SimpleVectorStore
 
@@ -146,6 +146,49 @@ class _DummyIndexBackend:
 
     def get_storage_contexts(self):
         return self.storage_context_code, self.storage_context_docs
+
+    def index_nodes(
+        self,
+        nodes_code,
+        nodes_docs,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        VectorStoreIndex(
+            nodes_code,
+            storage_context=self.storage_context_code,
+            embed_model=embed_model_code,
+            **embed_model_kwargs,
+        )
+        VectorStoreIndex(
+            nodes_docs,
+            storage_context=self.storage_context_docs,
+            embed_model=embed_model_docs,
+            **embed_model_kwargs,
+        )
+
+    def get_index_handles(
+        self,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        index_code = VectorStoreIndex.from_vector_store(
+            self.storage_context_code.vector_store,
+            storage_context=self.storage_context_code,
+            embed_model=embed_model_code,
+            **embed_model_kwargs,
+        )
+        index_docs = VectorStoreIndex.from_vector_store(
+            self.storage_context_docs.vector_store,
+            storage_context=self.storage_context_docs,
+            embed_model=embed_model_docs,
+            **embed_model_kwargs,
+        )
+        return index_code, index_docs
 
     def get_retrievers(self, *args, **kwargs):
         return ("code-retriever", "docs-retriever")


### PR DESCRIPTION
Moves full and patch index writes into vector backends so indexing no longer reaches into Chroma-specific internals.