### PR TITLE
refactor(providers): share LangChain embedding adapter

### DIFF
--- a/src/metis/providers/azure_openai.py
+++ b/src/metis/providers/azure_openai.py
@@ -9,7 +9,6 @@ import logging
 from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings
 from langchain_core.callbacks import Callbacks
 from pydantic import SecretStr
-from llama_index.core.base.embeddings.base import BaseEmbedding, Embedding
 from llama_index.core.callbacks import CallbackManager
 
 from metis.providers.base import (
@@ -17,44 +16,10 @@ from metis.providers.base import (
     ChatModelOptions,
     LLMProvider,
 )
+from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 from metis.providers.registry import register_provider
 
 logger = logging.getLogger(__name__)
-
-
-class AzureOpenAIEmbeddingAdapter(BaseEmbedding):
-    """Use LangChain's Azure embeddings client behind LlamaIndex's interface."""
-
-    _client: AzureOpenAIEmbeddings
-
-    def __init__(
-        self,
-        client: AzureOpenAIEmbeddings,
-        callback_manager: CallbackManager | None = None,
-    ) -> None:
-        if callback_manager is None:
-            super().__init__(model_name=client.model)
-        else:
-            super().__init__(model_name=client.model, callback_manager=callback_manager)
-        self._client = client
-
-    def _get_query_embedding(self, query: str) -> Embedding:
-        return self._client.embed_query(query)
-
-    async def _aget_query_embedding(self, query: str) -> Embedding:
-        return await self._client.aembed_query(query)
-
-    def _get_text_embedding(self, text: str) -> Embedding:
-        return self._client.embed_query(text)
-
-    async def _aget_text_embedding(self, text: str) -> Embedding:
-        return await self._client.aembed_query(text)
-
-    def _get_text_embeddings(self, texts: list[str]) -> list[Embedding]:
-        return self._client.embed_documents(texts)
-
-    async def _aget_text_embeddings(self, texts: list[str]) -> list[Embedding]:
-        return await self._client.aembed_documents(texts)
 
 
 class AzureOpenAIProvider(LLMProvider):
@@ -94,23 +59,25 @@ class AzureOpenAIProvider(LLMProvider):
 
     def get_embed_model_code(
         self, *, callback_manager: CallbackManager | None = None
-    ) -> AzureOpenAIEmbeddingAdapter:
-        return AzureOpenAIEmbeddingAdapter(
+    ) -> LangChainEmbeddingAdapter:
+        return LangChainEmbeddingAdapter(
             self._build_embeddings_client(
                 model=self.code_embedding_model,
                 deployment=self.code_embedding_deployment,
             ),
+            model_name=self.code_embedding_model,
             callback_manager=callback_manager,
         )
 
     def get_embed_model_docs(
         self, *, callback_manager: CallbackManager | None = None
-    ) -> AzureOpenAIEmbeddingAdapter:
-        return AzureOpenAIEmbeddingAdapter(
+    ) -> LangChainEmbeddingAdapter:
+        return LangChainEmbeddingAdapter(
             self._build_embeddings_client(
                 model=self.docs_embedding_model,
                 deployment=self.docs_embedding_deployment,
             ),
+            model_name=self.docs_embedding_model,
             callback_manager=callback_manager,
         )
 

--- a/src/metis/providers/embedding_adapter.py
+++ b/src/metis/providers/embedding_adapter.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from langchain_core.embeddings import Embeddings
+from llama_index.core.base.embeddings.base import BaseEmbedding, Embedding
+from llama_index.core.callbacks import CallbackManager
+
+
+class LangChainEmbeddingAdapter(BaseEmbedding):
+    """Expose a LangChain embeddings client through LlamaIndex's embedding API."""
+
+    _client: Embeddings
+
+    def __init__(
+        self,
+        client: Embeddings,
+        *,
+        model_name: str,
+        callback_manager: CallbackManager | None = None,
+    ) -> None:
+        if callback_manager is None:
+            super().__init__(model_name=model_name)
+        else:
+            super().__init__(model_name=model_name, callback_manager=callback_manager)
+        self._client = client
+
+    def _get_query_embedding(self, query: str) -> Embedding:
+        return self._client.embed_query(query)
+
+    async def _aget_query_embedding(self, query: str) -> Embedding:
+        return await self._client.aembed_query(query)
+
+    def _get_text_embedding(self, text: str) -> Embedding:
+        return self._client.embed_query(text)
+
+    async def _aget_text_embedding(self, text: str) -> Embedding:
+        return await self._client.aembed_query(text)
+
+    def _get_text_embeddings(self, texts: list[str]) -> list[Embedding]:
+        return self._client.embed_documents(texts)
+
+    async def _aget_text_embeddings(self, texts: list[str]) -> list[Embedding]:
+        return await self._client.aembed_documents(texts)

--- a/src/metis/providers/openai_compatible.py
+++ b/src/metis/providers/openai_compatible.py
@@ -5,21 +5,17 @@ from __future__ import annotations
 
 from typing import Any, Unpack, cast
 
-from langchain_openai import ChatOpenAI
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_core.callbacks import Callbacks
-from llama_index.embeddings.openai import (
-    OpenAIEmbedding,
-    OpenAIEmbeddingModelType,
-)
 from llama_index.core.callbacks import CallbackManager
+from pydantic import SecretStr
 
 from metis.providers.base import (
     ChatModelOptions,
     LLMProvider,
     OpenAICompatibleProviderConfig,
 )
-
-_ALLOWED_OPENAI_EMBED_MODELS = {member.value for member in OpenAIEmbeddingModelType}
+from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 
 
 class OpenAICompatibleProvider(LLMProvider):
@@ -71,7 +67,7 @@ class OpenAICompatibleProvider(LLMProvider):
 
     def get_embed_model_code(
         self, *, callback_manager: CallbackManager | None = None
-    ) -> OpenAIEmbedding:
+    ) -> LangChainEmbeddingAdapter:
         return self._build_embedding_model(
             self.code_embedding_model,
             self.code_embedding_extra_kwargs,
@@ -81,7 +77,7 @@ class OpenAICompatibleProvider(LLMProvider):
 
     def get_embed_model_docs(
         self, *, callback_manager: CallbackManager | None = None
-    ) -> OpenAIEmbedding:
+    ) -> LangChainEmbeddingAdapter:
         return self._build_embedding_model(
             self.docs_embedding_model,
             self.docs_embedding_extra_kwargs,
@@ -95,33 +91,26 @@ class OpenAICompatibleProvider(LLMProvider):
         extra_kwargs: dict[str, object],
         config_key: str,
         callback_manager: CallbackManager | None = None,
-    ) -> OpenAIEmbedding:
+    ) -> LangChainEmbeddingAdapter:
         if not model_name:
             raise ValueError(f"Missing '{config_key}' in configuration")
 
-        params: dict[str, object] = {}
-        params["model"] = (
-            model_name
-            if model_name in _ALLOWED_OPENAI_EMBED_MODELS
-            else OpenAIEmbeddingModelType.TEXT_EMBED_ADA_002.value
-        )
+        params: dict[str, object] = {"model": model_name}
         if self.api_key:
-            params["api_key"] = self.api_key
+            params["api_key"] = SecretStr(self.api_key)
         if self.base_url:
-            params["api_base"] = self.base_url
+            params["base_url"] = self.base_url
         if self.default_headers:
             params["default_headers"] = self.default_headers
-        if callback_manager is not None:
-            params["callback_manager"] = callback_manager
         if extra_kwargs:
             params.update(extra_kwargs)
 
-        embed = OpenAIEmbedding(**cast(dict[str, Any], params))
-        if model_name not in _ALLOWED_OPENAI_EMBED_MODELS:
-            embed._query_engine = model_name
-            embed._text_engine = model_name
-            embed.model_name = model_name
-        return embed
+        client = OpenAIEmbeddings(**cast(dict[str, Any], params))
+        return LangChainEmbeddingAdapter(
+            client,
+            model_name=model_name,
+            callback_manager=callback_manager,
+        )
 
     def get_chat_model(
         self,

--- a/tests/test_llamacpp_provider.py
+++ b/tests/test_llamacpp_provider.py
@@ -4,8 +4,8 @@
 from typing import cast
 
 from langchain_openai import ChatOpenAI
-from llama_index.embeddings.openai import OpenAIEmbedding
 from metis.providers.base import OpenAICompatibleProviderConfig
+from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 
 from metis.providers.llamacpp import LlamaCppProvider
 
@@ -101,22 +101,24 @@ def test_reasoning_effort_propagated_to_chat_model() -> None:
     assert llm.reasoning_effort == "high"
 
 
-def test_embed_model_code_returns_openai_embedding() -> None:
+def test_embed_model_code_returns_langchain_embedding_adapter() -> None:
     provider = LlamaCppProvider(_config(llm_api_key="test-key"))
 
     embed = provider.get_embed_model_code()
 
-    assert isinstance(embed, OpenAIEmbedding)
+    assert isinstance(embed, LangChainEmbeddingAdapter)
     assert embed.model_name == "nomic-embed-text:v1.5"
+    assert embed._client.model == "nomic-embed-text:v1.5"
 
 
-def test_embed_model_docs_returns_openai_embedding() -> None:
+def test_embed_model_docs_returns_langchain_embedding_adapter() -> None:
     provider = LlamaCppProvider(_config(llm_api_key="test-key"))
 
     embed = provider.get_embed_model_docs()
 
-    assert isinstance(embed, OpenAIEmbedding)
+    assert isinstance(embed, LangChainEmbeddingAdapter)
     assert embed.model_name == "nomic-embed-text:v1.5"
+    assert embed._client.model == "nomic-embed-text:v1.5"
 
 
 def test_lazy_loader_is_registered() -> None:


### PR DESCRIPTION
Use LangChain embedding clients behind one LlamaIndex-compatible adapter.