### PR TITLE
refactor(providers): clean up chat and embedding configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 .python-version
 uv.lock
 results/
+/local-tests/
+/metis.local.yaml
+/metis.local.yml

--- a/docs/providers/adding-new-provider.md
+++ b/docs/providers/adding-new-provider.md
@@ -1,126 +1,144 @@
-# Adding a New LLM Provider
+# Adding a New Provider
 
-Metis discovers providers through `src/metis/providers/registry.py`. Each provider module registers itself via `register_provider()` so the CLI can instantiate it based on `llm_provider.name` (and optionally `embedding_provider.name`) in `metis.yaml`.
+Metis has separate provider surfaces for chat and embeddings. Chat providers
+implement `ChatProvider`; embedding providers implement `EmbeddingProvider`.
+A backend can support one or both, but each surface has its own entry point
+and configuration spec.
 
 ## Provider Types
 
-### Option 1: `OpenAICompatibleProvider` (recommended)
+### OpenAI-Compatible Providers
 
-For backends exposing OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/embeddings`), inherit from `OpenAICompatibleProvider` in `src/metis/providers/openai_compatible.py`. It handles chat models, embeddings, and reasoning effort.
-
-**Examples:** [ollama.py](../../src/metis/providers/ollama.py), [vllm.py](../../src/metis/providers/vllm.py), [llamacpp.py](../../src/metis/providers/llamacpp.py)
-
-```python
-from metis.providers.openai_compatible import OpenAICompatibleProvider
-from metis.providers.registry import register_provider
-
-class MyProvider(OpenAICompatibleProvider):
-    def __init__(self, config):
-        super().__init__(
-            config,
-            default_base_url="http://localhost:9000/v1",
-            default_api_key="sk-placeholder",
-        )
-
-register_provider("my_provider", MyProvider)
-```
-
-### Option 2: `LLMProvider` (for non-OpenAI backends)
-
-For backends with a different API, inherit directly from `LLMProvider` (abstract base in `src/metis/providers/base.py`). Implement three methods:
-
-| Method | Returns | Purpose |
-|--------|---------|---------|
-| `get_chat_model()` | `BaseChatModel` | LangChain chat model |
-| `get_embed_model_code()` | `BaseEmbedding` | Code embeddings for vector store |
-| `get_embed_model_docs()` | `BaseEmbedding` | Docs embeddings for vector store |
-
-Defer validation to the method that needs it: check chat-model config in `get_chat_model()`, embedding config in `get_embed_model_*()`. The same provider class may be instantiated for chat only (via `llm_provider`) or embeddings only (via `embedding_provider`), so `__init__` should not require both. Wrap your LangChain `Embeddings` client in `LangChainEmbeddingAdapter` to satisfy the LlamaIndex `BaseEmbedding` return type.
-
-If the backend's models may reject `temperature`, gate it behind a `supports_temperature` config flag (default `False`) and drop the kwarg when unset.
-
-**Examples:** [azure_openai.py](../../src/metis/providers/azure_openai.py), [bedrock.py](../../src/metis/providers/bedrock.py), [gemini.py](../../src/metis/providers/gemini.py)
-
-## Required Registration
-
-You must update **three locations**:
-
-### 1. `registry.py` — lazy loader
-
-Add at the bottom of `src/metis/providers/registry.py`:
+For backends exposing OpenAI-compatible endpoints, reuse the shared base
+classes in `src/metis/providers/openai_compatible.py`:
 
 ```python
-register_provider_loader("my_provider", "metis.providers.my_provider:MyProvider")
+from metis.providers.config import ApiKeySources, ProviderConfigSpec
+from metis.providers.openai_compatible import OpenAICompatibleChatProvider
+from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
+
+
+class MyProvider(OpenAICompatibleChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="My Provider",
+        required_keys=("base_url", "model"),
+        api_key=ApiKeySources(required=True, env_vars=("MY_PROVIDER_API_KEY",)),
+        copy_keys=("base_url", "default_headers", "model"),
+    )
+
+
+class MyEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="My Provider embeddings",
+        required_keys=("base_url", "code_embedding_model", "docs_embedding_model"),
+        api_key=ApiKeySources(required=True, env_vars=("MY_PROVIDER_API_KEY",)),
+        copy_keys=(
+            "base_url",
+            "default_headers",
+            "code_embedding_model",
+            "docs_embedding_model",
+            "code_extra_kwargs",
+            "docs_extra_kwargs",
+        ),
+    )
+
 ```
 
-### 2. `configuration.py` — config validation + runtime wiring
+Examples: `openai.py`, `ollama.py`, `vllm.py`, `llamacpp.py`.
 
-Add entries to these dicts:
+### Provider-Specific APIs
 
-```python
-_LLM_PROVIDER_DISPLAY_NAMES["my_provider"] = "My Provider"
+For non-OpenAI APIs, implement the relevant interface directly:
 
-# Chat-side keys (validated at config load)
-_LLM_PROVIDER_REQUIRED_KEYS["my_provider"] = ("model",)
+| Interface | Required method | Purpose |
+| --- | --- | --- |
+| `ChatProvider` | `get_chat_model()` | Return a LangChain chat model. |
+| `EmbeddingProvider` | `get_embed_model_code()` / `get_embed_model_docs()` | Return LlamaIndex-compatible embeddings. |
 
-# Embedding-side keys (validated only when the index tool is enabled)
-_EMBEDDING_PROVIDER_REQUIRED_KEYS["my_provider"] = (
-    "code_embedding_model",
-    "docs_embedding_model",
-)
+Wrap LangChain `Embeddings` clients with `LangChainEmbeddingAdapter` so they
+match the LlamaIndex `BaseEmbedding` API used by the vector store.
 
-_LLM_PROVIDER_API_KEY_SOURCES["my_provider"] = {
-    "required": True,
-    "config_keys": (),
-    "config_env_keys": (),
-    "env_vars": ("MY_PROVIDER_API_KEY",),
-}
+Examples: `azure_openai.py`, `bedrock.py`, `gemini.py`, `bedrock_mantle.py`.
+
+## Configuration Specs
+
+Each provider class owns its config contract through `CONFIG_SPEC`.
+`configuration.py` reads that spec, resolves API keys, validates required
+keys, and returns the provider-specific runtime config.
+
+Use `ProviderConfigSpec` for:
+
+- `display_name`: provider name used in error messages.
+- `required_keys`: keys required in the relevant config block.
+- `api_key`: where credentials can be read from.
+- `copy_keys`: config keys copied into the provider runtime config. Use a tuple
+  for direct copies, or a mapping only when a runtime key needs alternate
+  source keys.
+
+Do not add provider-specific branches to `configuration.py` unless the config
+shape cannot be expressed with `ProviderConfigSpec`.
+
+## Discovery
+
+Providers are discovered from the `metis.providers` entry point group. Built-in
+providers declare those entry points in `pyproject.toml`; third-party provider
+packages can expose the same group.
+
+Entry point names use `<provider>.<surface>`, where `<surface>` is `chat` or
+`embedding`:
+
+```toml
+entry-points."metis.providers"."my_provider.chat" = "my_package.providers:MyProvider"
+entry-points."metis.providers"."my_provider.embedding" = "my_package.providers:MyEmbeddingProvider"
 ```
 
-Then add a branch in `_build_provider_runtime()` — the trailing `else` raises `ValueError` for unknown providers:
+Only register the surfaces the backend actually supports. Chat-only providers
+must not declare an embedding entry point. Provider modules should not register
+themselves at import time; the registry discovers entry point values without
+importing provider modules and caches the class when the provider is first
+requested.
 
-```python
-elif provider_name == "my_provider":
-    runtime["llm_api_key"] = api_key
-    runtime["openai_api_base"] = cfg.get("base_url", "")
-    runtime["openai_default_headers"] = cfg.get("default_headers", {})
-    runtime["model"] = cfg.get("model", "")
+## User Configuration
+
+Chat config goes under `llm_provider`; embedding config goes under the
+top-level `embedding_provider` block:
+
+```yaml
+llm_provider:
+  name: "my_provider"
+  base_url: "https://example.test/v1"
+  model: "chat-model"
+  api_key_env: "MY_PROVIDER_API_KEY"
+
+embedding_provider:
+  name: "my_provider"
+  base_url: "https://example.test/v1"
+  code_embedding_model: "embedding-model"
+  docs_embedding_model: "embedding-model"
+  api_key_env: "MY_PROVIDER_API_KEY"
 ```
 
-This branch is called for both `llm_provider` and `embedding_provider` blocks, so it must tolerate either set of keys being absent.
-
-### 3. Your provider module — `register_provider()` call
-
-Your module **must** call `register_provider()` at module level (the lazy loader imports the module, which triggers this registration).
+Embedding config is only required when the `index` tool is enabled.
 
 ## Dependencies
 
-If the provider needs packages outside the base install, add an `optional-dependencies.<provider>` extra in `pyproject.toml` and list it in `optional-dependencies.all-providers`. The lazy loader converts `ModuleNotFoundError` into a clear "required dependencies are missing" error. Guard the provider's tests with `pytest.importorskip("<package>")` so a base-only CI run skips them.
-
-## Configuration
-
-Provider-specific config keys go under `llm_provider:` (and/or `embedding_provider:`) in `metis.yaml`. Common keys used by `OpenAICompatibleProvider`:
-
-| Key | Example |
-|-----|---------|
-| `name` | `"my_provider"` |
-| `model` | `"llama3.1:8b"` |
-| `base_url` | `"http://localhost:9000/v1"` |
-| `code_embedding_model` | `"nomic-embed-text"` |
-| `docs_embedding_model` | `"nomic-embed-text"` |
-| `default_headers` | `{"X-Custom": "value"}` |
-
-Query-level settings (`model`, `temperature`, `max_tokens`, `reasoning_effort`) go under `query:` in `metis.yaml` and override `llm_provider:` values.
+If the provider needs packages outside the base install, add an
+`optional-dependencies.<provider>` extra in `pyproject.toml` and include it in
+`optional-dependencies.all-providers`. Guard provider tests with
+`pytest.importorskip("<package>")` when a base-only CI run should skip them.
 
 ## Testing
 
 Cover these in `tests/test_<provider>.py`:
 
-- Instantiation with valid config
-- `get_chat_model()` raises on missing chat config; `get_embed_model_*()` raises on missing embedding config
-- Chat model construction (class type, base_url, reasoning_effort)
-- `supports_temperature` gates the `temperature` kwarg
-- Embedding model construction
-- Lazy loader registration (verify `_LOADERS` entry and `get_provider()` resolution)
+- Valid config builds the expected LangChain/LlamaIndex objects.
+- Missing required chat keys fail through config validation.
+- Missing required embedding keys fail when `build_embedding_provider_config()`
+  is called.
+- API key precedence works for explicit `api_key`, `api_key_env`, and provider
+  default env vars.
+- Entry point discovery resolves the provider class.
 
-See `tests/test_bedrock_provider.py` and `tests/test_configuration.py` for examples.
+Keep private live-provider smoke tests local under ignored paths such as
+`local-tests/`. Store credentials in ignored `.env` files or environment
+variables, never in committed YAML.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1,7 +1,7 @@
 # Anthropic Provider
 
 Metis can use Anthropic Claude models, including Claude Opus, for chat, review,
-and triage. Indexing still requires an OpenAI-compatible embedding model because
+and triage. Indexing still requires a separate `embedding_provider` because
 Anthropic does not provide the embedding interface Metis uses.
 
 ## Install
@@ -17,7 +17,7 @@ Add or adjust the `llm_provider` block in your `metis.yaml`:
 ```yaml
 llm_provider:
   name: "anthropic"
-  model: "opus"
+  model: "<claude-model-id>"
   api_key_env: "ANTHROPIC_API_KEY"
 
 # Optional — only needed when the index tool is enabled.
@@ -34,20 +34,11 @@ query:
   temperature: 0.0
 ```
 
-- `model` can be an exact Claude model ID or one of Metis' short aliases.
-- Short aliases map to Claude API model aliases as follows:
-  - `opus` -> `claude-opus-4-8`
-  - `sonnet` -> `claude-sonnet-4-6`
-  - `haiku` -> `claude-haiku-4-5`
-  - `fable` -> `claude-fable-5`
-  - `mythos` -> `claude-mythos-5`
-- You can still use an exact Claude model ID when you need stricter version
-  control.
+- `model` must be a Claude model ID accepted by the Anthropic API.
 - The Anthropic API key is resolved from `llm_provider.api_key`, then
   `llm_provider.api_key_env`, then `ANTHROPIC_API_KEY`.
 - Embeddings can be supplied via a separate `embedding_provider` block (any
-  supported provider). The legacy `llm_provider.embedding_api_key` /
-  `embedding_api_key_env` keys still work for OpenAI-compatible embeddings.
+  supported embedding provider).
 - Embedding configuration is only required when the `index` tool is enabled
   (`--tools index`). It can be omitted entirely for chat/review/triage
   without retrieval.

--- a/docs/providers/azure_openai.md
+++ b/docs/providers/azure_openai.md
@@ -1,0 +1,56 @@
+# Azure OpenAI Provider
+
+Metis uses LangChain's Azure integrations for Azure OpenAI chat and
+embeddings. Chat and embeddings are configured separately so a chat deployment
+does not need to carry embedding settings.
+
+## Configuration
+
+```yaml
+llm_provider:
+  name: "azure_openai"
+  azure_endpoint: "https://<resource>.openai.azure.com/"
+  azure_api_version: "2024-12-01-preview"
+  engine: "<chat-deployment-name>"
+  chat_deployment_model: "<chat-model-name>"
+
+embedding_provider:
+  name: "azure_openai"
+  azure_endpoint: "https://<resource>.openai.azure.com/"
+  azure_api_version: "2024-02-01"
+  code_embedding_model: "text-embedding-3-small"
+  docs_embedding_model: "text-embedding-3-small"
+  code_deployment: "<embedding-deployment-name>"
+  docs_deployment: "<embedding-deployment-name>"
+
+metis_engine:
+  embed_dim: 1536
+```
+
+The Azure OpenAI API key is resolved from `api_key`, then `api_key_env`, then
+`AZURE_OPENAI_API_KEY`.
+
+## Chat APIs
+
+By default Metis uses `AzureChatOpenAI` through the chat completions surface.
+If a deployment should use Azure's Responses API, opt in explicitly:
+
+```yaml
+llm_provider:
+  name: "azure_openai"
+  azure_endpoint: "https://<resource>.openai.azure.com/"
+  azure_api_version: "2025-04-01-preview"
+  engine: "<chat-deployment-name>"
+  chat_deployment_model: "<chat-model-name>"
+  use_responses_api: true
+```
+
+Keep the `azure_api_version` aligned with the API surface your Azure
+deployment supports.
+
+## Embeddings
+
+Azure embeddings use `AzureOpenAIEmbeddings`. Azure needs both the model name
+and deployment name; deployments can be named differently from the underlying
+model. Set `metis_engine.embed_dim` to the vector size returned by the
+embedding deployment.

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -17,6 +17,10 @@ llm_provider:
   name: "bedrock"
   region: "us-east-1"
   model: "us.anthropic.claude-opus-4-8-v1:0"
+
+embedding_provider:
+  name: "bedrock"
+  region: "us-east-1"
   code_embedding_model: "amazon.titan-embed-text-v2:0"
   docs_embedding_model: "amazon.titan-embed-text-v2:0"
 ```
@@ -24,7 +28,7 @@ llm_provider:
 | Key                     | Required | Notes                                                              |
 | ----------------------- | -------- | ------------------------------------------------------------------ |
 | `region`                | yes      | Bedrock region (e.g. `us-east-1`).                                 |
-| `model`                 | yes      | Bedrock model or inference-profile ID.                             |
+| `model`                 | yes²     | Bedrock chat model or inference-profile ID.                        |
 | `code_embedding_model`  | yes¹     | Bedrock embedding model ID for code indexing.                      |
 | `docs_embedding_model`  | yes¹     | Bedrock embedding model ID for docs indexing.                      |
 | `aws_profile`           | no       | Named profile from `~/.aws/credentials`.                           |
@@ -34,7 +38,8 @@ llm_provider:
 | `endpoint_url`          | no       | Override Bedrock endpoint (e.g. VPC interface endpoint).           |
 | `supports_temperature`  | no       | Set `true` only if the target model accepts `temperature`.         |
 
-¹ Only required when the `index` engine tool is enabled.
+¹ Only required under `embedding_provider` when the `index` engine tool is enabled.
+² Only required under `llm_provider`.
 
 ## Credentials
 

--- a/docs/providers/embedding-provider.md
+++ b/docs/providers/embedding-provider.md
@@ -5,14 +5,14 @@ engine tool must be opted into via `--tools index` or
 `metis_engine.tools: [index]`). Embedding configuration is therefore
 optional unless you enable indexing.
 
-By default Metis uses the `llm_provider` for both chat and embeddings.
-To mix providers — e.g. Anthropic Claude for chat and OpenAI for
-embeddings — add a separate `embedding_provider` block:
+Embeddings are configured explicitly under a top-level `embedding_provider`
+block. This keeps chat-only providers such as Anthropic, Gemini, and Bedrock
+Mantle from needing embedding credentials or embedding model settings.
 
 ```yaml
 llm_provider:
   name: "anthropic"
-  model: "opus"
+  model: "<claude-model-id>"
 
 embedding_provider:
   name: "openai"
@@ -24,15 +24,17 @@ metis_engine:
   tools: [index]
 ```
 
-The `embedding_provider` block accepts the same keys as `llm_provider`
-for the chosen `name` (API key, base URL, region, etc.); only the
-embedding-related keys are required. If `embedding_provider` is omitted,
-embedding settings are read from `llm_provider` for backwards
-compatibility.
+The `embedding_provider` block uses the embedding provider's own config keys.
+For OpenAI-compatible providers (`openai`, `ollama`, `llamacpp`, `vllm`) use
+`code_embedding_model` and `docs_embedding_model`. Azure OpenAI also requires
+`code_deployment` and `docs_deployment`. Bedrock requires `region` and any
+AWS credential settings needed by your environment.
 
 When the `index` tool is enabled, Metis validates the embedding
-configuration at startup and fails fast if `code_embedding_model` /
-`docs_embedding_model` (and any provider-specific keys such as
-`region` for Bedrock or deployments for Azure) are missing. When the
-tool is disabled, the check is skipped and chat/review/triage run
-without an embedding model.
+configuration at startup and fails fast if `code_embedding_model` / `docs_embedding_model`
+or any provider-specific keys are missing. When the tool is disabled, the
+check is skipped and chat/review/triage run without an embedding model.
+
+Keep live credentials out of committed config. For local smoke tests, put
+provider YAMLs and any `.env` file under ignored local paths such as
+`local-tests/` and `.env`.

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -1,7 +1,8 @@
 # Gemini Provider
 
-Metis can use Google Gemini models for chat, review, and triage, with native
-Gemini embeddings for indexing.
+Metis can use Google Gemini models for chat, review, and triage. Gemini is
+currently a chat-only provider in Metis; use a separate `embedding_provider`
+when enabling the `index` tool.
 
 ## Install
 
@@ -18,8 +19,12 @@ llm_provider:
   name: "gemini"
   model: "gemini-2.5-flash"
   api_key_env: "GOOGLE_API_KEY"
-  code_embedding_model: "gemini-embedding-001"
-  docs_embedding_model: "gemini-embedding-001"
+
+# Optional — only needed when the index tool is enabled.
+embedding_provider:
+  name: "openai"
+  code_embedding_model: "text-embedding-3-large"
+  docs_embedding_model: "text-embedding-3-large"
 
 metis_engine:
   embed_dim: 3072
@@ -32,13 +37,10 @@ query:
 - `model` is passed directly to the Gemini API. Use an exact Gemini model ID.
 - The Gemini API key is resolved from `llm_provider.api_key`, then
   `llm_provider.api_key_env`, then `GOOGLE_API_KEY`, then `GEMINI_API_KEY`.
-- The same API key is used for Gemini chat and Gemini embeddings.
-- `code_embedding_model` and `docs_embedding_model` are native Gemini embedding
-  model names.
-- `metis_engine.embed_dim` must match the configured embedding model output
-  dimension. You can set `output_dimensionality` through
-  `code_embedding_extra_kwargs` and `docs_embedding_extra_kwargs` when using a
-  reduced embedding size.
+- Configure embeddings separately through `embedding_provider` if you enable
+  the `index` tool.
+- `metis_engine.embed_dim` must match the configured embedding provider output
+  dimension.
 - `query.reasoning_effort` values `minimal`, `low`, `medium`, and `high` are
   forwarded as Gemini `thinking_level`.
 
@@ -49,8 +51,6 @@ llm_provider:
   name: "gemini"
   model: "gemini-2.5-flash"
   api_key_env: "GOOGLE_API_KEY"
-  code_embedding_model: "gemini-embedding-001"
-  docs_embedding_model: "gemini-embedding-001"
   base_url: "https://example.test/gemini"
   additional_headers:
     X-Custom-Header: "value"

--- a/docs/providers/llamacpp.md
+++ b/docs/providers/llamacpp.md
@@ -40,13 +40,18 @@ llm_provider:
   name: "llamacpp"
   base_url: "http://localhost:8080/v1"
   model: "Llama3.1-8B"
+
+embedding_provider:
+  name: "llamacpp"
+  base_url: "http://localhost:8080/v1"
   code_embedding_model: "nomic-embed-text-v1.5"
   docs_embedding_model: "nomic-embed-text-v1.5"
 ```
 
 - `base_url` defaults to `http://localhost:8080/v1` if not configured.
 - `name` must be `"llamacpp"` (case-insensitive).
-- `model` is required. `code_embedding_model` / `docs_embedding_model` are only required when the `index` tool is enabled.
+- `model` is required under `llm_provider`. `code_embedding_model` / `docs_embedding_model` are
+  only required under `embedding_provider` when the `index` tool is enabled.
 - An API key is **not required** by the llama.cpp server; Metis uses a placeholder by default.
 
 ## Metis usage

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -30,6 +30,10 @@ llm_provider:
   name: "ollama"
   base_url: "http://localhost:11434/v1"
   model: "llama3.1:8b"
+
+embedding_provider:
+  name: "ollama"
+  base_url: "http://localhost:11434/v1"
   code_embedding_model: "nomic-embed-text:v1.5"
   docs_embedding_model: "nomic-embed-text:v1.5"
 ```

--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -110,6 +110,10 @@ llm_provider:
   name: "vllm"
   base_url: "http://${LLM_HOST_IP}:8888/v1"
   model: "<chat-model-id>"
+
+embedding_provider:
+  name: "vllm"
+  base_url: "http://${LLM_HOST_IP}:8888/v1"
   code_embedding_model: "<embedding-model-id>"
   docs_embedding_model: "<embedding-model-id>"
 

--- a/examples/azure_openai/config.yaml
+++ b/examples/azure_openai/config.yaml
@@ -1,19 +1,22 @@
+# Full metis.yaml example for Azure OpenAI chat plus Azure OpenAI embeddings.
 llm_provider:
   name: "azure_openai"
-
   azure_endpoint: "https://my-metis-eu.openai.azure.com/"
-  azure_api_version: "2024-02-15-preview"
-
+  azure_api_version: "2024-12-01-preview"
   engine: "gpt-4o-mini"
   chat_deployment_model: "gpt-4o-mini"
-
-  code_embedding_model: "text-embedding-3-large"
-  code_embedding_deployment: "text-embedding-3-large"
-  docs_embedding_model: "text-embedding-3-large"
-  docs_embedding_deployment: "text-embedding-3-large"
-
-  llama_query_temperature: 0.0
-  llama_query_max_tokens: 512
-
-  model_token_param: "max_completion_tokens"
   supports_temperature: false
+
+# Optional — only needed when the index tool is enabled.
+embedding_provider:
+  name: "azure_openai"
+  azure_endpoint: "https://my-metis-eu.openai.azure.com/"
+  azure_api_version: "2024-02-01"
+  code_embedding_model: "text-embedding-3-small"
+  docs_embedding_model: "text-embedding-3-small"
+  code_deployment: "text-embedding-3-small"
+  docs_deployment: "text-embedding-3-small"
+
+query:
+  temperature: 0.0
+  max_tokens: 512

--- a/examples/bedrock/metis_bedrock_example.yaml
+++ b/examples/bedrock/metis_bedrock_example.yaml
@@ -17,14 +17,19 @@ llm_provider:
   region: "us-east-1"
   # Anthropic Claude via Bedrock (use an inference-profile ID where required)
   model: "us.anthropic.claude-opus-4-8-v1:0"
-  code_embedding_model: "amazon.titan-embed-text-v2:0"
-  docs_embedding_model: "amazon.titan-embed-text-v2:0"
 
   # Credentials — all optional. If omitted, the boto3 default chain is used
   # (AWS_PROFILE / AWS_ACCESS_KEY_ID env vars, ~/.aws/credentials, IAM role).
   # aws_profile: "default"
   # aws_access_key_id: "..."
   # aws_secret_access_key: "..."
+
+# Optional — only needed when the index tool is enabled.
+embedding_provider:
+  name: "bedrock"
+  region: "us-east-1"
+  code_embedding_model: "amazon.titan-embed-text-v2:0"
+  docs_embedding_model: "amazon.titan-embed-text-v2:0"
 
 query:
   similarity_top_k: 5

--- a/examples/gemini/metis_gemini_example.yaml
+++ b/examples/gemini/metis_gemini_example.yaml
@@ -2,8 +2,12 @@ llm_provider:
   name: "gemini"
   model: "gemini-2.5-flash"
   api_key_env: "GOOGLE_API_KEY"
-  code_embedding_model: "gemini-embedding-001"
-  docs_embedding_model: "gemini-embedding-001"
+
+# Optional — only needed when the index tool is enabled.
+embedding_provider:
+  name: "openai"
+  code_embedding_model: "text-embedding-3-large"
+  docs_embedding_model: "text-embedding-3-large"
 
 metis_engine:
   embed_dim: 3072

--- a/examples/llamacpp/metis_llamacpp_example.yaml
+++ b/examples/llamacpp/metis_llamacpp_example.yaml
@@ -27,6 +27,11 @@ llm_provider:
   model: "Llama3.1-8B" # for 8GB system
 #  model: "Qwen3.5-9B" # for 16GB system
 #  model: "Qwen3.6-35B-A3B" # for 24GB system
+
+# Optional — only needed when the index tool is enabled.
+embedding_provider:
+  name: "llamacpp"
+  base_url: "http://localhost:8080/v1"
   code_embedding_model: "nomic-embed-text-v1.5"
   docs_embedding_model: "nomic-embed-text-v1.5"
 

--- a/examples/ollama/metis_ollama_example.yaml
+++ b/examples/ollama/metis_ollama_example.yaml
@@ -27,6 +27,11 @@ llm_provider:
   model: "llama3.1:8b" # for 8GB system
 #  model: "qwen3.5:9b" # for 16GB system
 #  model: "qwen3.6:35b-a3b" # for 24GB system
+
+# Optional — only needed when the index tool is enabled.
+embedding_provider:
+  name: "ollama"
+  base_url: "http://localhost:11434/v1"
   code_embedding_model: "nomic-embed-text:v1.5"
   docs_embedding_model: "nomic-embed-text:v1.5"
 

--- a/examples/vllm/metis_vllm_example.yaml
+++ b/examples/vllm/metis_vllm_example.yaml
@@ -24,6 +24,11 @@ llm_provider:
   name: "vllm"
   base_url: "http://YOUR-OLLAMA-HOST:8888/v1"
   model: "YOUR-CHAT-MODEL"
+
+# Optional — only needed when the index tool is enabled.
+embedding_provider:
+  name: "vllm"
+  base_url: "http://YOUR-OLLAMA-HOST:8888/v1"
   code_embedding_model: "YOUR-EMBEDDING-MODEL"
   docs_embedding_model: "YOUR-EMBEDDING-MODEL"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ optional-dependencies.all-providers = [
 ]
 optional-dependencies.anthropic = [
   "langchain-anthropic>=1.4.3",
+  "llama-index-llms-langchain>=0.8.0",
 ]
 optional-dependencies.azure = []
 optional-dependencies.bedrock = [
@@ -47,6 +48,7 @@ optional-dependencies.bedrock-mantle = [
   "anthropic[aws]>=0.74.0",
   "boto3>=1.34.0",
   "langchain-anthropic>=1.4.3",
+  "llama-index-llms-langchain>=0.8.0",
 ]
 optional-dependencies.dev = [
   "metis[all-providers]",
@@ -83,6 +85,21 @@ entry-points."metis.plugins".tablegen = "metis.plugins.tb_plugin:TableGenPlugin"
 entry-points."metis.plugins".terraform = "metis.plugins.terraform_plugin:TerraformPlugin"
 entry-points."metis.plugins".typescript = "metis.plugins.typescript_plugin:TypeScriptPlugin"
 entry-points."metis.plugins".verilog = "metis.plugins.verilog_plugin:VerilogPlugin"
+entry-points."metis.providers"."anthropic.chat" = "metis.providers.anthropic:AnthropicProvider"
+entry-points."metis.providers"."azure_openai.chat" = "metis.providers.azure_openai:AzureOpenAIProvider"
+entry-points."metis.providers"."azure_openai.embedding" = "metis.providers.azure_openai:AzureOpenAIEmbeddingProvider"
+entry-points."metis.providers"."bedrock.chat" = "metis.providers.bedrock:BedrockProvider"
+entry-points."metis.providers"."bedrock.embedding" = "metis.providers.bedrock:BedrockEmbeddingProvider"
+entry-points."metis.providers"."bedrock_mantle.chat" = "metis.providers.bedrock_mantle:BedrockMantleProvider"
+entry-points."metis.providers"."gemini.chat" = "metis.providers.gemini:GeminiProvider"
+entry-points."metis.providers"."llamacpp.chat" = "metis.providers.llamacpp:LlamaCppProvider"
+entry-points."metis.providers"."llamacpp.embedding" = "metis.providers.llamacpp:LlamaCppEmbeddingProvider"
+entry-points."metis.providers"."ollama.chat" = "metis.providers.ollama:OllamaProvider"
+entry-points."metis.providers"."ollama.embedding" = "metis.providers.ollama:OllamaEmbeddingProvider"
+entry-points."metis.providers"."openai.chat" = "metis.providers.openai:OpenAIProvider"
+entry-points."metis.providers"."openai.embedding" = "metis.providers.openai:OpenAIEmbeddingProvider"
+entry-points."metis.providers"."vllm.chat" = "metis.providers.vllm:VLLMProvider"
+entry-points."metis.providers"."vllm.embedding" = "metis.providers.vllm:VLLMEmbeddingProvider"
 
 [tool.setuptools]
 include-package-data = true

--- a/src/metis/chat_model_options.py
+++ b/src/metis/chat_model_options.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def merge_chat_model_kwargs(
+    *sources: Mapping[str, Any] | None,
+    model: Any = None,
+    callbacks: Any = None,
+    reasoning_effort: Any = None,
+    response_format: Any = None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    for source in sources:
+        if source:
+            kwargs.update(source)
+    if model is not None:
+        kwargs["model"] = model
+    if callbacks is not None:
+        kwargs["callbacks"] = callbacks
+    if response_format is not None:
+        kwargs["response_format"] = response_format
+    if reasoning_effort is not None:
+        kwargs["reasoning_effort"] = reasoning_effort
+    return {key: value for key, value in kwargs.items() if value is not None}

--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -11,13 +11,13 @@ from rich.markup import escape
 from prompt_toolkit import prompt
 from prompt_toolkit.history import InMemoryHistory
 
-from metis.configuration import load_runtime_config, validate_embedding_provider_config
+from metis.configuration import build_embedding_provider_config, load_runtime_config
 from metis.engine import MetisEngine
 from metis.engine.tools.selection import INDEX_TOOL, parse_engine_tools, tool_enabled
 from metis.usage import UsageRuntime
 from metis.utils import read_file_content
-from metis.providers.registry import get_provider
-from metis.providers.base import ProviderRuntimeConfig
+from metis.providers.registry import get_chat_provider
+from metis.providers.registry import get_embedding_provider
 
 try:
     from metis.vector_store.pgvector_store import PGVectorStoreImpl
@@ -94,12 +94,31 @@ def build_engine(args, runtime):
     if getattr(args, "enabled_tools", None) is None:
         _configure_enabled_tools(args, runtime)
     runtime["enabled_tools"] = _enabled_tools_for_args(args)
+    engine_runtime = dict(runtime)
 
-    llm_provider_name = runtime.get("llm_provider_name", "openai")
-    provider_cls = get_provider(llm_provider_name)
-    llm_provider = provider_cls(cast(ProviderRuntimeConfig, runtime))
+    llm_provider_name = runtime.get("llm_provider_name")
+    if not llm_provider_name:
+        raise RuntimeError("llm_provider configuration is required.")
+    llm_provider_name = str(llm_provider_name)
+    chat_provider_cls = get_chat_provider(llm_provider_name)
+    llm_provider = chat_provider_cls(cast(dict, runtime["llm_provider"]))
+    engine_runtime.pop("llm_provider_name", None)
+    engine_runtime.pop("llm_provider", None)
 
-    embedding_provider = _build_embedding_provider(args, runtime, llm_provider)
+    embedding_provider = None
+    if tool_enabled(runtime["enabled_tools"], INDEX_TOOL):
+        embedding_provider_config = build_embedding_provider_config(
+            cast(dict | None, runtime.get("embedding_provider_raw_config"))
+        )
+        if embedding_provider_config is None:
+            raise RuntimeError("Index tool requires embedding_provider configuration.")
+        embedding_provider_cls = get_embedding_provider(
+            str(embedding_provider_config["name"])
+        )
+        embedding_provider = embedding_provider_cls(
+            cast(dict, embedding_provider_config)
+        )
+    engine_runtime.pop("embedding_provider_raw_config", None)
 
     usage_runtime = UsageRuntime(args.codebase_path)
 
@@ -115,38 +134,9 @@ def build_engine(args, runtime):
         vector_backend=vector_backend,
         custom_prompt_text=resolve_custom_prompt(args),
         usage_runtime=usage_runtime,
-        **runtime,
+        **engine_runtime,
     )
     return engine, vector_backend
-
-
-def _build_embedding_provider(args, runtime, llm_provider):
-    enabled_tools = runtime.get("enabled_tools") or set()
-    index_enabled = tool_enabled(enabled_tools, INDEX_TOOL)
-
-    embed_name = runtime.get("embedding_provider_name")
-    embed_runtime = runtime.get("embedding_provider_config") or {}
-    embed_raw = runtime.get("embedding_provider_raw_config") or {}
-    same_as_llm = embed_name == runtime.get("llm_provider_name")
-    section = "llm_provider" if same_as_llm else "embedding_provider"
-
-    if index_enabled:
-        validate_embedding_provider_config(embed_name, embed_raw, section=section)
-    elif not same_as_llm:
-        try:
-            validate_embedding_provider_config(embed_name, embed_raw, section=section)
-        except ValueError as exc:
-            print_console(
-                f"[yellow]Warning:[/yellow] {escape(str(exc))} "
-                "(index tool disabled; embeddings will fail if requested.)",
-                args.quiet,
-            )
-
-    if same_as_llm:
-        return llm_provider
-
-    embed_cls = get_provider(embed_name)
-    return embed_cls(cast(ProviderRuntimeConfig, embed_runtime))
 
 
 def finalize_cli_session(engine, args):

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -25,6 +25,7 @@ from rich.progress import (
 from metis.engine.options import ReviewOptions
 from .exporters import export_csv, export_html, export_sarif
 from metis.sarif.utils import create_fingerprint
+from metis.vector_store.retrievers import retriever_query_config
 
 try:
     METIS_VERSION = importlib.metadata.version("metis")
@@ -639,6 +640,7 @@ def build_pg_backend(args, runtime, embed_model_code, embed_model_docs, quiet=Fa
         embed_model_code=embed_model_code,
         embed_model_docs=embed_model_docs,
         embed_dim=runtime["embed_dim"],
+        query_config=retriever_query_config(runtime),
         hnsw_kwargs=runtime.get("hnsw_kwargs", {}),
     )
 
@@ -650,5 +652,5 @@ def build_chroma_backend(args, runtime, embed_model_code, embed_model_docs):
         persist_dir=args.chroma_dir,
         embed_model_code=embed_model_code,
         embed_model_docs=embed_model_docs,
-        query_config=runtime,
+        query_config=retriever_query_config(runtime),
     )

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -1,376 +1,25 @@
 # SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import logging
+import os
+from importlib.resources import as_file
+from importlib.resources import files
+from pathlib import Path
+
 import yaml
 
-from importlib.resources import files, as_file
-from pathlib import Path
-from typing import TypedDict
-
+from metis.providers.config import build_provider_config
+from metis.providers.registry import get_chat_provider
+from metis.providers.registry import get_embedding_provider
 from metis.reachability_settings import collect_reachability_config
 
 logger = logging.getLogger("metis")
 
 
-class _ApiKeySources(TypedDict):
-    required: bool
-    config_keys: tuple[str, ...]
-    config_env_keys: tuple[str, ...]
-    env_vars: tuple[str, ...]
-
-
-_LLM_PROVIDER_DISPLAY_NAMES: dict[str, str] = {
-    "openai": "OpenAI",
-    "azure_openai": "Azure OpenAI",
-    "vllm": "vLLM",
-    "ollama": "Ollama",
-    "anthropic": "Anthropic",
-    "bedrock": "AWS Bedrock",
-    "bedrock_mantle": "Bedrock Mantle",
-    "gemini": "Gemini",
-    "llamacpp": "llama.cpp",
-}
-
-_LLM_PROVIDER_REQUIRED_KEYS: dict[str, tuple[str, ...]] = {
-    "openai": ("model",),
-    "azure_openai": (
-        "azure_endpoint",
-        "azure_api_version",
-        "engine",
-        "chat_deployment_model",
-    ),
-    "vllm": ("base_url", "model"),
-    "ollama": ("model",),
-    "llamacpp": ("model",),
-    "anthropic": ("model",),
-    "bedrock": ("model", "region"),
-    "bedrock_mantle": ("model",),
-    "gemini": ("model",),
-}
-
-_EMBEDDING_PROVIDER_REQUIRED_KEYS: dict[str, tuple[str, ...]] = {
-    "openai": ("code_embedding_model", "docs_embedding_model"),
-    "azure_openai": (
-        "azure_endpoint",
-        "azure_api_version",
-        "code_embedding_model",
-        "docs_embedding_model",
-        "code_embedding_deployment",
-        "docs_embedding_deployment",
-    ),
-    "vllm": ("base_url", "code_embedding_model", "docs_embedding_model"),
-    "ollama": ("code_embedding_model", "docs_embedding_model"),
-    "llamacpp": ("code_embedding_model", "docs_embedding_model"),
-    "anthropic": ("code_embedding_model", "docs_embedding_model"),
-    "bedrock": ("region", "code_embedding_model", "docs_embedding_model"),
-    "bedrock_mantle": ("code_embedding_model", "docs_embedding_model"),
-    "gemini": ("code_embedding_model", "docs_embedding_model"),
-}
-
-_LLM_PROVIDER_API_KEY_SOURCES: dict[str, _ApiKeySources] = {
-    "openai": {
-        "required": True,
-        "config_keys": (),
-        "config_env_keys": (),
-        "env_vars": ("OPENAI_API_KEY",),
-    },
-    "azure_openai": {
-        "required": True,
-        "config_keys": (),
-        "config_env_keys": (),
-        "env_vars": ("AZURE_OPENAI_API_KEY",),
-    },
-    "vllm": {
-        "required": False,
-        "config_keys": ("api_key",),
-        "config_env_keys": ("api_key_env",),
-        "env_vars": ("VLLM_API_KEY",),
-    },
-    "ollama": {
-        "required": False,
-        "config_keys": ("api_key",),
-        "config_env_keys": ("api_key_env",),
-        "env_vars": (),
-    },
-    "anthropic": {
-        "required": True,
-        "config_keys": ("api_key",),
-        "config_env_keys": ("api_key_env",),
-        "env_vars": ("ANTHROPIC_API_KEY",),
-    },
-    "bedrock": {
-        "required": False,
-        "config_keys": (),
-        "config_env_keys": (),
-        "env_vars": (),
-    },
-    "bedrock_mantle": {
-        "required": False,
-        "config_keys": (),
-        "config_env_keys": (),
-        "env_vars": (),
-    },
-    "gemini": {
-        "required": False,
-        "config_keys": ("api_key",),
-        "config_env_keys": ("api_key_env",),
-        "env_vars": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
-    },
-    "llamacpp": {
-        "required": False,
-        "config_keys": ("api_key",),
-        "config_env_keys": ("api_key_env",),
-        "env_vars": ("LLAMACPP_API_KEY",),
-    },
-}
-
-_ANTHROPIC_MODEL_ALIASES = {
-    "opus": "claude-opus-4-8",
-    "sonnet": "claude-sonnet-4-6",
-    "haiku": "claude-haiku-4-5",
-    "fable": "claude-fable-5",
-    "mythos": "claude-mythos-5",
-}
-
-
 def load_yaml(path):
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
-
-
-def _missing_required_keys(config: dict, keys: tuple[str, ...]) -> list[str]:
-    missing = []
-    for key in keys:
-        value = config.get(key)
-        if value is None or (isinstance(value, str) and not value.strip()):
-            missing.append(key)
-    return missing
-
-
-def _validate_provider_config(
-    provider_name: str,
-    provider_config: dict,
-    required_table: dict[str, tuple[str, ...]],
-    section: str,
-) -> None:
-    required_keys = required_table.get(provider_name)
-    if not required_keys:
-        return
-    missing_keys = _missing_required_keys(provider_config, required_keys)
-    if not missing_keys:
-        return
-
-    display_name = _LLM_PROVIDER_DISPLAY_NAMES.get(provider_name, provider_name)
-    missing = ", ".join(f"{section}.{key}" for key in missing_keys)
-    required = ", ".join(f"{section}.{key}" for key in required_keys)
-    raise ValueError(
-        f"{display_name} provider requires additional metis.yaml configuration. "
-        f"Missing: {missing}. Required keys: {required}."
-    )
-
-
-def _validate_llm_provider_config(provider_name: str, provider_config: dict) -> None:
-    _validate_provider_config(
-        provider_name, provider_config, _LLM_PROVIDER_REQUIRED_KEYS, "llm_provider"
-    )
-
-
-def validate_embedding_provider_config(
-    provider_name: str, provider_config: dict, section: str = "embedding_provider"
-) -> None:
-    _validate_provider_config(
-        provider_name, provider_config, _EMBEDDING_PROVIDER_REQUIRED_KEYS, section
-    )
-
-
-def _resolve_llm_api_key(provider_name: str, provider_config: dict) -> str:
-    sources = _LLM_PROVIDER_API_KEY_SOURCES.get(provider_name)
-    if sources is None:
-        return ""
-
-    for config_key in sources["config_keys"]:
-        value = provider_config.get(config_key)
-        if isinstance(value, str) and value.strip():
-            return value
-
-    for config_env_key in sources["config_env_keys"]:
-        env_var = provider_config.get(config_env_key)
-        if isinstance(env_var, str) and env_var.strip():
-            value = os.environ.get(env_var)
-            if value:
-                return value
-
-    for env_var in sources["env_vars"]:
-        value = os.environ.get(env_var)
-        if value:
-            return value
-
-    if sources["required"]:
-        display_name = _LLM_PROVIDER_DISPLAY_NAMES.get(provider_name, provider_name)
-        source_descriptions = [
-            f"{env_var} environment variable" for env_var in sources["env_vars"]
-        ]
-        source_descriptions.extend(
-            f"llm_provider.{key}" for key in sources["config_keys"]
-        )
-        source_descriptions.extend(
-            f"environment variable named by llm_provider.{key}"
-            for key in sources["config_env_keys"]
-        )
-        sources_text = " or ".join(source_descriptions)
-        raise RuntimeError(
-            f"{sources_text} is required for {display_name} provider but not set."
-        )
-
-    return ""
-
-
-def _resolve_anthropic_model_name(model: str | None) -> str:
-    model = str(model or "").strip()
-    normalized = model.lower()
-    resolved = _ANTHROPIC_MODEL_ALIASES.get(normalized, model)
-    if not resolved.startswith("claude-"):
-        aliases = ", ".join(_ANTHROPIC_MODEL_ALIASES)
-        raise ValueError(
-            "Anthropic provider requires an exact Claude model ID or a supported "
-            f"short alias: {aliases}."
-        )
-    return resolved
-
-
-def _build_provider_runtime(provider_name: str, cfg: dict) -> dict[str, object]:
-    """Build the provider-specific portion of the runtime config dict."""
-    runtime: dict[str, object] = {}
-    api_key = _resolve_llm_api_key(provider_name, cfg)
-
-    runtime["code_embedding_model"] = cfg.get("code_embedding_model", "")
-    runtime["docs_embedding_model"] = cfg.get("docs_embedding_model", "")
-    runtime["code_embedding_extra_kwargs"] = cfg.get("code_embedding_extra_kwargs", {})
-    runtime["docs_embedding_extra_kwargs"] = cfg.get("docs_embedding_extra_kwargs", {})
-
-    if not provider_name:
-        raise ValueError(
-            "Provider configuration is missing 'name' (e.g. 'openai', 'anthropic')."
-        )
-    if provider_name == "openai":
-        runtime["llm_api_key"] = api_key
-        runtime["openai_api_base"] = cfg.get("base_url", "")
-        runtime["openai_default_headers"] = cfg.get("default_headers", {})
-        runtime["model"] = cfg.get("model", "")
-    elif provider_name == "azure_openai":
-        runtime["llm_api_key"] = api_key
-        runtime["azure_endpoint"] = cfg.get("azure_endpoint", "")
-        runtime["azure_api_version"] = cfg.get("azure_api_version", "")
-        runtime["engine"] = cfg.get("engine", "")
-        runtime["chat_deployment_model"] = cfg.get("chat_deployment_model", "")
-        runtime["code_embedding_deployment"] = cfg.get("code_embedding_deployment", "")
-        runtime["docs_embedding_deployment"] = cfg.get("docs_embedding_deployment", "")
-        runtime["model_token_param"] = cfg.get(
-            "model_token_param", "max_completion_tokens"
-        )
-        runtime["supports_temperature"] = cfg.get("supports_temperature", False)
-    elif provider_name == "vllm":
-        runtime["llm_api_key"] = api_key
-        runtime["openai_api_base"] = cfg.get("base_url", "")
-        runtime["openai_default_headers"] = cfg.get("default_headers", {})
-        runtime["model"] = cfg.get("model", "")
-    elif provider_name == "ollama":
-        runtime["llm_api_key"] = api_key
-        runtime["openai_api_base"] = cfg.get("base_url", "http://localhost:11434/v1")
-        runtime["openai_default_headers"] = cfg.get("default_headers", {})
-        runtime["model"] = cfg.get("model", "")
-        runtime["force_openai_like"] = True
-    elif provider_name == "anthropic":
-        raw_model = cfg.get("model")
-        model = _resolve_anthropic_model_name(raw_model) if raw_model else ""
-        runtime["llm_api_key"] = api_key
-        runtime["embedding_api_key"] = _resolve_anthropic_embedding_api_key(cfg)
-        runtime["model"] = model
-        runtime["anthropic_api_url"] = cfg.get("base_url") or cfg.get(
-            "anthropic_api_url"
-        )
-        runtime["embedding_api_base"] = cfg.get("embedding_base_url") or cfg.get(
-            "embedding_api_base"
-        )
-        runtime["embedding_default_headers"] = cfg.get("embedding_default_headers", {})
-        runtime["supports_temperature"] = cfg.get("supports_temperature", False)
-    elif provider_name == "bedrock":
-        runtime["llm_api_key"] = api_key
-        runtime["model"] = cfg.get("model", "")
-        runtime["bedrock_region"] = cfg.get("region") or cfg.get("aws_region")
-        runtime["bedrock_endpoint_url"] = cfg.get("endpoint_url", "")
-        runtime["supports_temperature"] = cfg.get("supports_temperature", False)
-        runtime["aws_profile"] = cfg.get("aws_profile", "")
-        runtime["aws_access_key_id"] = cfg.get(
-            "aws_access_key_id", os.environ.get("AWS_ACCESS_KEY_ID", "")
-        )
-        runtime["aws_secret_access_key"] = cfg.get(
-            "aws_secret_access_key", os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-        )
-        runtime["aws_session_token"] = cfg.get(
-            "aws_session_token", os.environ.get("AWS_SESSION_TOKEN", "")
-        )
-    elif provider_name == "bedrock_mantle":
-        runtime["llm_api_key"] = api_key
-        runtime["embedding_api_key"] = _resolve_anthropic_embedding_api_key(cfg)
-        runtime["model"] = cfg.get("model", "")
-        runtime["aws_region"] = cfg.get("aws_region")
-        runtime["aws_profile"] = cfg.get("aws_profile")
-        runtime["aws_access_key_id"] = cfg.get(
-            "aws_access_key_id", os.environ.get("AWS_ACCESS_KEY_ID", "")
-        )
-        runtime["aws_secret_access_key"] = cfg.get(
-            "aws_secret_access_key", os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-        )
-        runtime["aws_session_token"] = cfg.get(
-            "aws_session_token", os.environ.get("AWS_SESSION_TOKEN", "")
-        )
-        runtime["bedrock_base_url"] = cfg.get("base_url") or cfg.get("bedrock_base_url")
-        runtime["default_headers"] = cfg.get("default_headers", {})
-        runtime["supports_temperature"] = cfg.get("supports_temperature", False)
-        runtime["embedding_api_base"] = cfg.get("embedding_base_url") or cfg.get(
-            "embedding_api_base"
-        )
-        runtime["embedding_default_headers"] = cfg.get("embedding_default_headers", {})
-    elif provider_name == "gemini":
-        runtime["llm_api_key"] = api_key
-        runtime["model"] = cfg.get("model", "")
-        runtime["gemini_api_base"] = cfg.get("base_url") or cfg.get("gemini_api_base")
-        runtime["gemini_additional_headers"] = cfg.get(
-            "additional_headers", {}
-        ) or cfg.get("gemini_additional_headers", {})
-        runtime["gemini_project"] = cfg.get("project")
-        runtime["gemini_location"] = cfg.get("location")
-        runtime["gemini_vertexai"] = cfg.get("vertexai")
-        runtime["gemini_client_args"] = cfg.get("client_args", {})
-    elif provider_name == "llamacpp":
-        runtime["llm_api_key"] = api_key
-        runtime["openai_api_base"] = cfg.get("base_url", "")
-        runtime["openai_default_headers"] = cfg.get("default_headers", {})
-        runtime["model"] = cfg.get("model", "")
-    else:
-        raise ValueError(f"Unsupported LLM provider: {provider_name}")
-    return runtime
-
-
-def _resolve_anthropic_embedding_api_key(provider_config: dict) -> str:
-    value = provider_config.get("embedding_api_key")
-    if isinstance(value, str) and value.strip():
-        return value
-
-    env_var = provider_config.get("embedding_api_key_env")
-    if isinstance(env_var, str) and env_var.strip():
-        value = os.environ.get(env_var)
-        if value:
-            return value
-
-    value = os.environ.get("OPENAI_API_KEY")
-    if value:
-        return value
-
-    return ""
 
 
 def load_runtime_config(config_path=None, enable_psql=False):
@@ -401,26 +50,20 @@ def load_runtime_config(config_path=None, enable_psql=False):
             pg_db_name=secrets.get("database_name"),
         )
 
-    llm_cfg = cfg.get("llm_provider", {})
-    llm_provider_name = llm_cfg.get("name", "").lower()
+    llm_cfg = dict(cfg.get("llm_provider") or {})
+    llm_provider_name = str(llm_cfg.get("name", "")).lower()
     runtime["llm_provider_name"] = llm_provider_name
-    _validate_llm_provider_config(llm_provider_name, llm_cfg)
-    runtime.update(_build_provider_runtime(llm_provider_name, llm_cfg))
+    llm_provider_cls = _get_provider_cls(
+        provider_name=llm_provider_name,
+        section="llm_provider",
+    )
+    llm_provider_config = build_provider_config(
+        provider_name=llm_provider_name,
+        provider_cls=llm_provider_cls,
+        raw_config=llm_cfg,
+        section="llm_provider",
+    )
 
-    # Embedding provider — optional separate block; falls back to llm_provider
-    embed_cfg = cfg.get("embedding_provider")
-    if embed_cfg:
-        embed_provider_name = embed_cfg.get("name", llm_provider_name).lower()
-        embed_runtime = _build_provider_runtime(embed_provider_name, embed_cfg)
-    else:
-        embed_provider_name = llm_provider_name
-        embed_cfg = llm_cfg
-        embed_runtime = dict(runtime)
-    runtime["embedding_provider_name"] = embed_provider_name
-    runtime["embedding_provider_config"] = embed_runtime
-    runtime["embedding_provider_raw_config"] = dict(embed_cfg)
-
-    # Engine/vector store settings
     engine_cfg = cfg.get("metis_engine", {})
     runtime["max_token_length"] = engine_cfg.get("max_token_length", 100000)
     runtime["max_workers"] = engine_cfg.get("max_workers", 8)
@@ -450,24 +93,67 @@ def load_runtime_config(config_path=None, enable_psql=False):
     runtime["enabled_tools"] = engine_cfg.get("tools")
     runtime.update(collect_reachability_config(cfg, engine_cfg))
 
-    # Query config
     query_cfg = cfg.get("query", {})
-    llama_query_model = query_cfg.get("model") or runtime.get("model", "")
-    if llm_provider_name == "anthropic":
-        llama_query_model = _resolve_anthropic_model_name(llama_query_model)
+    llama_query_model = query_cfg.get("model") or llm_provider_config.get("model", "")
+    llama_query_model = str(llama_query_model or "")
+    runtime["model"] = llm_provider_config.get("model", "")
     runtime["llama_query_model"] = llama_query_model
-    runtime["llama_query_temperature"] = query_cfg.get("temperature", 0.0)
-    runtime["llama_query_max_tokens"] = query_cfg.get("max_tokens", 3072)
-    runtime["llama_query_reasoning_effort"] = (
-        query_cfg.get("reasoning_effort")
-        or query_cfg.get("reasoning_level")
-        or llm_cfg.get("reasoning_effort")
-        or llm_cfg.get("reasoning_level")
-    )
+    if query_cfg.get("temperature") is not None:
+        runtime["llama_query_temperature"] = query_cfg["temperature"]
+    runtime["llama_query_max_tokens"] = query_cfg.get("max_tokens")
+    runtime["llama_query_reasoning_effort"] = query_cfg.get(
+        "reasoning_effort"
+    ) or llm_cfg.get("reasoning_effort")
     runtime["similarity_top_k"] = query_cfg.get("similarity_top_k", 5)
     runtime["triage_similarity_top_k"] = query_cfg.get("triage_similarity_top_k", 3)
+    chat_model_kwargs: dict[str, object] = {}
+    if runtime.get("llama_query_temperature") is not None:
+        chat_model_kwargs["temperature"] = runtime["llama_query_temperature"]
+    if runtime["llama_query_max_tokens"] is not None:
+        chat_model_kwargs["max_tokens"] = runtime["llama_query_max_tokens"]
+    if runtime["llama_query_reasoning_effort"]:
+        chat_model_kwargs["reasoning_effort"] = runtime["llama_query_reasoning_effort"]
+    runtime["chat_model_kwargs"] = chat_model_kwargs
+    runtime["llm_provider"] = llm_provider_config
+
+    embedding_provider_raw_config = dict(cfg.get("embedding_provider") or {})
+    if not embedding_provider_raw_config:
+        runtime["embedding_provider_raw_config"] = None
+    else:
+        runtime["embedding_provider_raw_config"] = embedding_provider_raw_config
 
     return runtime
+
+
+def build_embedding_provider_config(
+    embedding_provider_config: dict | None,
+) -> dict[str, object] | None:
+    embedding_cfg = dict(embedding_provider_config or {})
+    if not embedding_cfg:
+        return None
+
+    provider_name = str(embedding_cfg.get("name", "")).lower()
+    section = "embedding_provider"
+    provider_cls = _get_provider_cls(
+        provider_name=provider_name,
+        section=section,
+    )
+    config = build_provider_config(
+        provider_name=provider_name,
+        provider_cls=provider_cls,
+        raw_config=embedding_cfg,
+        section="embedding_provider",
+    )
+    return {"name": provider_name, **config}
+
+
+def _get_provider_cls(provider_name: str, section: str) -> type:
+    try:
+        if section == "llm_provider":
+            return get_chat_provider(provider_name)
+        return get_embedding_provider(provider_name)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported {section} provider: {provider_name}") from exc
 
 
 def load_plugin_config(plugins_path: str | Path | None = None):
@@ -513,7 +199,6 @@ def config_path_fallback(
         if not resource.is_file():
             continue
 
-        # ensure we have a real path
         with as_file(resource) as real_path:
             logger.info(f"Loading default {candidate_filename}")
             return load_yaml(real_path)

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -8,6 +8,7 @@ import logging
 from metis.configuration import load_plugin_config
 from metis.exceptions import PluginNotFoundError
 from metis.plugin_loader import discover_supported_language_names, load_plugins
+from metis.chat_model_options import merge_chat_model_kwargs
 from metis.reachability_settings import coerce_reachability_settings
 from metis.usage import UsageRuntime
 from metis.vector_store.base import BaseVectorStore
@@ -59,8 +60,8 @@ class MetisEngine:
             setattr(self, k, kwargs[k])
 
         self.llm_provider = llm_provider
-        self.embedding_provider = embedding_provider or llm_provider
         self.usage_runtime = self._init_usage_runtime(kwargs)
+        self.chat_model_kwargs = dict(kwargs.get("chat_model_kwargs") or {})
         self.doc_chunk_size = kwargs.get("doc_chunk_size", 1024)
         self.doc_chunk_overlap = kwargs.get("doc_chunk_overlap", 200)
         self.triage_similarity_top_k = kwargs.get(
@@ -97,23 +98,19 @@ class MetisEngine:
                 self.code_exts.add(lowered)
                 self.ext_plugin_map[lowered] = plugin
 
-        self._init_embed_models()
-
         self._config = EngineConfig(
             codebase_path=self.codebase_path,
             vector_backend=self.vector_backend,
             llm_provider=self.llm_provider,
+            embedding_provider=embedding_provider,
             usage_runtime=self.usage_runtime,
             plugin_config=self.plugin_config,
             custom_prompt_text=self.custom_prompt_text,
             custom_guidance_precedence=self.custom_guidance_precedence,
-            embed_model_code=self._embed_model_code,
-            embed_model_docs=self._embed_model_docs,
-            engine_get_embed_model_code=self.get_embed_model_code,
-            engine_get_embed_model_docs=self.get_embed_model_docs,
             max_workers=self.max_workers,
             max_token_length=self.max_token_length,
             llama_query_model=self.llama_query_model,
+            chat_model_kwargs=self.chat_model_kwargs,
             similarity_top_k=self.similarity_top_k,
             doc_chunk_size=self.doc_chunk_size,
             doc_chunk_overlap=self.doc_chunk_overlap,
@@ -131,7 +128,6 @@ class MetisEngine:
             self._config,
             self._state,
             self.repository,
-            normalize_top_k=self._normalize_top_k,
         )
         self.index_context = self.tools.index
         self.reachability = TreeSitterReachabilityService(
@@ -152,45 +148,6 @@ class MetisEngine:
 
     def _init_usage_runtime(self, kwargs) -> UsageRuntime:
         return kwargs.get("usage_runtime") or UsageRuntime(self.codebase_path)
-
-    def _attach_embed_models_to_backend(self) -> None:
-        if hasattr(self.vector_backend, "embed_model_code"):
-            self.vector_backend.embed_model_code = self._embed_model_code
-        if hasattr(self.vector_backend, "embed_model_docs"):
-            self.vector_backend.embed_model_docs = self._embed_model_docs
-
-    def _get_backend_embed_model(self, attr: str):
-        if attr in getattr(self.vector_backend, "__dict__", {}):
-            return getattr(self.vector_backend, attr)
-        return None
-
-    def _init_embed_models(self) -> None:
-        self._embed_model_code = self._get_backend_embed_model("embed_model_code")
-        self._embed_model_docs = self._get_backend_embed_model("embed_model_docs")
-        self._attach_embed_models_to_backend()
-
-    def _build_embed_model(self, kind: str):
-        method_name = (
-            "get_embed_model_code" if kind == "code" else "get_embed_model_docs"
-        )
-        method = getattr(self.embedding_provider, method_name)
-        return method(**self.usage_runtime.hooks.embed_model_kwargs())
-
-    def get_embed_model_code(self):
-        if self._embed_model_code is None:
-            self._embed_model_code = self._build_embed_model("code")
-            self._attach_embed_models_to_backend()
-            if hasattr(self, "_config"):
-                self._config.embed_model_code = self._embed_model_code
-        return self._embed_model_code
-
-    def get_embed_model_docs(self):
-        if self._embed_model_docs is None:
-            self._embed_model_docs = self._build_embed_model("docs")
-            self._attach_embed_models_to_backend()
-            if hasattr(self, "_config"):
-                self._config.embed_model_docs = self._embed_model_docs
-        return self._embed_model_docs
 
     def usage_command(
         self,
@@ -221,12 +178,12 @@ class MetisEngine:
             codebase_path=self.codebase_path,
             llm_provider=self.llm_provider,
             llama_query_model=self.llama_query_model,
+            chat_model_kwargs=self.chat_model_kwargs,
             plugin_config=self.plugin_config,
             max_workers=self.max_workers,
             triage_similarity_top_k=self.triage_similarity_top_k,
             triage_checkpoint_every=self.triage_checkpoint_every,
             triage_tool_timeout_seconds=self.triage_tool_timeout_seconds,
-            normalize_top_k=self._normalize_top_k,
             create_retrievers=self.tools.index.create_retrievers,
             get_plugin_for_extension=self._get_plugin_for_extension,
             usage_hooks=self.usage_runtime.hooks,
@@ -245,9 +202,15 @@ class MetisEngine:
                 custom_guidance_precedence=self.custom_guidance_precedence,
                 llama_query_model=self.llama_query_model,
                 max_token_length=self.max_token_length,
-                chat_model_kwargs=self.usage_runtime.hooks.chat_model_kwargs(),
+                chat_model_kwargs=self._chat_model_kwargs(),
             )
         return self._state.review_graph
+
+    def _chat_model_kwargs(self) -> dict:
+        return merge_chat_model_kwargs(
+            self.chat_model_kwargs,
+            self.usage_runtime.hooks.chat_model_kwargs(),
+        )
 
     def _get_ask_graph(self):
         if self._state.ask_graph is None:
@@ -286,15 +249,6 @@ class MetisEngine:
             "retriever_docs": retriever_docs,
         }
         return self._get_ask_graph().ask(req)
-
-    def _normalize_top_k(self, value, default: int) -> int:
-        try:
-            parsed = int(value)
-        except Exception:
-            parsed = default
-        if parsed <= 0:
-            return default
-        return parsed
 
     def _create_retrievers(self, top_k: int):
         return self.tools.index.create_retrievers(top_k)

--- a/src/metis/engine/helpers.py
+++ b/src/metis/engine/helpers.py
@@ -7,14 +7,27 @@ import os
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
+from metis.chat_model_options import merge_chat_model_kwargs
+
 logger = logging.getLogger("metis")
 
 
-def summarize_changes(llm_provider, file_path, issues, summary_prompt, callbacks=None):
+def summarize_changes(
+    llm_provider,
+    file_path,
+    issues,
+    summary_prompt,
+    *,
+    model=None,
+    chat_model_kwargs=None,
+    callbacks=None,
+):
     try:
-        kwargs = {}
-        if callbacks is not None:
-            kwargs["callbacks"] = callbacks
+        kwargs = merge_chat_model_kwargs(
+            chat_model_kwargs,
+            model=model,
+            callbacks=callbacks,
+        )
         chat = llm_provider.get_chat_model(**kwargs)
         prompt_tmpl = ChatPromptTemplate.from_messages(
             [("system", "{system}"), ("user", "{input}")]

--- a/src/metis/engine/index_context_service.py
+++ b/src/metis/engine/index_context_service.py
@@ -3,12 +3,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
 from metis.exceptions import RetrieverInitError
 
 from .indexing_service import IndexingService
+from .options import normalize_top_k
 from .repository import EngineRepository
 from .runtime import EngineConfig, EngineState
 
@@ -22,16 +20,21 @@ class IndexContextService:
         config: EngineConfig,
         state: EngineState,
         repository: EngineRepository,
-        *,
-        normalize_top_k: Callable[[Any, int], int],
     ):
         self._config = config
         self._state = state
-        self._normalize_top_k = normalize_top_k
-        self.indexing = IndexingService(config, state, repository)
+        self._embed_model_code = self._get_backend_embed_model("embed_model_code")
+        self._embed_model_docs = self._get_backend_embed_model("embed_model_docs")
+        self._attach_embed_models_to_backend()
+        self.indexing = IndexingService(
+            config,
+            state,
+            repository,
+            get_embedding_models=self.get_embedding_models,
+        )
 
     def create_retrievers(self, top_k: int):
-        self._ensure_embed_models()
+        self.get_embedding_models()
         self._config.vector_backend.init()
         retriever_code, retriever_docs = self._config.vector_backend.get_retrievers(
             self._config.llm_provider,
@@ -54,7 +57,7 @@ class IndexContextService:
                 and self._state.retriever_docs is not None
             ):
                 return self._state.retriever_code, self._state.retriever_docs
-            top_k = self._normalize_top_k(self._config.similarity_top_k, 5)
+            top_k = normalize_top_k(self._config.similarity_top_k, 5)
             retriever_code, retriever_docs = self.create_retrievers(top_k)
             self._state.retriever_code = retriever_code
             self._state.retriever_docs = retriever_docs
@@ -70,6 +73,31 @@ class IndexContextService:
         if callable(close_fn):
             close_fn()
 
-    def _ensure_embed_models(self) -> None:
-        self._config.embed_model_code = self._config.engine_get_embed_model_code()
-        self._config.embed_model_docs = self._config.engine_get_embed_model_docs()
+    def get_embedding_models(self):
+        if self._embed_model_code is None:
+            self._embed_model_code = self._build_embed_model("code")
+        if self._embed_model_docs is None:
+            self._embed_model_docs = self._build_embed_model("docs")
+        self._attach_embed_models_to_backend()
+        return self._embed_model_code, self._embed_model_docs
+
+    def _build_embed_model(self, kind: str):
+        provider = self._config.embedding_provider
+        if provider is None:
+            raise RuntimeError("Index tool requires embedding_provider configuration.")
+        method_name = (
+            "get_embed_model_code" if kind == "code" else "get_embed_model_docs"
+        )
+        method = getattr(provider, method_name)
+        return method(**self._config.usage_runtime.hooks.embed_model_kwargs())
+
+    def _attach_embed_models_to_backend(self) -> None:
+        if hasattr(self._config.vector_backend, "embed_model_code"):
+            self._config.vector_backend.embed_model_code = self._embed_model_code
+        if hasattr(self._config.vector_backend, "embed_model_docs"):
+            self._config.vector_backend.embed_model_docs = self._embed_model_docs
+
+    def _get_backend_embed_model(self, attr: str):
+        if attr in getattr(self._config.vector_backend, "__dict__", {}):
+            return getattr(self._config.vector_backend, attr)
+        return None

--- a/src/metis/engine/indexing_service.py
+++ b/src/metis/engine/indexing_service.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
 import os
+from typing import Any
 
 import unidiff
 from llama_index.core import SimpleDirectoryReader
@@ -27,10 +29,13 @@ class IndexingService:
         config: EngineConfig,
         state: EngineState,
         repository: EngineRepository,
+        *,
+        get_embedding_models: Callable[[], tuple[Any, Any]],
     ):
         self._config = config
         self._state = state
         self._repository = repository
+        self._get_embedding_models = get_embedding_models
 
     def _get_broken_symlink_excludes(self, supported_exts: list[str]) -> list[str]:
         base_path = os.path.abspath(self._config.codebase_path)
@@ -72,7 +77,7 @@ class IndexingService:
         return code_count + doc_count
 
     def index_prepare_nodes_iter(self):
-        self._ensure_embed_models()
+        self._get_embedding_models()
         docs_supported_exts = self._config.plugin_config.get("docs", {}).get(
             "supported_extensions", [".md"]
         )
@@ -134,19 +139,19 @@ class IndexingService:
         pending = self._state.pending_nodes
         if not pending:
             return
-        self._ensure_embed_models()
+        embed_model_code, embed_model_docs = self._get_embedding_models()
         nodes_code, nodes_docs = pending
         self._config.vector_backend.index_nodes(
             nodes_code,
             nodes_docs,
-            embed_model_code=self._config.embed_model_code,
-            embed_model_docs=self._config.embed_model_docs,
+            embed_model_code=embed_model_code,
+            embed_model_docs=embed_model_docs,
             **self._config.usage_runtime.hooks.embed_model_kwargs(),
         )
         self._state.pending_nodes = None
 
     def update_index(self, patch_text):
-        self._ensure_embed_models()
+        embed_model_code, embed_model_docs = self._get_embedding_models()
         try:
             patch_set = unidiff.PatchSet.from_string(patch_text)
             logger.info("Parsed the provided patch string successfully.")
@@ -155,8 +160,8 @@ class IndexingService:
         self._config.vector_backend.init()
 
         index_code, index_docs = self._config.vector_backend.get_index_handles(
-            embed_model_code=self._config.embed_model_code,
-            embed_model_docs=self._config.embed_model_docs,
+            embed_model_code=embed_model_code,
+            embed_model_docs=embed_model_docs,
             **self._config.usage_runtime.hooks.embed_model_kwargs(),
         )
 
@@ -212,7 +217,3 @@ class IndexingService:
                     target_index.refresh_ref_docs([doc])
                 target_index.docstore.set_document_hash(doc.id_, doc.hash)
         logger.info("Index update complete based on the provided patch diff.")
-
-    def _ensure_embed_models(self):
-        self._config.embed_model_code = self._config.engine_get_embed_model_code()
-        self._config.embed_model_docs = self._config.engine_get_embed_model_docs()

--- a/src/metis/engine/llm_runner.py
+++ b/src/metis/engine/llm_runner.py
@@ -8,6 +8,8 @@ from langchain_core.messages import SystemMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
+from metis.chat_model_options import merge_chat_model_kwargs
+
 
 @dataclass(frozen=True, slots=True)
 class JsonPromptRequest:
@@ -28,22 +30,6 @@ class JsonPromptRequest:
     chat_model_kwargs: dict[str, Any] | None = None
 
 
-def _chat_model_kwargs(
-    usage_runtime=None, *, reasoning_effort=None, chat_model_kwargs=None
-):
-    kwargs = {}
-    if usage_runtime is not None:
-        kwargs.update(usage_runtime.hooks.chat_model_kwargs())
-    if chat_model_kwargs:
-        kwargs.update(chat_model_kwargs)
-    if (
-        reasoning_effort
-        and str(reasoning_effort).lower() not in "none off false default".split()
-    ):
-        kwargs["reasoning_effort"] = reasoning_effort
-    return kwargs
-
-
 class JsonPromptRunner:
     def __init__(self, llm_provider, usage_runtime=None):
         self._llm_provider = llm_provider
@@ -53,18 +39,21 @@ class JsonPromptRunner:
         last_failure = "unknown failure"
         for attempt in range(2):
             try:
-                params: dict[str, Any] = {"model": request.model}
+                usage_chat_kwargs = (
+                    self._usage_runtime.hooks.chat_model_kwargs()
+                    if self._usage_runtime is not None
+                    else None
+                )
+                params = merge_chat_model_kwargs(
+                    request.chat_model_kwargs,
+                    usage_chat_kwargs,
+                    model=request.model,
+                    reasoning_effort=request.reasoning_effort,
+                )
                 if request.max_tokens is not None:
                     params["max_tokens"] = request.max_tokens
                 if request.temperature is not None:
                     params["temperature"] = request.temperature
-                params.update(
-                    _chat_model_kwargs(
-                        self._usage_runtime,
-                        reasoning_effort=request.reasoning_effort,
-                        chat_model_kwargs=request.chat_model_kwargs,
-                    )
-                )
                 chat = self._llm_provider.get_chat_model(**params)
                 prompt = ChatPromptTemplate.from_messages(
                     [

--- a/src/metis/engine/options.py
+++ b/src/metis/engine/options.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,3 +16,13 @@ class ReviewOptions:
 class TriageOptions:
     use_retrieval_context: bool = False
     include_triaged: bool = False
+
+
+def normalize_top_k(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed <= 0:
+        return default
+    return parsed

--- a/src/metis/engine/review_service.py
+++ b/src/metis/engine/review_service.py
@@ -409,6 +409,8 @@ class ReviewService:
                     file_diff.path,
                     issues,
                     summary_prompt,
+                    model=self._config.llama_query_model,
+                    chat_model_kwargs=self._config.chat_model_kwargs,
                     callbacks=self._config.usage_runtime.hooks.callbacks,
                 )
                 if changes_summary:

--- a/src/metis/engine/runtime.py
+++ b/src/metis/engine/runtime.py
@@ -15,17 +15,15 @@ class EngineConfig:
     codebase_path: str
     vector_backend: Any
     llm_provider: Any
+    embedding_provider: Any | None
     usage_runtime: UsageRuntime
     plugin_config: dict[str, Any]
     custom_prompt_text: str | None
     custom_guidance_precedence: str
-    embed_model_code: Any
-    embed_model_docs: Any
-    engine_get_embed_model_code: Any
-    engine_get_embed_model_docs: Any
     max_workers: int
     max_token_length: int
     llama_query_model: str
+    chat_model_kwargs: dict[str, Any]
     similarity_top_k: int
     doc_chunk_size: int
     doc_chunk_overlap: int

--- a/src/metis/engine/tools/engine.py
+++ b/src/metis/engine/tools/engine.py
@@ -3,9 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
 
 from ..repository import EngineRepository
 from ..runtime import EngineConfig, EngineState
@@ -24,14 +22,11 @@ def build_engine_tools(
     config: EngineConfig,
     state: EngineState,
     repository: EngineRepository,
-    *,
-    normalize_top_k: Callable[[Any, int], int],
 ) -> EngineTools:
     return EngineTools(
         index=build_index_tool(
             config,
             state,
             repository,
-            normalize_top_k=normalize_top_k,
         )
     )

--- a/src/metis/engine/tools/index.py
+++ b/src/metis/engine/tools/index.py
@@ -3,9 +3,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
 from ..index_context_service import IndexContextService
 from ..repository import EngineRepository
 from ..runtime import EngineConfig, EngineState
@@ -33,6 +30,9 @@ class IndexTool:
     def get_retrievers(self):
         return self._handle.require().get_retrievers()
 
+    def get_embedding_models(self):
+        return self._handle.require().get_embedding_models()
+
     def clear_retriever_cache(self) -> None:
         if self.enabled:
             self._handle.require().clear_retriever_cache()
@@ -45,8 +45,6 @@ def build_index_tool(
     config: EngineConfig,
     state: EngineState,
     repository: EngineRepository,
-    *,
-    normalize_top_k: Callable[[Any, int], int],
 ) -> IndexTool:
     if not tool_enabled(config.enabled_tools, INDEX_TOOL):
         handle: ToolHandle[IndexContextService] = ToolHandle(INDEX_TOOL, None)
@@ -56,6 +54,5 @@ def build_index_tool(
         config,
         state,
         repository,
-        normalize_top_k=normalize_top_k,
     )
     return IndexTool(ToolHandle(INDEX_TOOL, service))

--- a/src/metis/engine/triage_service.py
+++ b/src/metis/engine/triage_service.py
@@ -22,12 +22,12 @@ class TriageService(TriageServiceRuntimeMixin, TriageServiceExecutionMixin):
         codebase_path: str,
         llm_provider: Any,
         llama_query_model: str,
+        chat_model_kwargs: dict[str, Any] | None,
         plugin_config: dict[str, Any],
         max_workers: int,
         triage_similarity_top_k: int,
         triage_checkpoint_every: int,
         triage_tool_timeout_seconds: int,
-        normalize_top_k: Callable[[Any, int], int],
         create_retrievers: Callable[[int], tuple[Any, Any]],
         get_plugin_for_extension: Callable[[str], Any],
         usage_hooks: UsageHooks | None = None,
@@ -35,12 +35,12 @@ class TriageService(TriageServiceRuntimeMixin, TriageServiceExecutionMixin):
         self.codebase_path = codebase_path
         self.llm_provider = llm_provider
         self.llama_query_model = llama_query_model
+        self.chat_model_kwargs = dict(chat_model_kwargs or {})
         self.plugin_config = plugin_config
         self.max_workers = max(1, max_workers)
         self.triage_similarity_top_k = triage_similarity_top_k
         self.triage_checkpoint_every = triage_checkpoint_every
         self.triage_tool_timeout_seconds = int(triage_tool_timeout_seconds)
-        self._normalize_top_k = normalize_top_k
         self._create_retrievers = create_retrievers
         self._get_plugin_for_extension = get_plugin_for_extension
         self._usage_hooks = usage_hooks

--- a/src/metis/engine/triage_service_runtime.py
+++ b/src/metis/engine/triage_service_runtime.py
@@ -9,8 +9,10 @@ import threading
 
 from metis.engine.analysis.base import AnalyzerEvidence, AnalyzerRequest
 from metis.engine.graphs import TriageGraph
+from metis.engine.options import normalize_top_k
 from metis.engine.tools.registry import build_toolbox
 from metis.exceptions import RetrieverInitError
+from metis.chat_model_options import merge_chat_model_kwargs
 
 from .triage_constants import DEFAULT_TRIAGE_SIMILARITY_TOP_K
 
@@ -45,13 +47,17 @@ class TriageServiceRuntimeMixin:
             codebase_path=self.codebase_path,
             timeout_seconds=self.triage_tool_timeout_seconds,
         )
+        usage_chat_kwargs = (
+            self._usage_hooks.chat_model_kwargs() if self._usage_hooks else None
+        )
         return TriageGraph(
             llm_provider=self.llm_provider,
             llama_query_model=self.llama_query_model,
             toolbox=toolbox,
             plugin_config=self.plugin_config,
-            chat_model_kwargs=(
-                self._usage_hooks.chat_model_kwargs() if self._usage_hooks else {}
+            chat_model_kwargs=merge_chat_model_kwargs(
+                self.chat_model_kwargs,
+                usage_chat_kwargs,
             ),
         )
 
@@ -63,7 +69,7 @@ class TriageServiceRuntimeMixin:
         return graph
 
     def _init_and_get_triage_retrievers(self):
-        top_k = self._normalize_top_k(
+        top_k = normalize_top_k(
             self.triage_similarity_top_k, DEFAULT_TRIAGE_SIMILARITY_TOP_K
         )
         retriever_code, retriever_docs = self._create_retrievers(top_k)

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -31,9 +31,13 @@ metis_engine:
 llm_provider:
   name: "openai"
   model: "gpt-5.5"
-  # Optional for reasoning-capable OpenAI models: none, minimal, low, medium,
-  # high, or xhigh depending on model support. Can be overridden under query.
+  # Optional for reasoning-capable models: use a value supported by the
+  # configured provider/model. Can be overridden under query.
   # reasoning_effort: "medium"
+
+# Optional — only needed when the index tool is enabled.
+embedding_provider:
+  name: "openai"
   code_embedding_model: "text-embedding-3-large"
   docs_embedding_model: "text-embedding-3-large"
 

--- a/src/metis/providers/anthropic.py
+++ b/src/metis/providers/anthropic.py
@@ -3,129 +3,69 @@
 
 from __future__ import annotations
 
-from typing import Any, Unpack, cast
+from typing import Any, cast
 
-from langchain_anthropic import ChatAnthropic
 from langchain_core.callbacks import Callbacks
-from langchain_openai import OpenAIEmbeddings
-from llama_index.core.callbacks import CallbackManager
-from pydantic import SecretStr
 
-from metis.providers.base import ChatModelOptions, LLMProvider
-from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
-from metis.providers.registry import register_provider
+from metis.providers.base import ChatProvider
+from metis.providers.config import ApiKeySources
+from metis.providers.config import ProviderConfigSpec
 
 
-class AnthropicProvider(LLMProvider):
+class AnthropicProvider(ChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="Anthropic",
+        required_keys=("model",),
+        api_key=ApiKeySources(required=True, env_vars=("ANTHROPIC_API_KEY",)),
+        copy_keys=("base_url", "model", "supports_temperature"),
+    )
+
     def __init__(self, config: dict[str, Any]):
         self.config = config
-        self.api_key = config.get("llm_api_key")
-        self.embedding_api_key = config.get("embedding_api_key")
-        self.query_model = config.get("llama_query_model") or config.get("model")
+        self.api_key = config.get("api_key")
+        self.default_model = config.get("model")
         self.supports_temperature = bool(config.get("supports_temperature", False))
-        self.temperature = float(config.get("llama_query_temperature", 0.0))
-        self.max_tokens = int(config.get("llama_query_max_tokens", 3072))
-        self.base_url = config.get("anthropic_api_url") or config.get("base_url")
+        self.base_url = config.get("base_url")
 
-        self.code_embedding_model = config.get("code_embedding_model")
-        self.docs_embedding_model = config.get("docs_embedding_model")
-        self.code_embedding_extra_kwargs = dict(
-            config.get("code_embedding_extra_kwargs", {})
-        )
-        self.docs_embedding_extra_kwargs = dict(
-            config.get("docs_embedding_extra_kwargs", {})
-        )
-        self.embedding_api_base = config.get("embedding_api_base") or config.get(
-            "embedding_base_url"
-        )
-        self.embedding_default_headers = dict(
-            config.get("embedding_default_headers", {})
-        )
-
-    def _require_embedding_api_key(self) -> str:
-        if not self.embedding_api_key:
+        if not self.api_key:
             raise ValueError(
-                "Anthropic provider embeddings require llm_provider.embedding_api_key, "
-                "llm_provider.embedding_api_key_env, or OPENAI_API_KEY."
+                "ANTHROPIC_API_KEY environment variable is required for Anthropic provider but not set."
             )
-        return self.embedding_api_key
-
-    def get_embed_model_code(
-        self, *, callback_manager: CallbackManager | None = None
-    ) -> LangChainEmbeddingAdapter:
-        return self._build_embedding_model(
-            self.code_embedding_model,
-            self.code_embedding_extra_kwargs,
-            "code_embedding_model",
-            callback_manager=callback_manager,
-        )
-
-    def get_embed_model_docs(
-        self, *, callback_manager: CallbackManager | None = None
-    ) -> LangChainEmbeddingAdapter:
-        return self._build_embedding_model(
-            self.docs_embedding_model,
-            self.docs_embedding_extra_kwargs,
-            "docs_embedding_model",
-            callback_manager=callback_manager,
-        )
-
-    def _build_embedding_model(
-        self,
-        model_name: str | None,
-        extra_kwargs: dict[str, object],
-        config_key: str,
-        callback_manager: CallbackManager | None = None,
-    ) -> LangChainEmbeddingAdapter:
-        if not model_name:
-            raise ValueError(f"Missing '{config_key}' in configuration")
-
-        params: dict[str, object] = {
-            "model": model_name,
-            "api_key": SecretStr(self._require_embedding_api_key()),
-        }
-        if self.embedding_api_base:
-            params["base_url"] = self.embedding_api_base
-        if self.embedding_default_headers:
-            params["default_headers"] = self.embedding_default_headers
-        if extra_kwargs:
-            params.update(extra_kwargs)
-
-        client = OpenAIEmbeddings(**cast(dict[str, Any], params))
-        return LangChainEmbeddingAdapter(
-            client,
-            model_name=model_name,
-            callback_manager=callback_manager,
-        )
 
     def get_chat_model(
         self,
         *args: str,
         callbacks: Callbacks = None,
-        **kwargs: Unpack[ChatModelOptions],
-    ) -> ChatAnthropic:
+        **kwargs: object,
+    ) -> Any:
+        try:
+            from langchain_anthropic import ChatAnthropic
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "Anthropic provider requires the langchain-anthropic extra."
+            ) from exc
+
         requested_model = kwargs.pop("model", None)
         positional_model = args[0] if args else None
-        model_name = requested_model or positional_model or self.query_model
+        model_name = requested_model or positional_model or self.default_model
         if not model_name:
             raise ValueError("Missing chat model configuration")
-        if not self.api_key:
-            raise ValueError(
-                "ANTHROPIC_API_KEY environment variable is required for "
-                "Anthropic provider but not set."
-            )
 
         params: dict[str, Any] = {
             "model": model_name,
             "api_key": self.api_key,
-            "max_tokens": kwargs.get("max_tokens", self.max_tokens),
         }
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is not None:
+            params["max_tokens"] = int(max_tokens)
         if "top_p" in kwargs and "temperature" in kwargs:
             raise ValueError(
                 "Anthropic chat model accepts either temperature or top_p, not both."
             )
         if self.supports_temperature and "top_p" not in kwargs:
-            params["temperature"] = kwargs.get("temperature", self.temperature)
+            temperature = kwargs.get("temperature")
+            if temperature is not None:
+                params["temperature"] = float(temperature)
         if self.base_url:
             params["base_url"] = self.base_url
         if callbacks is not None:
@@ -143,6 +83,3 @@ class AnthropicProvider(LLMProvider):
                 params[optional_key] = kwargs[optional_key]
 
         return ChatAnthropic(**cast(dict[str, Any], params))
-
-
-register_provider("anthropic", AnthropicProvider)

--- a/src/metis/providers/azure_openai.py
+++ b/src/metis/providers/azure_openai.py
@@ -3,50 +3,156 @@
 
 from __future__ import annotations
 
-from typing import Any, Unpack, cast
+from typing import Any, NotRequired, Required, TypedDict, cast
 
-import logging
-from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings
 from langchain_core.callbacks import Callbacks
-from pydantic import SecretStr
+from langchain_openai import AzureChatOpenAI
+from langchain_openai import AzureOpenAIEmbeddings
 from llama_index.core.callbacks import CallbackManager
+from pydantic import SecretStr
 
-from metis.providers.base import (
-    AzureOpenAIProviderConfig,
-    ChatModelOptions,
-    LLMProvider,
-)
+from metis.providers.base import ChatProvider
+from metis.providers.base import EmbeddingProvider
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
-from metis.providers.registry import register_provider
+from metis.providers.config import ApiKeySources
+from metis.providers.config import ProviderConfigSpec
 
-logger = logging.getLogger(__name__)
+
+class AzureOpenAIChatConfig(TypedDict, total=False):
+    api_key: Required[str]
+    azure_endpoint: Required[str]
+    azure_api_version: Required[str]
+    engine: Required[str]
+    chat_deployment_model: Required[str]
+    model: NotRequired[str]
+    supports_temperature: NotRequired[bool]
+    use_responses_api: NotRequired[bool]
 
 
-class AzureOpenAIProvider(LLMProvider):
-    def __init__(self, config: AzureOpenAIProviderConfig) -> None:
-        self.api_key = config.get("llm_api_key", "")
-        self.azure_endpoint = config.get("azure_endpoint", "")
-        self.api_version = config.get("azure_api_version", "")
-        self.engine = config.get("engine", "")
-        self.chat_deployment_model = config.get("chat_deployment_model", "")
+class AzureOpenAIEmbeddingConfig(TypedDict, total=False):
+    api_key: Required[str]
+    azure_endpoint: Required[str]
+    azure_api_version: Required[str]
+    code_embedding_model: Required[str]
+    docs_embedding_model: Required[str]
+    code_deployment: Required[str]
+    docs_deployment: Required[str]
 
-        self.code_embedding_model = config.get("code_embedding_model", "")
-        self.docs_embedding_model = config.get("docs_embedding_model", "")
-        self.code_embedding_deployment = config.get(
-            "code_embedding_deployment", self.code_embedding_model
-        )
-        self.docs_embedding_deployment = config.get(
-            "docs_embedding_deployment", self.docs_embedding_model
-        )
 
-        self.temperature = float(config.get("llama_query_temperature", 0.0))
-        self.max_tokens = int(config.get("llama_query_max_tokens", 3072))
-        self.reasoning_effort = config.get("llama_query_reasoning_effort")
+class AzureOpenAIProvider(ChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="Azure OpenAI",
+        required_keys=(
+            "azure_endpoint",
+            "azure_api_version",
+            "engine",
+            "chat_deployment_model",
+        ),
+        api_key=ApiKeySources(required=True, env_vars=("AZURE_OPENAI_API_KEY",)),
+        copy_keys={
+            "azure_endpoint": ("azure_endpoint",),
+            "azure_api_version": ("azure_api_version",),
+            "engine": ("engine",),
+            "chat_deployment_model": ("chat_deployment_model",),
+            "model": ("chat_deployment_model",),
+            "supports_temperature": ("supports_temperature",),
+            "use_responses_api": ("use_responses_api",),
+        },
+    )
 
-        self.model_token_param = config.get(
-            "model_token_param", "max_completion_tokens"
-        )
+    def __init__(self, config: AzureOpenAIChatConfig) -> None:
+        self.api_key = config["api_key"]
+        self.azure_endpoint = config["azure_endpoint"]
+        self.api_version = config["azure_api_version"]
+        self.engine = config["engine"]
+        self.chat_deployment_model = config["chat_deployment_model"]
         self.supports_temperature = config.get("supports_temperature", False)
+        self.use_responses_api = config.get("use_responses_api")
+
+        if not self.engine:
+            raise ValueError("Missing 'engine' (Azure deployment name).")
+        if not self.chat_deployment_model:
+            raise ValueError(
+                "Missing 'chat_deployment_model' "
+                "Azure calls must specify a deployment model."
+            )
+
+    def get_chat_model(
+        self,
+        *args: str,
+        callbacks: Callbacks = None,
+        **kwargs: object,
+    ) -> AzureChatOpenAI:
+        requested_deployment = kwargs.pop("deployment_name", None)
+        positional_deployment = args[0] if args else None
+        deployment = requested_deployment or positional_deployment or self.engine
+        params: dict[str, object] = {
+            "api_key": self.api_key,
+            "azure_endpoint": self.azure_endpoint,
+            "api_version": self.api_version,
+            "azure_deployment": deployment,
+            "model": self.chat_deployment_model,
+        }
+        if self.use_responses_api is not None:
+            params["use_responses_api"] = bool(self.use_responses_api)
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is not None:
+            params["max_tokens"] = int(max_tokens)
+        if callbacks is not None:
+            params["callbacks"] = callbacks
+        if "response_format" in kwargs:
+            if kwargs["response_format"] is not None:
+                params["response_format"] = kwargs["response_format"]
+        else:
+            params["response_format"] = {"type": "json_object"}
+        if self.supports_temperature:
+            temperature = kwargs.get("temperature")
+            if temperature is not None:
+                params["temperature"] = float(temperature)
+        for optional_key in (
+            "timeout",
+            "max_retries",
+            "seed",
+            "frequency_penalty",
+            "presence_penalty",
+            "reasoning_effort",
+            "verbosity",
+        ):
+            if optional_key in kwargs:
+                params[optional_key] = kwargs[optional_key]
+        return AzureChatOpenAI(**cast(dict[str, Any], params))
+
+
+class AzureOpenAIEmbeddingProvider(EmbeddingProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="Azure OpenAI embeddings",
+        required_keys=(
+            "azure_endpoint",
+            "azure_api_version",
+            "code_embedding_model",
+            "docs_embedding_model",
+            "code_deployment",
+            "docs_deployment",
+        ),
+        api_key=ApiKeySources(required=True, env_vars=("AZURE_OPENAI_API_KEY",)),
+        copy_keys=(
+            "azure_endpoint",
+            "azure_api_version",
+            "code_embedding_model",
+            "docs_embedding_model",
+            "code_deployment",
+            "docs_deployment",
+        ),
+    )
+
+    def __init__(self, config: AzureOpenAIEmbeddingConfig) -> None:
+        self.api_key = config["api_key"]
+        self.azure_endpoint = config["azure_endpoint"]
+        self.api_version = config["azure_api_version"]
+        self.code_embedding_model = config["code_embedding_model"]
+        self.docs_embedding_model = config["docs_embedding_model"]
+        self.code_deployment = config["code_deployment"]
+        self.docs_deployment = config["docs_deployment"]
 
     def get_embed_model_code(
         self, *, callback_manager: CallbackManager | None = None
@@ -54,7 +160,7 @@ class AzureOpenAIProvider(LLMProvider):
         return LangChainEmbeddingAdapter(
             self._build_embeddings_client(
                 model=self.code_embedding_model,
-                deployment=self.code_embedding_deployment,
+                deployment=self.code_deployment,
             ),
             model_name=self.code_embedding_model,
             callback_manager=callback_manager,
@@ -66,61 +172,11 @@ class AzureOpenAIProvider(LLMProvider):
         return LangChainEmbeddingAdapter(
             self._build_embeddings_client(
                 model=self.docs_embedding_model,
-                deployment=self.docs_embedding_deployment,
+                deployment=self.docs_deployment,
             ),
             model_name=self.docs_embedding_model,
             callback_manager=callback_manager,
         )
-
-    def get_chat_model(
-        self,
-        *args: str,
-        callbacks: Callbacks = None,
-        **kwargs: Unpack[ChatModelOptions],
-    ) -> AzureChatOpenAI:
-        requested_deployment = kwargs.pop("deployment_name", None)
-        positional_deployment = args[0] if args else None
-        deployment = requested_deployment or positional_deployment or self.engine
-        if not deployment:
-            raise ValueError("Missing 'engine' (Azure deployment name).")
-        if not self.chat_deployment_model:
-            raise ValueError(
-                "Missing 'chat_deployment_model' "
-                "Azure calls must specify a deployment model."
-            )
-        params: dict[str, object] = {
-            "api_key": self.api_key,
-            "azure_endpoint": self.azure_endpoint,
-            "api_version": self.api_version,
-            "azure_deployment": deployment,
-            "model": self.chat_deployment_model,
-            "max_tokens": kwargs.get("max_tokens", self.max_tokens),
-            "use_responses_api": True,
-        }
-        if callbacks is not None:
-            params["callbacks"] = callbacks
-        if self.reasoning_effort:
-            params["reasoning_effort"] = self.reasoning_effort
-        if "response_format" in kwargs:
-            if kwargs["response_format"] is not None:
-                params["response_format"] = kwargs["response_format"]
-        else:
-            params["response_format"] = {"type": "json_object"}
-        if self.supports_temperature:
-            params["temperature"] = kwargs.get("temperature", self.temperature)
-        for optional_key in (
-            "timeout",
-            "max_retries",
-            "seed",
-            "frequency_penalty",
-            "presence_penalty",
-            "response_format",
-            "reasoning_effort",
-            "verbosity",
-        ):
-            if optional_key in kwargs and optional_key != "response_format":
-                params[optional_key] = kwargs[optional_key]
-        return AzureChatOpenAI(**cast(dict[str, Any], params))
 
     def _build_embeddings_client(
         self, model: str, deployment: str
@@ -133,6 +189,3 @@ class AzureOpenAIProvider(LLMProvider):
             api_version=self.api_version,
             base_url=None,
         )
-
-
-register_provider("azure_openai", AzureOpenAIProvider)

--- a/src/metis/providers/base.py
+++ b/src/metis/providers/base.py
@@ -3,120 +3,12 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import NotRequired, Required, TypedDict, Unpack
+from typing import TypedDict
 
 from langchain_core.callbacks import Callbacks
 from langchain_core.language_models.chat_models import BaseChatModel
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.callbacks import CallbackManager
-
-
-class ChatModelOptions(TypedDict, total=False):
-    model: str
-    deployment_name: str
-    temperature: float
-    max_tokens: int
-    top_p: float
-    top_k: int
-    timeout: float
-    request_timeout: float
-    max_retries: int
-    frequency_penalty: float
-    presence_penalty: float
-    seed: int
-    logit_bias: Mapping[str, int]
-    response_format: Mapping[str, object] | None
-    reasoning_effort: str
-    verbosity: str
-    stop: str | list[str]
-    stop_sequences: list[str]
-    default_request_timeout: float
-    safety_settings: object
-    thinking_budget: int
-    thinking_level: str
-    include_thoughts: bool
-    response_mime_type: str
-    response_schema: object
-    n: int
-
-
-class OpenAICompatibleProviderConfig(TypedDict, total=False):
-    llm_api_key: str
-    openai_api_base: str
-    api_base: str
-    base_url: str
-    openai_default_headers: Mapping[str, str]
-    default_headers: Mapping[str, str]
-    model: str
-    llama_query_model: str
-    llama_query_temperature: float
-    llama_query_max_tokens: int
-    llama_query_reasoning_effort: str
-    code_embedding_model: str
-    docs_embedding_model: str
-    code_embedding_extra_kwargs: Mapping[str, object]
-    docs_embedding_extra_kwargs: Mapping[str, object]
-
-
-class AzureOpenAIProviderConfig(TypedDict, total=False):
-    llm_api_key: Required[str]
-    azure_endpoint: Required[str]
-    azure_api_version: Required[str]
-    engine: Required[str]
-    chat_deployment_model: Required[str]
-    code_embedding_model: Required[str]
-    docs_embedding_model: Required[str]
-    code_embedding_deployment: NotRequired[str]
-    docs_embedding_deployment: NotRequired[str]
-    llama_query_temperature: NotRequired[float]
-    llama_query_max_tokens: NotRequired[int]
-    llama_query_reasoning_effort: NotRequired[str]
-    model_token_param: NotRequired[str]
-    supports_temperature: NotRequired[bool]
-
-
-class BedrockProviderConfig(TypedDict, total=False):
-    bedrock_region: Required[str]
-    model: Required[str]
-    llama_query_model: NotRequired[str]
-    code_embedding_model: NotRequired[str]
-    docs_embedding_model: NotRequired[str]
-    aws_region: NotRequired[str]
-    aws_profile: NotRequired[str]
-    aws_access_key_id: NotRequired[str]
-    aws_secret_access_key: NotRequired[str]
-    aws_session_token: NotRequired[str]
-    bedrock_endpoint_url: NotRequired[str]
-    llama_query_temperature: NotRequired[float]
-    llama_query_max_tokens: NotRequired[int]
-    supports_temperature: NotRequired[bool]
-
-
-class GeminiProviderConfig(TypedDict, total=False):
-    llm_api_key: Required[str]
-    model: Required[str]
-    llama_query_model: str
-    llama_query_temperature: float
-    llama_query_max_tokens: int
-    llama_query_reasoning_effort: str
-    code_embedding_model: Required[str]
-    docs_embedding_model: Required[str]
-    code_embedding_extra_kwargs: Mapping[str, object]
-    docs_embedding_extra_kwargs: Mapping[str, object]
-    gemini_api_base: str
-    gemini_additional_headers: Mapping[str, str]
-    gemini_project: str
-    gemini_location: str
-    gemini_vertexai: bool | None
-    gemini_client_args: Mapping[str, object]
-
-
-ProviderRuntimeConfig = (
-    OpenAICompatibleProviderConfig
-    | AzureOpenAIProviderConfig
-    | BedrockProviderConfig
-    | GeminiProviderConfig
-)
 
 
 class EmbedModelKwargs(TypedDict, total=False):
@@ -131,8 +23,23 @@ class RetrieverKwargs(ProviderChatModelKwargs, total=False):
     callback_manager: CallbackManager
 
 
-class LLMProvider(ABC):
-    def __init__(self, config: ProviderRuntimeConfig) -> None:
+class ChatProvider(ABC):
+    def __init__(self, config: Mapping[str, object]) -> None:
+        pass
+
+    @abstractmethod
+    def get_chat_model(
+        self,
+        *args: str,
+        callbacks: Callbacks = None,
+        **kwargs: object,
+    ) -> BaseChatModel:
+        """Return a LangChain chat model instance."""
+        pass
+
+
+class EmbeddingProvider(ABC):
+    def __init__(self, config: Mapping[str, object]) -> None:
         pass
 
     @abstractmethod
@@ -147,14 +54,4 @@ class LLMProvider(ABC):
         self, *, callback_manager: CallbackManager | None = None
     ) -> BaseEmbedding:
         """Return a docs embedding model for vector store."""
-        pass
-
-    @abstractmethod
-    def get_chat_model(
-        self,
-        *args: str,
-        callbacks: Callbacks = None,
-        **kwargs: Unpack[ChatModelOptions],
-    ) -> BaseChatModel:
-        """Return a LangChain chat model instance."""
         pass

--- a/src/metis/providers/bedrock.py
+++ b/src/metis/providers/bedrock.py
@@ -3,78 +3,174 @@
 
 from __future__ import annotations
 
-import logging
-from typing import Any, Unpack
+from typing import Any, Mapping, cast
+from typing import Required, TypedDict
 
-from langchain_aws import BedrockEmbeddings, ChatBedrockConverse
 from langchain_core.callbacks import Callbacks
 from llama_index.core.callbacks import CallbackManager
 
-from metis.providers.base import BedrockProviderConfig, ChatModelOptions, LLMProvider
+from metis.providers.base import ChatProvider
+from metis.providers.base import EmbeddingProvider
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
-from metis.providers.registry import register_provider
-
-logger = logging.getLogger(__name__)
+from metis.providers.config import ProviderConfigSpec
 
 
-class BedrockProvider(LLMProvider):
-    def __init__(self, config: BedrockProviderConfig) -> None:
+AWS_CREDENTIAL_CONFIG = {
+    "endpoint_url": ("endpoint_url",),
+    "aws_profile": ("aws_profile",),
+    "aws_access_key_id": ("aws_access_key_id", "env:AWS_ACCESS_KEY_ID"),
+    "aws_secret_access_key": ("aws_secret_access_key", "env:AWS_SECRET_ACCESS_KEY"),
+    "aws_session_token": ("aws_session_token", "env:AWS_SESSION_TOKEN"),
+}
+
+BedrockEmbeddings: Any
+ChatBedrockConverse: Any
+
+try:
+    from langchain_aws import BedrockEmbeddings
+    from langchain_aws import ChatBedrockConverse
+except ModuleNotFoundError:
+    BedrockEmbeddings = None
+    ChatBedrockConverse = None
+
+
+class BedrockChatConfig(TypedDict, total=False):
+    region: Required[str]
+    model: Required[str]
+    supports_temperature: bool
+    aws_profile: str
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    aws_session_token: str
+    endpoint_url: str
+
+
+class BedrockEmbeddingConfig(TypedDict, total=False):
+    region: Required[str]
+    code_embedding_model: Required[str]
+    docs_embedding_model: Required[str]
+    aws_profile: str
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    aws_session_token: str
+    endpoint_url: str
+
+
+def _credential_kwargs(config: Mapping[str, object]) -> dict[str, object]:
+    region = config.get("region")
+    if not region:
+        raise ValueError("Bedrock provider requires 'region' in metis.yaml.")
+
+    kwargs: dict[str, object] = {"region_name": region}
+    endpoint_url = config.get("endpoint_url")
+    if endpoint_url:
+        kwargs["endpoint_url"] = endpoint_url
+    aws_profile = config.get("aws_profile")
+    if aws_profile:
+        kwargs["credentials_profile_name"] = aws_profile
+
+    aws_access_key_id = config.get("aws_access_key_id")
+    aws_secret_access_key = config.get("aws_secret_access_key")
+    if aws_access_key_id and aws_secret_access_key:
+        kwargs["aws_access_key_id"] = aws_access_key_id
+        kwargs["aws_secret_access_key"] = aws_secret_access_key
+        aws_session_token = config.get("aws_session_token")
+        if aws_session_token:
+            kwargs["aws_session_token"] = aws_session_token
+
+    return kwargs
+
+
+class BedrockProvider(ChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="AWS Bedrock",
+        required_keys=("model", "region"),
+        copy_keys={
+            "model": ("model",),
+            "region": ("region",),
+            **AWS_CREDENTIAL_CONFIG,
+            "supports_temperature": ("supports_temperature",),
+        },
+    )
+
+    def __init__(self, config: BedrockChatConfig) -> None:
         self.config = config
-        self.region = config.get("bedrock_region") or config.get("aws_region")
-        self.query_model = config.get("llama_query_model") or config.get("model")
+        self.default_model = config.get("model")
         self.supports_temperature = bool(config.get("supports_temperature", False))
-        self.temperature = float(config.get("llama_query_temperature", 0.0))
-        self.max_tokens = int(config.get("llama_query_max_tokens", 3072))
+        self._credentials = _credential_kwargs(config)
 
-        self.aws_profile = config.get("aws_profile") or None
-        self.aws_access_key_id = config.get("aws_access_key_id") or None
-        self.aws_secret_access_key = config.get("aws_secret_access_key") or None
-        self.aws_session_token = config.get("aws_session_token") or None
-        self.endpoint_url = config.get("bedrock_endpoint_url") or None
+    def get_chat_model(
+        self,
+        *args: str,
+        callbacks: Callbacks = None,
+        **kwargs: object,
+    ) -> Any:
+        if ChatBedrockConverse is None:
+            raise ModuleNotFoundError(
+                "AWS Bedrock provider requires the langchain-aws extra."
+            )
+        requested_model = kwargs.pop("model", None)
+        positional_model = args[0] if args else None
+        model_name = requested_model or positional_model or self.default_model
+        if not model_name:
+            raise ValueError("Missing chat model configuration")
 
+        params: dict[str, object] = {
+            "model": model_name,
+            **self._credentials,
+        }
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is not None:
+            params["max_tokens"] = int(max_tokens)
+        if self.supports_temperature:
+            temperature = kwargs.get("temperature")
+            if temperature is not None:
+                params["temperature"] = float(temperature)
+        if callbacks is not None:
+            params["callbacks"] = callbacks
+
+        for optional_key in (
+            "timeout",
+            "request_timeout",
+            "max_retries",
+            "top_p",
+            "stop",
+        ):
+            if optional_key in kwargs:
+                params[optional_key] = kwargs[optional_key]
+
+        return ChatBedrockConverse(**cast(dict[str, Any], params))
+
+
+class BedrockEmbeddingProvider(EmbeddingProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="AWS Bedrock embeddings",
+        required_keys=("region", "code_embedding_model", "docs_embedding_model"),
+        copy_keys={
+            "region": ("region",),
+            **AWS_CREDENTIAL_CONFIG,
+            "code_embedding_model": ("code_embedding_model",),
+            "docs_embedding_model": ("docs_embedding_model",),
+        },
+    )
+
+    def __init__(self, config: BedrockEmbeddingConfig) -> None:
+        self.config = config
         self.code_embedding_model = config.get("code_embedding_model")
         self.docs_embedding_model = config.get("docs_embedding_model")
+        self._credentials = _credential_kwargs(config)
 
-        if not self.region:
+        if not self.code_embedding_model or not self.docs_embedding_model:
             raise ValueError(
-                "Bedrock provider requires 'region' "
-                "(set llm_provider.region in metis.yaml)."
+                "Missing embedding model configuration "
+                "(set 'code_embedding_model' and 'docs_embedding_model')"
             )
-
-    def _credential_kwargs(self) -> dict[str, Any]:
-        kwargs: dict[str, Any] = {"region_name": self.region}
-        if self.endpoint_url:
-            kwargs["endpoint_url"] = self.endpoint_url
-        if self.aws_profile:
-            kwargs["credentials_profile_name"] = self.aws_profile
-        if self.aws_access_key_id and self.aws_secret_access_key:
-            kwargs["aws_access_key_id"] = self.aws_access_key_id
-            kwargs["aws_secret_access_key"] = self.aws_secret_access_key
-            if self.aws_session_token:
-                kwargs["aws_session_token"] = self.aws_session_token
-        return kwargs
-
-    def _build_embedding_model(
-        self,
-        model_id: str | None,
-        config_key: str,
-        callback_manager: CallbackManager | None = None,
-    ) -> LangChainEmbeddingAdapter:
-        if not model_id:
-            raise ValueError(f"Missing '{config_key}' in configuration")
-        client = BedrockEmbeddings(model_id=model_id, **self._credential_kwargs())
-        return LangChainEmbeddingAdapter(
-            client,
-            model_name=model_id,
-            callback_manager=callback_manager,
-        )
 
     def get_embed_model_code(
         self, *, callback_manager: CallbackManager | None = None
     ) -> LangChainEmbeddingAdapter:
         return self._build_embedding_model(
             self.code_embedding_model,
-            "code_embedding_model",
             callback_manager=callback_manager,
         )
 
@@ -83,37 +179,25 @@ class BedrockProvider(LLMProvider):
     ) -> LangChainEmbeddingAdapter:
         return self._build_embedding_model(
             self.docs_embedding_model,
-            "docs_embedding_model",
             callback_manager=callback_manager,
         )
 
-    def get_chat_model(
+    def _build_embedding_model(
         self,
-        *args: str,
-        callbacks: Callbacks = None,
-        **kwargs: Unpack[ChatModelOptions],
-    ) -> ChatBedrockConverse:
-        requested_model = kwargs.pop("model", None)
-        positional_model = args[0] if args else None
-        model_id = requested_model or positional_model or self.query_model
-        if not model_id:
-            raise ValueError("Missing chat model configuration")
-
-        params: dict[str, Any] = {
-            "model": model_id,
-            "max_tokens": kwargs.get("max_tokens", self.max_tokens),
-            **self._credential_kwargs(),
-        }
-        if self.supports_temperature:
-            params["temperature"] = kwargs.get("temperature", self.temperature)
-        if callbacks is not None:
-            params["callbacks"] = callbacks
-
-        for optional_key in ("top_p", "stop", "max_retries"):
-            if optional_key in kwargs:
-                params[optional_key] = kwargs[optional_key]
-
-        return ChatBedrockConverse(**params)
-
-
-register_provider("bedrock", BedrockProvider)
+        model_name: str,
+        callback_manager: CallbackManager | None = None,
+    ) -> LangChainEmbeddingAdapter:
+        if BedrockEmbeddings is None:
+            raise ModuleNotFoundError(
+                "AWS Bedrock embeddings require the langchain-aws extra."
+            )
+        credential_kwargs = cast(dict[str, Any], self._credentials)
+        client = BedrockEmbeddings(
+            model_id=model_name,
+            **credential_kwargs,
+        )
+        return LangChainEmbeddingAdapter(
+            client,
+            model_name=model_name,
+            callback_manager=callback_manager,
+        )

--- a/src/metis/providers/bedrock_mantle.py
+++ b/src/metis/providers/bedrock_mantle.py
@@ -4,191 +4,133 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Any, Unpack, cast
+from typing import Any, cast
 
-from anthropic import AnthropicBedrockMantle
-from anthropic import AsyncAnthropicBedrockMantle
-from langchain_anthropic import ChatAnthropic
 from langchain_core.callbacks import Callbacks
-from langchain_openai import OpenAIEmbeddings
-from llama_index.core.callbacks import CallbackManager
 from pydantic import Field
-from pydantic import SecretStr
 
-from metis.providers.base import ChatModelOptions
-from metis.providers.base import LLMProvider
-from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
-from metis.providers.registry import register_provider
+from metis.providers.base import ChatProvider
+from metis.providers.config import ProviderConfigSpec
 
+AnthropicBedrockMantle: Any
+AsyncAnthropicBedrockMantle: Any
+ChatAnthropic: Any
+ChatBedrockMantle: Any
 
-class ChatBedrockMantle(ChatAnthropic):
-    """Anthropic chat model transported through Amazon Bedrock Mantle."""
-
-    aws_region: str | None = None
-    aws_profile: str | None = None
-    aws_access_key: str | None = None
-    aws_secret_key: str | None = None
-    aws_session_token: str | None = None
-    bedrock_base_url: str | None = Field(default=None, alias="bedrock_base_url")
-
-    @property
-    def _llm_type(self) -> str:
-        return "anthropic-bedrock-mantle-chat"
-
-    def _bedrock_client_params(self) -> dict[str, Any]:
-        params: dict[str, Any] = {
-            "aws_region": self.aws_region,
-            "aws_profile": self.aws_profile,
-            "aws_access_key": self.aws_access_key,
-            "aws_secret_key": self.aws_secret_key,
-            "aws_session_token": self.aws_session_token,
-            "max_retries": self.max_retries,
-        }
-        if self.bedrock_base_url:
-            params["base_url"] = self.bedrock_base_url
-        if self.default_headers:
-            params["default_headers"] = self.default_headers
-        if self.default_request_timeout is None or self.default_request_timeout > 0:
-            params["timeout"] = self.default_request_timeout
-        return {key: value for key, value in params.items() if value is not None}
-
-    @cached_property
-    def _client(self) -> AnthropicBedrockMantle:
-        return AnthropicBedrockMantle(**self._bedrock_client_params())
-
-    @cached_property
-    def _async_client(self) -> AsyncAnthropicBedrockMantle:
-        return AsyncAnthropicBedrockMantle(**self._bedrock_client_params())
+try:
+    from anthropic import AnthropicBedrockMantle
+    from anthropic import AsyncAnthropicBedrockMantle
+    from langchain_anthropic import ChatAnthropic
+except ModuleNotFoundError:
+    AnthropicBedrockMantle = None
+    AsyncAnthropicBedrockMantle = None
+    ChatAnthropic = None
 
 
-class BedrockMantleProvider(LLMProvider):
+if ChatAnthropic is not None:
+
+    class ChatBedrockMantle(ChatAnthropic):
+        """Anthropic chat model transported through Amazon Bedrock Mantle."""
+
+        aws_region: str | None = None
+        aws_profile: str | None = None
+        bedrock_base_url: str | None = Field(default=None, alias="bedrock_base_url")
+
+        @property
+        def _llm_type(self) -> str:
+            return "anthropic-bedrock-mantle-chat"
+
+        def _bedrock_client_params(self) -> dict[str, Any]:
+            params: dict[str, Any] = {
+                "aws_region": self.aws_region,
+                "aws_profile": self.aws_profile,
+                "max_retries": self.max_retries,
+            }
+            if self.bedrock_base_url:
+                params["base_url"] = self.bedrock_base_url
+            if self.default_headers:
+                params["default_headers"] = self.default_headers
+            if self.default_request_timeout is None or self.default_request_timeout > 0:
+                params["timeout"] = self.default_request_timeout
+            return {key: value for key, value in params.items() if value is not None}
+
+        @cached_property
+        def _client(self) -> AnthropicBedrockMantle:
+            return AnthropicBedrockMantle(**self._bedrock_client_params())
+
+        @cached_property
+        def _async_client(self) -> AsyncAnthropicBedrockMantle:
+            return AsyncAnthropicBedrockMantle(**self._bedrock_client_params())
+
+else:
+    ChatBedrockMantle = None
+
+
+class BedrockMantleProvider(ChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="Bedrock Mantle",
+        required_keys=("model",),
+        copy_keys=(
+            "model",
+            "aws_profile",
+            "aws_region",
+            "base_url",
+            "default_headers",
+            "supports_temperature",
+        ),
+    )
+
     def __init__(self, config: dict[str, Any]):
         self.config = config
-        self.embedding_api_key = config.get("embedding_api_key")
-        self.query_model = config.get("llama_query_model") or config.get("model")
+        self.default_model = config.get("model")
         self.supports_temperature = bool(config.get("supports_temperature", False))
-        self.temperature = (
-            float(config.get("llama_query_temperature", 0.0))
-            if self.supports_temperature
-            else None
-        )
-        self.max_tokens = int(config.get("llama_query_max_tokens", 3072))
         self.aws_region = config.get("aws_region")
         self.aws_profile = config.get("aws_profile")
-        self.aws_access_key = config.get("aws_access_key_id") or None
-        self.aws_secret_key = config.get("aws_secret_access_key") or None
-        self.aws_session_token = config.get("aws_session_token") or None
-        self.base_url = config.get("bedrock_base_url") or config.get("base_url")
+        self.base_url = config.get("base_url")
         self.default_headers = dict(config.get("default_headers", {}))
-
-        self.code_embedding_model = config.get("code_embedding_model")
-        self.docs_embedding_model = config.get("docs_embedding_model")
-        self.code_embedding_extra_kwargs = dict(
-            config.get("code_embedding_extra_kwargs", {})
-        )
-        self.docs_embedding_extra_kwargs = dict(
-            config.get("docs_embedding_extra_kwargs", {})
-        )
-        self.embedding_api_base = config.get("embedding_api_base") or config.get(
-            "embedding_base_url"
-        )
-        self.embedding_default_headers = dict(
-            config.get("embedding_default_headers", {})
-        )
-
-    def _require_embedding_api_key(self) -> str:
-        if not self.embedding_api_key:
-            raise ValueError(
-                "Bedrock Mantle provider embeddings require "
-                "llm_provider.embedding_api_key, llm_provider.embedding_api_key_env, "
-                "or OPENAI_API_KEY."
-            )
-        return self.embedding_api_key
-
-    def get_embed_model_code(
-        self, *, callback_manager: CallbackManager | None = None
-    ) -> LangChainEmbeddingAdapter:
-        return self._build_embedding_model(
-            self.code_embedding_model,
-            self.code_embedding_extra_kwargs,
-            "code_embedding_model",
-            callback_manager=callback_manager,
-        )
-
-    def get_embed_model_docs(
-        self, *, callback_manager: CallbackManager | None = None
-    ) -> LangChainEmbeddingAdapter:
-        return self._build_embedding_model(
-            self.docs_embedding_model,
-            self.docs_embedding_extra_kwargs,
-            "docs_embedding_model",
-            callback_manager=callback_manager,
-        )
-
-    def _build_embedding_model(
-        self,
-        model_name: str | None,
-        extra_kwargs: dict[str, object],
-        config_key: str,
-        callback_manager: CallbackManager | None = None,
-    ) -> LangChainEmbeddingAdapter:
-        if not model_name:
-            raise ValueError(f"Missing '{config_key}' in configuration")
-
-        params: dict[str, object] = {
-            "model": model_name,
-            "api_key": SecretStr(self._require_embedding_api_key()),
-        }
-        if self.embedding_api_base:
-            params["base_url"] = self.embedding_api_base
-        if self.embedding_default_headers:
-            params["default_headers"] = self.embedding_default_headers
-        if extra_kwargs:
-            params.update(extra_kwargs)
-
-        client = OpenAIEmbeddings(**cast(dict[str, Any], params))
-        return LangChainEmbeddingAdapter(
-            client,
-            model_name=model_name,
-            callback_manager=callback_manager,
-        )
 
     def get_chat_model(
         self,
         *args: str,
         callbacks: Callbacks = None,
-        **kwargs: Unpack[ChatModelOptions],
-    ) -> ChatBedrockMantle:
+        **kwargs: object,
+    ) -> Any:
+        if ChatBedrockMantle is None:
+            raise ModuleNotFoundError(
+                "Bedrock Mantle provider requires the anthropic and "
+                "langchain-anthropic extras."
+            )
         requested_model = kwargs.pop("model", None)
         positional_model = args[0] if args else None
-        model_name = requested_model or positional_model or self.query_model
+        model_name = requested_model or positional_model or self.default_model
         if not model_name:
             raise ValueError("Missing chat model configuration")
 
         params: dict[str, Any] = {
             "model": model_name,
-            "max_tokens": kwargs.get("max_tokens", self.max_tokens),
             "aws_region": self.aws_region,
             "aws_profile": self.aws_profile,
         }
-        if self.aws_access_key and self.aws_secret_key:
-            params["aws_access_key"] = self.aws_access_key
-            params["aws_secret_key"] = self.aws_secret_key
-            if self.aws_session_token:
-                params["aws_session_token"] = self.aws_session_token
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is not None:
+            params["max_tokens"] = int(max_tokens)
         if self.base_url:
             params["bedrock_base_url"] = self.base_url
         if self.default_headers:
             params["default_headers"] = self.default_headers
-        if "top_p" in kwargs and "temperature" in kwargs:
-            raise ValueError(
-                "Bedrock Mantle chat model accepts either temperature or top_p, not both."
-            )
         if self.supports_temperature:
+            if "top_p" in kwargs and "temperature" in kwargs:
+                raise ValueError(
+                    "Bedrock Mantle chat model accepts either temperature or top_p, not both."
+                )
             if "temperature" in kwargs:
-                params["temperature"] = kwargs["temperature"]
-            elif "top_p" not in kwargs and self.temperature is not None:
-                params["temperature"] = self.temperature
+                temperature = kwargs["temperature"]
+            elif "top_p" not in kwargs:
+                temperature = None
+            else:
+                temperature = None
+            if temperature is not None:
+                params["temperature"] = float(temperature)
         if callbacks is not None:
             params["callbacks"] = callbacks
 
@@ -204,6 +146,3 @@ class BedrockMantleProvider(LLMProvider):
                 params[optional_key] = kwargs[optional_key]
 
         return ChatBedrockMantle(**cast(dict[str, Any], params))
-
-
-register_provider("bedrock_mantle", BedrockMantleProvider)

--- a/src/metis/providers/config.py
+++ b/src/metis/providers/config.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from dataclasses import field
+import os
+
+CopyKeySpec = tuple[str, ...] | Mapping[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class ApiKeySources:
+    required: bool = False
+    config_keys: tuple[str, ...] = ("api_key",)
+    config_env_keys: tuple[str, ...] = ("api_key_env",)
+    env_vars: tuple[str, ...] = ()
+    optional_when: tuple[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class ProviderConfigSpec:
+    display_name: str
+    required_keys: tuple[str, ...] = ()
+    api_key: ApiKeySources = field(default_factory=ApiKeySources)
+    copy_keys: CopyKeySpec = ()
+
+
+def build_provider_config(
+    *,
+    provider_name: str,
+    provider_cls: type,
+    raw_config: Mapping[str, object],
+    section: str,
+) -> dict[str, object]:
+    spec = _provider_config_spec(provider_name, provider_cls, section)
+    provider_config = dict(raw_config)
+    _validate_required_keys(
+        provider_config=provider_config,
+        spec=spec,
+        section=section,
+    )
+
+    config = _copy_provider_config(provider_config, spec)
+    api_key = _resolve_api_key(
+        provider_config=provider_config,
+        spec=spec,
+        section=section,
+    )
+    if api_key:
+        config["api_key"] = api_key
+
+    return _compact_provider_config(config)
+
+
+def _provider_config_spec(
+    provider_name: str, provider_cls: type, section: str
+) -> ProviderConfigSpec:
+    spec = getattr(provider_cls, "CONFIG_SPEC", None)
+    if isinstance(spec, ProviderConfigSpec):
+        return spec
+    raise ValueError(
+        f"{provider_name} is registered as a {section} provider but does not define "
+        "CONFIG_SPEC."
+    )
+
+
+def _validate_required_keys(
+    *,
+    provider_config: Mapping[str, object],
+    spec: ProviderConfigSpec,
+    section: str,
+) -> None:
+    missing_keys = [
+        key for key in spec.required_keys if _is_missing(provider_config.get(key))
+    ]
+    if not missing_keys:
+        return
+
+    missing = ", ".join(f"{section}.{key}" for key in missing_keys)
+    required_text = ", ".join(f"{section}.{key}" for key in spec.required_keys)
+    raise ValueError(
+        f"{spec.display_name} provider requires additional metis.yaml configuration. "
+        f"Missing: {missing}. Required keys: {required_text}."
+    )
+
+
+def _resolve_api_key(
+    *,
+    provider_config: Mapping[str, object],
+    spec: ProviderConfigSpec,
+    section: str,
+) -> str:
+    sources = spec.api_key
+    for config_key in sources.config_keys:
+        value = provider_config.get(config_key)
+        if isinstance(value, str) and value.strip():
+            return value
+
+    for config_env_key in sources.config_env_keys:
+        env_var = provider_config.get(config_env_key)
+        if isinstance(env_var, str) and env_var.strip():
+            value = os.environ.get(env_var)
+            if value:
+                return value
+
+    for env_var in sources.env_vars:
+        value = os.environ.get(env_var)
+        if value:
+            return value
+
+    if not sources.required or _optional_condition_matches(
+        provider_config, sources.optional_when
+    ):
+        return ""
+
+    source_descriptions = [
+        f"{env_var} environment variable" for env_var in sources.env_vars
+    ]
+    source_descriptions.extend(f"{section}.{key}" for key in sources.config_keys)
+    source_descriptions.extend(
+        f"environment variable named by {section}.{key}"
+        for key in sources.config_env_keys
+    )
+    sources_text = " or ".join(source_descriptions)
+    raise RuntimeError(
+        f"{sources_text} is required for {spec.display_name} provider but not set."
+    )
+
+
+def _copy_provider_config(
+    provider_config: Mapping[str, object], spec: ProviderConfigSpec
+) -> dict[str, object]:
+    config: dict[str, object] = {}
+    for output_key, sources in _copy_key_sources(spec.copy_keys):
+        value = _first_value(provider_config, sources)
+        if _is_missing(value):
+            continue
+        config[output_key] = value
+    return config
+
+
+def _copy_key_sources(copy_keys: CopyKeySpec):
+    if isinstance(copy_keys, Mapping):
+        return copy_keys.items()
+    return ((key, (key,)) for key in copy_keys)
+
+
+def _first_value(
+    provider_config: Mapping[str, object], sources: tuple[str, ...]
+) -> object | None:
+    for source in sources:
+        value: object | None
+        if source.startswith("env:"):
+            value = os.environ.get(source.removeprefix("env:"))
+        elif source in provider_config:
+            value = provider_config[source]
+        else:
+            continue
+        if not _is_missing(value):
+            return value
+    return None
+
+
+def _optional_condition_matches(
+    provider_config: Mapping[str, object],
+    optional_when: tuple[str, object] | None,
+) -> bool:
+    if optional_when is None:
+        return False
+    key, expected_value = optional_when
+    return provider_config.get(key) == expected_value
+
+
+def _compact_provider_config(config: Mapping[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in config.items()
+        if value is not None and value != "" and value != {}
+    }
+
+
+def _is_missing(value: object) -> bool:
+    return value is None or value == "" or value == {}

--- a/src/metis/providers/gemini.py
+++ b/src/metis/providers/gemini.py
@@ -3,50 +3,65 @@
 
 from __future__ import annotations
 
-from typing import Any, Unpack, cast
+from collections.abc import Mapping
+from typing import Any, Required, TypedDict, cast
 
 from langchain_core.callbacks import Callbacks
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_google_genai import GoogleGenerativeAIEmbeddings
-from llama_index.core.callbacks import CallbackManager
 
-from metis.providers.base import ChatModelOptions
-from metis.providers.base import GeminiProviderConfig
-from metis.providers.base import LLMProvider
-from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
-from metis.providers.registry import register_provider
+from metis.providers.base import ChatProvider
+from metis.providers.config import ApiKeySources
+from metis.providers.config import ProviderConfigSpec
 
 
-class GeminiProvider(LLMProvider):
-    def __init__(self, config: GeminiProviderConfig) -> None:
+class GeminiChatConfig(TypedDict, total=False):
+    api_key: str
+    model: Required[str]
+    base_url: str
+    additional_headers: Mapping[str, str]
+    project: str
+    location: str
+    vertexai: bool | None
+    client_args: Mapping[str, object]
+
+
+class GeminiProvider(ChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="Gemini",
+        required_keys=("model",),
+        api_key=ApiKeySources(
+            required=True,
+            env_vars=("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+            optional_when=("vertexai", True),
+        ),
+        copy_keys=(
+            "model",
+            "base_url",
+            "additional_headers",
+            "project",
+            "location",
+            "vertexai",
+            "client_args",
+        ),
+    )
+
+    def __init__(self, config: GeminiChatConfig) -> None:
         self.config = config
-        self.api_key = config.get("llm_api_key")
-        self.query_model = config.get("llama_query_model") or config.get("model")
-        self.temperature = float(config.get("llama_query_temperature", 0.0))
-        self.max_tokens = int(config.get("llama_query_max_tokens", 3072))
-        self.reasoning_effort = config.get("llama_query_reasoning_effort")
-
-        self.code_embedding_model = config.get("code_embedding_model")
-        self.docs_embedding_model = config.get("docs_embedding_model")
-        self.code_embedding_extra_kwargs = dict(
-            config.get("code_embedding_extra_kwargs", {})
-        )
-        self.docs_embedding_extra_kwargs = dict(
-            config.get("docs_embedding_extra_kwargs", {})
-        )
-
-        self.base_url = config.get("gemini_api_base")
-        self.additional_headers = dict(config.get("gemini_additional_headers", {}))
-        self.project = config.get("gemini_project")
-        self.location = config.get("gemini_location")
-        self.vertexai = config.get("gemini_vertexai")
-        self.client_args = dict(config.get("gemini_client_args", {}))
+        self.api_key = config.get("api_key")
+        self.default_model = config.get("model")
+        self.base_url = config.get("base_url")
+        self.additional_headers = dict(config.get("additional_headers", {}))
+        self.project = config.get("project")
+        self.location = config.get("location")
+        self.vertexai = config.get("vertexai")
+        self.client_args = dict(config.get("client_args", {}))
 
         if not self.api_key and not self.vertexai:
             raise ValueError(
                 "GOOGLE_API_KEY or GEMINI_API_KEY environment variable is required "
                 "for Gemini provider but not set."
             )
+        if not self.default_model:
+            raise ValueError("Missing chat model configuration (set 'model')")
 
     def _common_params(self) -> dict[str, object]:
         params: dict[str, object] = {}
@@ -66,78 +81,47 @@ class GeminiProvider(LLMProvider):
             params["client_args"] = self.client_args
         return params
 
-    def get_embed_model_code(
-        self, *, callback_manager: CallbackManager | None = None
-    ) -> LangChainEmbeddingAdapter:
-        return self._build_embedding_model(
-            self.code_embedding_model,
-            self.code_embedding_extra_kwargs,
-            "code_embedding_model",
-            callback_manager=callback_manager,
-        )
-
-    def get_embed_model_docs(
-        self, *, callback_manager: CallbackManager | None = None
-    ) -> LangChainEmbeddingAdapter:
-        return self._build_embedding_model(
-            self.docs_embedding_model,
-            self.docs_embedding_extra_kwargs,
-            "docs_embedding_model",
-            callback_manager=callback_manager,
-        )
-
-    def _build_embedding_model(
-        self,
-        model_name: str | None,
-        extra_kwargs: dict[str, object],
-        config_key: str,
-        callback_manager: CallbackManager | None = None,
-    ) -> LangChainEmbeddingAdapter:
-        if not model_name:
-            raise ValueError(f"Missing '{config_key}' in configuration")
-
-        params = {
-            "model": model_name,
-            **self._common_params(),
-            **extra_kwargs,
-        }
-        client = GoogleGenerativeAIEmbeddings(**cast(dict[str, Any], params))
-        return LangChainEmbeddingAdapter(
-            client,
-            model_name=model_name,
-            callback_manager=callback_manager,
-        )
-
     def get_chat_model(
         self,
         *args: str,
         callbacks: Callbacks = None,
-        **kwargs: Unpack[ChatModelOptions],
-    ) -> ChatGoogleGenerativeAI:
+        **kwargs: object,
+    ) -> Any:
+        try:
+            from langchain_google_genai import ChatGoogleGenerativeAI
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "Gemini provider requires the langchain-google-genai extra."
+            ) from exc
+
         requested_model = kwargs.pop("model", None)
         positional_model = args[0] if args else None
-        model_name = requested_model or positional_model or self.query_model
+        model_name = requested_model or positional_model or self.default_model
         if not model_name:
             raise ValueError("Missing chat model configuration")
 
         response_format = kwargs.pop("response_format", None)
         params: dict[str, object] = {
             "model": model_name,
-            "temperature": kwargs.get("temperature", self.temperature),
-            "max_tokens": kwargs.get("max_tokens", self.max_tokens),
             **self._common_params(),
         }
+        temperature = kwargs.get("temperature")
+        if temperature is not None:
+            params["temperature"] = float(temperature)
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is not None:
+            params["max_tokens"] = int(max_tokens)
         if callbacks is not None:
             params["callbacks"] = callbacks
 
         if (
-            response_format
+            isinstance(response_format, Mapping)
             and response_format.get("type") == "json_object"
             and "response_mime_type" not in kwargs
         ):
             params["response_mime_type"] = "application/json"
 
-        reasoning_effort = kwargs.get("reasoning_effort", self.reasoning_effort)
+        reasoning_effort = kwargs.get("reasoning_effort")
         if (
             "thinking_level" not in kwargs
             and isinstance(reasoning_effort, str)
@@ -163,7 +147,7 @@ class GeminiProvider(LLMProvider):
             if optional_key in kwargs:
                 params[optional_key] = kwargs[optional_key]
 
-        return ChatGoogleGenerativeAI(**cast(dict[str, Any], params))
-
-
-register_provider("gemini", GeminiProvider)
+        chat_model = ChatGoogleGenerativeAI(**cast(dict[str, Any], params))
+        if temperature is None:
+            cast(Any, chat_model).temperature = None
+        return chat_model

--- a/src/metis/providers/llamacpp.py
+++ b/src/metis/providers/llamacpp.py
@@ -15,13 +15,15 @@ from __future__ import annotations
 
 import logging
 
-from metis.providers.openai_compatible import OpenAICompatibleProvider
-from metis.providers.registry import register_provider
+from metis.providers.openai_compatible import OpenAICompatibleChatProvider
+from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
+from metis.providers.config import ApiKeySources
+from metis.providers.config import ProviderConfigSpec
 
 logger = logging.getLogger(__name__)
 
 
-class LlamaCppProvider(OpenAICompatibleProvider):
+class LlamaCppProvider(OpenAICompatibleChatProvider):
     """Provider for llama.cpp HTTP server.
 
     The server is OpenAI-API compatible and supports:
@@ -36,23 +38,39 @@ class LlamaCppProvider(OpenAICompatibleProvider):
 
     DEFAULT_BASE_URL = "http://localhost:8080/v1"
     DEFAULT_API_KEY = "sk-no-key-required"
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="llama.cpp",
+        required_keys=("model",),
+        api_key=ApiKeySources(required=False, env_vars=("LLAMACPP_API_KEY",)),
+        copy_keys=("base_url", "default_headers", "model"),
+    )
 
     def __init__(self, config):
-        super().__init__(
-            config,
-            default_base_url=self.DEFAULT_BASE_URL,
-            default_api_key=self.DEFAULT_API_KEY,
-        )
+        super().__init__(config)
 
-        if (
-            not config.get("openai_api_base")
-            and not config.get("api_base")
-            and not config.get("base_url")
-        ):
+        if not config.get("base_url"):
             logger.info(
                 "llama.cpp base URL not configured, defaulting to %s",
                 self.DEFAULT_BASE_URL,
             )
 
 
-register_provider("llamacpp", LlamaCppProvider)
+class LlamaCppEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
+    DEFAULT_BASE_URL = LlamaCppProvider.DEFAULT_BASE_URL
+    DEFAULT_API_KEY = LlamaCppProvider.DEFAULT_API_KEY
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="llama.cpp embeddings",
+        required_keys=("code_embedding_model", "docs_embedding_model"),
+        api_key=ApiKeySources(required=False, env_vars=("LLAMACPP_API_KEY",)),
+        copy_keys=(
+            "base_url",
+            "default_headers",
+            "code_embedding_model",
+            "docs_embedding_model",
+            "code_extra_kwargs",
+            "docs_extra_kwargs",
+        ),
+    )
+
+    def __init__(self, config):
+        super().__init__(config)

--- a/src/metis/providers/ollama.py
+++ b/src/metis/providers/ollama.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 
 import logging
 
-from metis.providers.openai_compatible import OpenAICompatibleProvider
-from metis.providers.registry import register_provider
+from metis.providers.openai_compatible import OpenAICompatibleChatProvider
+from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
+from metis.providers.config import ProviderConfigSpec
 
 logger = logging.getLogger(__name__)
 
 
-class OllamaProvider(OpenAICompatibleProvider):
+class OllamaProvider(OpenAICompatibleChatProvider):
     """Provider for Ollama's OpenAI-compatible API.
 
     Default base URL is http://localhost:11434/v1.
@@ -25,18 +26,36 @@ class OllamaProvider(OpenAICompatibleProvider):
 
     DEFAULT_BASE_URL = "http://localhost:11434/v1"
     DEFAULT_API_KEY = "default-key"
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="Ollama",
+        required_keys=("model",),
+        copy_keys=("base_url", "default_headers", "model"),
+    )
 
     def __init__(self, config):
-        if not config.get("llm_api_key"):
+        if not config.get("api_key"):
             logger.warning(
                 "Langchain Ollama integration requires an non-empty api_key, "
                 "using a default."
             )
-        super().__init__(
-            config,
-            default_base_url=self.DEFAULT_BASE_URL,
-            default_api_key=self.DEFAULT_API_KEY,
-        )
+        super().__init__(config)
 
 
-register_provider("ollama", OllamaProvider)
+class OllamaEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
+    DEFAULT_BASE_URL = OllamaProvider.DEFAULT_BASE_URL
+    DEFAULT_API_KEY = OllamaProvider.DEFAULT_API_KEY
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="Ollama embeddings",
+        required_keys=("code_embedding_model", "docs_embedding_model"),
+        copy_keys=(
+            "base_url",
+            "default_headers",
+            "code_embedding_model",
+            "docs_embedding_model",
+            "code_extra_kwargs",
+            "docs_extra_kwargs",
+        ),
+    )
+
+    def __init__(self, config):
+        super().__init__(config)

--- a/src/metis/providers/openai.py
+++ b/src/metis/providers/openai.py
@@ -1,16 +1,50 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from metis.providers.openai_compatible import OpenAICompatibleProvider
-from metis.providers.registry import register_provider
+from metis.providers.openai_compatible import OpenAICompatibleChatProvider
+from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
+from metis.providers.config import ApiKeySources
+from metis.providers.config import ProviderConfigSpec
 
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class OpenAIProvider(OpenAICompatibleProvider):
-    pass
+class OpenAIProvider(OpenAICompatibleChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="OpenAI",
+        required_keys=("model",),
+        api_key=ApiKeySources(required=True, env_vars=("OPENAI_API_KEY",)),
+        copy_keys=("base_url", "default_headers", "model"),
+    )
+
+    def __init__(self, config):
+        super().__init__(config)
+        if not self.api_key:
+            raise ValueError(
+                "OPENAI_API_KEY environment variable is required for OpenAI provider but not set."
+            )
 
 
-register_provider("openai", OpenAIProvider)
+class OpenAIEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="OpenAI embeddings",
+        required_keys=("code_embedding_model", "docs_embedding_model"),
+        api_key=ApiKeySources(required=True, env_vars=("OPENAI_API_KEY",)),
+        copy_keys=(
+            "base_url",
+            "default_headers",
+            "code_embedding_model",
+            "docs_embedding_model",
+            "code_extra_kwargs",
+            "docs_extra_kwargs",
+        ),
+    )
+
+    def __init__(self, config):
+        super().__init__(config)
+        if not self.api_key:
+            raise ValueError(
+                "OPENAI_API_KEY environment variable is required for OpenAI embeddings but not set."
+            )

--- a/src/metis/providers/openai_compatible.py
+++ b/src/metis/providers/openai_compatible.py
@@ -3,122 +3,73 @@
 
 from __future__ import annotations
 
-from typing import Any, Unpack, cast
+from collections.abc import Mapping
+from typing import Any, Required, TypedDict, cast
 
-from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_core.callbacks import Callbacks
+from langchain_openai import ChatOpenAI
+from langchain_openai import OpenAIEmbeddings
 from llama_index.core.callbacks import CallbackManager
 from pydantic import SecretStr
 
-from metis.providers.base import (
-    ChatModelOptions,
-    LLMProvider,
-    OpenAICompatibleProviderConfig,
-)
+from metis.providers.base import ChatProvider
+from metis.providers.base import EmbeddingProvider
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 
 
-class OpenAICompatibleProvider(LLMProvider):
-    def __init__(
-        self,
-        config: OpenAICompatibleProviderConfig,
-        *,
-        default_base_url: str | None = None,
-        default_api_key: str | None = None,
-    ) -> None:
+class OpenAICompatibleChatConfig(TypedDict, total=False):
+    api_key: str
+    base_url: str
+    default_headers: Mapping[str, str]
+    model: Required[str]
+
+
+class OpenAICompatibleEmbeddingConfig(TypedDict, total=False):
+    api_key: str
+    base_url: str
+    default_headers: Mapping[str, str]
+    code_embedding_model: Required[str]
+    docs_embedding_model: Required[str]
+    code_extra_kwargs: Mapping[str, object]
+    docs_extra_kwargs: Mapping[str, object]
+
+
+class OpenAICompatibleChatProvider(ChatProvider):
+    DEFAULT_BASE_URL: str | None = None
+    DEFAULT_API_KEY: str | None = None
+
+    def __init__(self, config: OpenAICompatibleChatConfig) -> None:
         self.config = config
-        self.api_key = config.get("llm_api_key")
-        self.base_url = (
-            config.get("openai_api_base")
-            or config.get("api_base")
-            or config.get("base_url")
-            or default_base_url
-        )
-        self.default_headers = dict(
-            config.get("openai_default_headers") or config.get("default_headers") or {}
-        )
-        self.query_model = config.get("llama_query_model") or config.get("model")
-        self.temperature = float(config.get("llama_query_temperature", 0.0))
-        self.max_tokens = int(config.get("llama_query_max_tokens", 3072))
-        self.reasoning_effort = config.get("llama_query_reasoning_effort")
-        self.code_embedding_model = config.get("code_embedding_model")
-        self.docs_embedding_model = config.get("docs_embedding_model")
-        self.code_embedding_extra_kwargs = dict(
-            config.get("code_embedding_extra_kwargs", {})
-        )
-        self.docs_embedding_extra_kwargs = dict(
-            config.get("docs_embedding_extra_kwargs", {})
-        )
-        # Apply default API key when none provided
-        if not self.api_key and default_api_key:
-            self.api_key = default_api_key
+        self.api_key = config.get("api_key") or self.DEFAULT_API_KEY
+        self.base_url = config.get("base_url") or self.DEFAULT_BASE_URL
+        self.default_headers = dict(config.get("default_headers") or {})
+        self.default_model = config.get("model")
 
-    def get_embed_model_code(
-        self, *, callback_manager: CallbackManager | None = None
-    ) -> LangChainEmbeddingAdapter:
-        return self._build_embedding_model(
-            self.code_embedding_model,
-            self.code_embedding_extra_kwargs,
-            "code_embedding_model",
-            callback_manager=callback_manager,
-        )
-
-    def get_embed_model_docs(
-        self, *, callback_manager: CallbackManager | None = None
-    ) -> LangChainEmbeddingAdapter:
-        return self._build_embedding_model(
-            self.docs_embedding_model,
-            self.docs_embedding_extra_kwargs,
-            "docs_embedding_model",
-            callback_manager=callback_manager,
-        )
-
-    def _build_embedding_model(
-        self,
-        model_name: str | None,
-        extra_kwargs: dict[str, object],
-        config_key: str,
-        callback_manager: CallbackManager | None = None,
-    ) -> LangChainEmbeddingAdapter:
-        if not model_name:
-            raise ValueError(f"Missing '{config_key}' in configuration")
-
-        params: dict[str, object] = {"model": model_name}
-        if self.api_key:
-            params["api_key"] = SecretStr(self.api_key)
-        if self.base_url:
-            params["base_url"] = self.base_url
-        if self.default_headers:
-            params["default_headers"] = self.default_headers
-        if extra_kwargs:
-            params.update(extra_kwargs)
-
-        client = OpenAIEmbeddings(**cast(dict[str, Any], params))
-        return LangChainEmbeddingAdapter(
-            client,
-            model_name=model_name,
-            callback_manager=callback_manager,
-        )
+        if not self.default_model:
+            raise ValueError("Missing chat model configuration")
 
     def get_chat_model(
         self,
         *args: str,
         callbacks: Callbacks = None,
-        **kwargs: Unpack[ChatModelOptions],
+        **kwargs: object,
     ) -> ChatOpenAI:
         requested_model = kwargs.pop("model", None)
         positional_model = args[0] if args else None
-        model_name = requested_model or positional_model or self.query_model
+        model_name = requested_model or positional_model or self.default_model
         if not model_name:
             raise ValueError("Missing chat model configuration")
 
         params: dict[str, object] = {
             "model": model_name,
-            "temperature": kwargs.get("temperature", self.temperature),
-            "max_tokens": kwargs.get("max_tokens", self.max_tokens),
             "use_responses_api": True,
         }
-
+        temperature = kwargs.get("temperature")
+        if temperature is not None:
+            params["temperature"] = float(temperature)
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is not None:
+            params["max_tokens"] = int(max_tokens)
         if self.api_key:
             params["api_key"] = self.api_key
         if self.base_url:
@@ -127,8 +78,6 @@ class OpenAICompatibleProvider(LLMProvider):
             params["default_headers"] = self.default_headers
         if callbacks is not None:
             params["callbacks"] = callbacks
-        if self.reasoning_effort:
-            params["reasoning_effort"] = self.reasoning_effort
 
         for optional_key in (
             "timeout",
@@ -145,3 +94,65 @@ class OpenAICompatibleProvider(LLMProvider):
                 params[optional_key] = kwargs[optional_key]
 
         return ChatOpenAI(**cast(dict[str, Any], params))
+
+
+class OpenAICompatibleEmbeddingProvider(EmbeddingProvider):
+    DEFAULT_BASE_URL: str | None = None
+    DEFAULT_API_KEY: str | None = None
+
+    def __init__(self, config: OpenAICompatibleEmbeddingConfig) -> None:
+        self.config = config
+        self.api_key = config.get("api_key") or self.DEFAULT_API_KEY
+        self.base_url = config.get("base_url") or self.DEFAULT_BASE_URL
+        self.default_headers = dict(config.get("default_headers") or {})
+        self.code_embedding_model = config.get("code_embedding_model")
+        self.docs_embedding_model = config.get("docs_embedding_model")
+        self.code_extra_kwargs = dict(config.get("code_extra_kwargs", {}))
+        self.docs_extra_kwargs = dict(config.get("docs_extra_kwargs", {}))
+
+        if not self.code_embedding_model or not self.docs_embedding_model:
+            raise ValueError(
+                "Missing embedding model configuration "
+                "(set 'code_embedding_model' and 'docs_embedding_model')"
+            )
+
+    def get_embed_model_code(
+        self, *, callback_manager: CallbackManager | None = None
+    ) -> LangChainEmbeddingAdapter:
+        return self._build_embedding_model(
+            self.code_embedding_model,
+            self.code_extra_kwargs,
+            callback_manager=callback_manager,
+        )
+
+    def get_embed_model_docs(
+        self, *, callback_manager: CallbackManager | None = None
+    ) -> LangChainEmbeddingAdapter:
+        return self._build_embedding_model(
+            self.docs_embedding_model,
+            self.docs_extra_kwargs,
+            callback_manager=callback_manager,
+        )
+
+    def _build_embedding_model(
+        self,
+        model_name: str,
+        extra_kwargs: dict[str, object],
+        callback_manager: CallbackManager | None = None,
+    ) -> LangChainEmbeddingAdapter:
+        params: dict[str, object] = {"model": model_name}
+        if self.api_key:
+            params["api_key"] = SecretStr(self.api_key)
+        if self.base_url:
+            params["base_url"] = self.base_url
+        if self.default_headers:
+            params["default_headers"] = self.default_headers
+        if extra_kwargs:
+            params.update(extra_kwargs)
+
+        client = OpenAIEmbeddings(**cast(dict[str, Any], params))
+        return LangChainEmbeddingAdapter(
+            client,
+            model_name=model_name,
+            callback_manager=callback_manager,
+        )

--- a/src/metis/providers/registry.py
+++ b/src/metis/providers/registry.py
@@ -1,80 +1,169 @@
-# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from importlib import metadata
 from importlib import import_module
-from typing import Dict, Type
+from pathlib import Path
+import tomllib
+from typing import Type
 
-from metis.providers.base import LLMProvider
+from metis.providers.base import ChatProvider
+from metis.providers.base import EmbeddingProvider
 
-_PROVIDERS: Dict[str, Type[LLMProvider]] = {}
-_LOADERS: Dict[str, str] = {}
+_PROVIDER_ENTRY_POINT_GROUP = "metis.providers"
+_PROVIDER_ENTRY_POINT_SURFACES = {"chat", "embedding"}
+_CHAT_PROVIDERS: dict[str, Type[ChatProvider]] = {}
+_EMBEDDING_PROVIDERS: dict[str, Type[EmbeddingProvider]] = {}
+_PROVIDER_LOADERS_DISCOVERED = False
 
 
-def register_provider(name: str, provider_cls: Type[LLMProvider]) -> None:
-    """Register an LLM provider under a case-insensitive name."""
+@dataclass(frozen=True)
+class ProviderLoader:
+    chat: str | None = None
+    embedding: str | None = None
+
+
+_PROVIDER_LOADERS: dict[str, ProviderLoader] = {}
+
+
+def _register_chat_provider(name: str, provider_cls: Type[ChatProvider]) -> None:
+    _CHAT_PROVIDERS[name.lower()] = provider_cls
+
+
+def _register_embedding_provider(
+    name: str, provider_cls: Type[EmbeddingProvider]
+) -> None:
+    _EMBEDDING_PROVIDERS[name.lower()] = provider_cls
+
+
+def _register_provider_loader(
+    name: str, *, chat: str | None = None, embedding: str | None = None
+) -> None:
+    if chat is None and embedding is None:
+        raise ValueError("Provider loader must define a chat or embedding class.")
     key = name.lower()
-    _PROVIDERS[key] = provider_cls
+    current = _PROVIDER_LOADERS.get(key, ProviderLoader())
+    if chat is not None and current.chat not in (None, chat):
+        raise ValueError(f"Chat provider loader already registered for: {name}")
+    if embedding is not None and current.embedding not in (None, embedding):
+        raise ValueError(f"Embedding provider loader already registered for: {name}")
+    _PROVIDER_LOADERS[key] = ProviderLoader(
+        chat=chat or current.chat,
+        embedding=embedding or current.embedding,
+    )
 
 
-def register_provider_loader(name: str, dotted_path: str) -> None:
-    """
-    Register a deferred loader for a provider. The dotted path should be
-    formatted as ``"module.submodule:ClassName"``.
-    """
+def get_chat_provider(name: str) -> Type[ChatProvider]:
     key = name.lower()
-    _LOADERS[key] = dotted_path
+    if key in _CHAT_PROVIDERS:
+        return _CHAT_PROVIDERS[key]
+    _discover_provider_loaders()
+    loader = _PROVIDER_LOADERS.get(key)
+    if loader and loader.chat:
+        return _load_chat_provider(name, loader.chat)
+    raise ValueError(f"Unsupported chat provider: {name}")
 
 
-def _load_provider_from_path(name: str, dotted_path: str) -> Type[LLMProvider]:
+def get_embedding_provider(name: str) -> Type[EmbeddingProvider]:
+    key = name.lower()
+    if key in _EMBEDDING_PROVIDERS:
+        return _EMBEDDING_PROVIDERS[key]
+    _discover_provider_loaders()
+    loader = _PROVIDER_LOADERS.get(key)
+    if loader and loader.embedding:
+        return _load_embedding_provider(name, loader.embedding)
+    raise ValueError(f"Unsupported embedding provider: {name}")
+
+
+def _discover_provider_loaders() -> None:
+    global _PROVIDER_LOADERS_DISCOVERED
+    if _PROVIDER_LOADERS_DISCOVERED:
+        return
+
+    for entry_point in metadata.entry_points().select(
+        group=_PROVIDER_ENTRY_POINT_GROUP
+    ):
+        provider_name, surface = _parse_provider_entry_point_name(entry_point.name)
+        if surface == "chat":
+            _register_provider_loader(provider_name, chat=entry_point.value)
+        else:
+            _register_provider_loader(provider_name, embedding=entry_point.value)
+
+    _discover_source_tree_provider_loaders()
+
+    _PROVIDER_LOADERS_DISCOVERED = True
+
+
+def _discover_source_tree_provider_loaders() -> None:
+    pyproject_path = _find_pyproject_path()
+    if pyproject_path is None:
+        return
+
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    provider_entry_points = (
+        data.get("project", {}).get("entry-points", {}).get(_PROVIDER_ENTRY_POINT_GROUP)
+        or {}
+    )
+    for entry_point_name, dotted_path in provider_entry_points.items():
+        provider_name, surface = _parse_provider_entry_point_name(entry_point_name)
+        if surface == "chat":
+            _register_provider_loader(provider_name, chat=dotted_path)
+        else:
+            _register_provider_loader(provider_name, embedding=dotted_path)
+
+
+def _find_pyproject_path() -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        pyproject_path = parent / "pyproject.toml"
+        if pyproject_path.is_file():
+            return pyproject_path
+    return None
+
+
+def _parse_provider_entry_point_name(name: str) -> tuple[str, str]:
+    provider_name, separator, surface = name.rpartition(".")
+    if (
+        not separator
+        or not provider_name
+        or surface not in _PROVIDER_ENTRY_POINT_SURFACES
+    ):
+        surfaces = ", ".join(sorted(_PROVIDER_ENTRY_POINT_SURFACES))
+        raise ValueError(
+            f"Provider entry point '{name}' must be named '<provider>.<{surfaces}>'."
+        )
+    return provider_name, surface
+
+
+def _load_chat_provider(name: str, dotted_path: str) -> Type[ChatProvider]:
     module_path, class_name = dotted_path.split(":", 1)
-    module = import_module(module_path)
-
-    # Provider modules can self-register on import.
+    try:
+        module = import_module(module_path)
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            f"Chat provider '{name}' is registered but required dependencies are missing."
+        ) from exc
     key = name.lower()
-    if key in _PROVIDERS:
-        return _PROVIDERS[key]
-
+    if key in _CHAT_PROVIDERS:
+        return _CHAT_PROVIDERS[key]
     provider_cls = getattr(module, class_name)
-    register_provider(name, provider_cls)
+    _register_chat_provider(name, provider_cls)
     return provider_cls
 
 
-def get_provider(name: str) -> Type[LLMProvider]:
-    """Fetch a previously registered provider class."""
+def _load_embedding_provider(name: str, dotted_path: str) -> Type[EmbeddingProvider]:
+    module_path, class_name = dotted_path.split(":", 1)
+    try:
+        module = import_module(module_path)
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            f"Embedding provider '{name}' is registered but required dependencies are missing."
+        ) from exc
     key = name.lower()
-    if key in _PROVIDERS:
-        return _PROVIDERS[key]
-
-    dotted_path = _LOADERS.get(key)
-    if dotted_path:
-        try:
-            return _load_provider_from_path(name, dotted_path)
-        except ModuleNotFoundError as exc:
-            raise ModuleNotFoundError(
-                f"Provider '{name}' is registered but required dependencies are missing."
-            ) from exc
-
-    raise ValueError(f"Unsupported LLM provider: {name}")
-
-
-def registered_providers() -> Dict[str, Type[LLMProvider]]:
-    """Return a copy of the provider registry."""
-    return dict(_PROVIDERS)
-
-
-# Built-in provider loaders (lazy import until requested)
-register_provider_loader("openai", "metis.providers.openai:OpenAIProvider")
-register_provider_loader(
-    "azure_openai", "metis.providers.azure_openai:AzureOpenAIProvider"
-)
-register_provider_loader("vllm", "metis.providers.vllm:VLLMProvider")
-register_provider_loader("ollama", "metis.providers.ollama:OllamaProvider")
-register_provider_loader("anthropic", "metis.providers.anthropic:AnthropicProvider")
-register_provider_loader("bedrock", "metis.providers.bedrock:BedrockProvider")
-register_provider_loader(
-    "bedrock_mantle", "metis.providers.bedrock_mantle:BedrockMantleProvider"
-)
-register_provider_loader("gemini", "metis.providers.gemini:GeminiProvider")
-register_provider_loader("llamacpp", "metis.providers.llamacpp:LlamaCppProvider")
+    if key in _EMBEDDING_PROVIDERS:
+        return _EMBEDDING_PROVIDERS[key]
+    provider_cls = getattr(module, class_name)
+    _register_embedding_provider(name, provider_cls)
+    return provider_cls

--- a/src/metis/providers/vllm.py
+++ b/src/metis/providers/vllm.py
@@ -3,23 +3,48 @@
 
 import logging
 
-from metis.providers.openai_compatible import OpenAICompatibleProvider
-from metis.providers.registry import register_provider
+from metis.providers.openai_compatible import OpenAICompatibleChatProvider
+from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
+from metis.providers.config import ApiKeySources
+from metis.providers.config import ProviderConfigSpec
 
 
 logger = logging.getLogger(__name__)
 
 
-class VLLMProvider(OpenAICompatibleProvider):
+class VLLMProvider(OpenAICompatibleChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="vLLM",
+        required_keys=("base_url", "model"),
+        api_key=ApiKeySources(required=False, env_vars=("VLLM_API_KEY",)),
+        copy_keys=("base_url", "default_headers", "model"),
+    )
+
     def __init__(self, config):
         super().__init__(config)
         if not self.base_url:
-            raise ValueError(
-                "vLLM provider requires 'openai_api_base' to be configured"
-            )
+            raise ValueError("vLLM provider requires 'base_url' to be configured")
 
         if not self.api_key:
             logger.debug("vLLM provider running without API key")
 
 
-register_provider("vllm", VLLMProvider)
+class VLLMEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
+    CONFIG_SPEC = ProviderConfigSpec(
+        display_name="vLLM embeddings",
+        required_keys=("base_url", "code_embedding_model", "docs_embedding_model"),
+        api_key=ApiKeySources(required=False, env_vars=("VLLM_API_KEY",)),
+        copy_keys=(
+            "base_url",
+            "default_headers",
+            "code_embedding_model",
+            "docs_embedding_model",
+            "code_extra_kwargs",
+            "docs_extra_kwargs",
+        ),
+    )
+
+    def __init__(self, config):
+        super().__init__(config)
+        if not self.base_url:
+            raise ValueError("vLLM embeddings require 'base_url' to be configured")

--- a/src/metis/vector_store/chroma_store.py
+++ b/src/metis/vector_store/chroma_store.py
@@ -14,6 +14,7 @@ from metis.vector_store.base import BaseVectorStore
 from metis.vector_store.retrievers import (
     ChromaCollectionRetriever,
     QueryAnswerRetriever,
+    query_chat_model_kwargs,
 )
 
 logger = logging.getLogger(__name__)
@@ -63,9 +64,10 @@ class ChromaStore(BaseVectorStore):
     ):
         try:
             top_k = similarity_top_k or self.query_config.get("similarity_top_k", 5)
-            chat_model_kwargs = {"response_format": None}
-            if callbacks:
-                chat_model_kwargs["callbacks"] = callbacks
+            chat_model_kwargs = query_chat_model_kwargs(
+                self.query_config,
+                callbacks=callbacks,
+            )
             retriever_code = QueryAnswerRetriever(
                 ChromaCollectionRetriever(
                     self.collection_code,

--- a/src/metis/vector_store/pgvector_store.py
+++ b/src/metis/vector_store/pgvector_store.py
@@ -10,6 +10,7 @@ from metis.exceptions import (
 )
 from metis.vector_store.base import BaseVectorStore
 from metis.vector_store.retrievers import LlamaIndexNodeRetriever, QueryAnswerRetriever
+from metis.vector_store.retrievers import query_chat_model_kwargs
 from llama_index.vector_stores.postgres import PGVectorStore
 from sqlalchemy.engine.url import make_url
 
@@ -27,6 +28,7 @@ class PGVectorStoreImpl(BaseVectorStore):
         embed_model_code,
         embed_model_docs,
         embed_dim,
+        query_config=None,
         hnsw_kwargs=None,
     ):
         self.connection_string = connection_string
@@ -34,6 +36,7 @@ class PGVectorStoreImpl(BaseVectorStore):
         self.embed_model_code = embed_model_code
         self.embed_model_docs = embed_model_docs
         self.embed_dim = embed_dim
+        self.query_config = query_config or {}
         self.hnsw_kwargs = hnsw_kwargs or {}
         self._initialized = False
 
@@ -101,9 +104,10 @@ class PGVectorStoreImpl(BaseVectorStore):
                 embed_model=self.embed_model_docs,
                 callback_manager=callback_manager,
             )
-            chat_model_kwargs = {"response_format": None}
-            if callbacks:
-                chat_model_kwargs["callbacks"] = callbacks
+            chat_model_kwargs = query_chat_model_kwargs(
+                self.query_config,
+                callbacks=callbacks,
+            )
             retriever_code = QueryAnswerRetriever(
                 LlamaIndexNodeRetriever(
                     index_code.as_retriever(similarity_top_k=similarity_top_k)

--- a/src/metis/vector_store/retrievers.py
+++ b/src/metis/vector_store/retrievers.py
@@ -10,6 +10,26 @@ from langchain_core.documents import Document
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
+from metis.chat_model_options import merge_chat_model_kwargs
+
+
+def retriever_query_config(runtime: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "llama_query_model": runtime.get("llama_query_model"),
+        "chat_model_kwargs": dict(runtime.get("chat_model_kwargs") or {}),
+        "similarity_top_k": runtime.get("similarity_top_k", 5),
+    }
+
+
+def query_chat_model_kwargs(
+    query_config: dict[str, Any], *, callbacks: Any = None
+) -> dict[str, Any]:
+    return merge_chat_model_kwargs(
+        query_config.get("chat_model_kwargs") or {},
+        model=query_config.get("llama_query_model"),
+        callbacks=callbacks,
+    )
+
 
 class QueryAnswerRetriever:
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,18 +52,25 @@ def dummy_backend():
 def dummy_llm():
     llm = Mock()
     llm.get_chat_model.return_value = MagicMock()
-    llm.get_embed_model_code.return_value = Mock()
-    llm.get_embed_model_docs.return_value = Mock()
     return llm
 
 
 @pytest.fixture
-def engine(dummy_backend, dummy_llm):
+def dummy_embedding_provider():
+    provider = Mock()
+    provider.get_embed_model_code.return_value = Mock()
+    provider.get_embed_model_docs.return_value = Mock()
+    return provider
+
+
+@pytest.fixture
+def engine(dummy_backend, dummy_llm, dummy_embedding_provider):
     return MetisEngine(
         codebase_path="./tests/data",
         vector_backend=dummy_backend,
         language_plugin="c",
         llm_provider=dummy_llm,
+        embedding_provider=dummy_embedding_provider,
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -78,6 +85,13 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="Run tests marked with @pytest.mark.postgres",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "postgres: tests that require a local Postgres service",
     )
 
 

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -9,21 +9,14 @@ pytest.importorskip("langchain_anthropic")
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.callbacks.base import BaseCallbackHandler
-from llama_index.core.callbacks import CallbackManager
 
 from metis.providers.anthropic import AnthropicProvider
 
 
 def _config(**overrides):
     config = {
-        "llm_api_key": "anthropic-key",
-        "embedding_api_key": "embedding-key",
+        "api_key": "anthropic-key",
         "model": "claude-opus-4-1-20250805",
-        "llama_query_model": "claude-opus-4-1-20250805",
-        "llama_query_temperature": 0.2,
-        "llama_query_max_tokens": 256,
-        "code_embedding_model": "text-embedding-3-large",
-        "docs_embedding_model": "text-embedding-3-small",
     }
     config.update(overrides)
     return config
@@ -36,106 +29,33 @@ def test_chat_model_uses_anthropic_configuration():
 
     assert isinstance(llm, ChatAnthropic)
     assert llm.model == "claude-opus-4-1-20250805"
-    assert llm.max_tokens == 256
-    assert llm.temperature is None
 
 
 def test_chat_model_allows_runtime_overrides_and_callbacks():
-    provider = AnthropicProvider(_config(supports_temperature=True))
+    provider = AnthropicProvider(_config())
     callback = Mock(spec=BaseCallbackHandler)
 
     llm = provider.get_chat_model(
         model="claude-opus-4-1-20250805",
         callbacks=[callback],
         max_tokens=128,
-        temperature=0.0,
     )
 
     assert llm.model == "claude-opus-4-1-20250805"
     assert llm.callbacks == [callback]
     assert llm.max_tokens == 128
-    assert llm.temperature == 0.0
 
 
-def test_chat_model_top_p_omits_default_temperature():
-    provider = AnthropicProvider(_config(supports_temperature=True))
+def test_chat_model_accepts_top_p():
+    provider = AnthropicProvider(_config())
 
     llm = provider.get_chat_model(top_p=0.8)
 
     assert llm.top_p == 0.8
-    assert llm.temperature is None
 
 
-def test_chat_model_rejects_temperature_and_top_p_together():
-    provider = AnthropicProvider(_config())
-
+def test_provider_requires_api_key():
     with pytest.raises(ValueError) as exc_info:
-        provider.get_chat_model(temperature=0.0, top_p=0.8)
+        AnthropicProvider(_config(api_key=""))
 
-    assert "either temperature or top_p" in str(exc_info.value)
-
-
-def test_chat_model_passes_temperature_when_supported():
-    provider = AnthropicProvider(_config(supports_temperature=True))
-
-    llm = provider.get_chat_model()
-
-    assert llm.temperature == 0.2
-
-
-def test_chat_model_drops_explicit_temperature_when_not_supported():
-    provider = AnthropicProvider(_config())
-
-    llm = provider.get_chat_model(temperature=0.1)
-
-    assert llm.temperature is None
-
-
-def test_provider_accepts_callback_manager_for_embeddings():
-    provider = AnthropicProvider(_config())
-    callback_manager = CallbackManager([])
-
-    embeddings = provider.get_embed_model_code(callback_manager=callback_manager)
-
-    assert embeddings.callback_manager is callback_manager
-
-
-def test_embedding_models_use_openai_compatible_embeddings():
-    provider = AnthropicProvider(_config())
-
-    code_embeddings = provider.get_embed_model_code()
-    docs_embeddings = provider.get_embed_model_docs()
-
-    assert code_embeddings.model_name == "text-embedding-3-large"
-    assert docs_embeddings.model_name == "text-embedding-3-small"
-
-
-def test_custom_openai_compatible_embedding_model_name_is_preserved():
-    provider = AnthropicProvider(
-        _config(
-            code_embedding_model="custom-embedding",
-            docs_embedding_model="custom-embedding",
-        )
-    )
-
-    embeddings = provider.get_embed_model_code()
-
-    assert embeddings.model_name == "custom-embedding"
-
-
-def test_provider_allows_chat_without_embedding_api_key():
-    provider = AnthropicProvider(_config(embedding_api_key=""))
-
-    llm = provider.get_chat_model()
-
-    assert isinstance(llm, ChatAnthropic)
-    assert llm.model == "claude-opus-4-1-20250805"
-
-
-def test_embedding_model_requires_embedding_api_key_when_used():
-    provider = AnthropicProvider(_config(embedding_api_key=""))
-
-    with pytest.raises(ValueError) as exc_info:
-        provider.get_embed_model_code()
-
-    assert "embedding_api_key" in str(exc_info.value)
+    assert "ANTHROPIC_API_KEY" in str(exc_info.value)

--- a/tests/test_azure_provider.py
+++ b/tests/test_azure_provider.py
@@ -1,84 +1,101 @@
-# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import cast
-
-from langchain_openai import AzureChatOpenAI
-from llama_index.core.callbacks import CallbackManager
-from langchain_core.callbacks.base import BaseCallbackHandler
+from typing import Any, cast
 from unittest.mock import Mock
 
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_openai import AzureChatOpenAI
+from llama_index.core.callbacks import CallbackManager
+
+from metis.providers.azure_openai import AzureOpenAIChatConfig
+from metis.providers.azure_openai import AzureOpenAIEmbeddingConfig
+from metis.providers.azure_openai import AzureOpenAIEmbeddingProvider
 from metis.providers.azure_openai import AzureOpenAIProvider
-from metis.providers.base import AzureOpenAIProviderConfig
 
 
-def _config() -> AzureOpenAIProviderConfig:
-    return {
-        "llm_api_key": "test-key",
+def _chat_config(**overrides: object) -> AzureOpenAIChatConfig:
+    config: dict[str, object] = {
+        "api_key": "test-key",
         "azure_endpoint": "https://example.openai.azure.com/",
         "azure_api_version": "2024-02-01",
         "engine": "chat-deployment",
         "chat_deployment_model": "gpt-4o-mini",
+    }
+    config.update(overrides)
+    return cast(AzureOpenAIChatConfig, config)
+
+
+def _embedding_config(**overrides: object) -> AzureOpenAIEmbeddingConfig:
+    config: dict[str, object] = {
+        "api_key": "test-key",
+        "azure_endpoint": "https://example.openai.azure.com/",
+        "azure_api_version": "2024-02-01",
         "code_embedding_model": "text-embedding-3-large",
         "docs_embedding_model": "text-embedding-3-small",
+        "code_deployment": "code-embedding-deployment",
+        "docs_deployment": "docs-embedding-deployment",
     }
+    config.update(overrides)
+    return cast(AzureOpenAIEmbeddingConfig, config)
 
 
 def test_chat_model_uses_configured_deployment() -> None:
-    provider = AzureOpenAIProvider(_config())
+    provider = AzureOpenAIProvider(_chat_config())
 
     llm = provider.get_chat_model(response_format=None)
 
     assert isinstance(llm, AzureChatOpenAI)
     assert llm.deployment_name == "chat-deployment"
     assert llm.model_name == "gpt-4o-mini"
+    assert llm.use_responses_api is not True
+    assert llm.max_tokens is None
+
+
+def test_chat_model_can_use_responses_api() -> None:
+    provider = AzureOpenAIProvider(_chat_config(use_responses_api=True))
+
+    llm = provider.get_chat_model(response_format=None)
+
     assert llm.use_responses_api is True
-    assert llm.max_tokens == 3072
 
 
 def test_embedding_adapter_preserves_azure_config() -> None:
-    provider = AzureOpenAIProvider(_config())
+    provider = AzureOpenAIEmbeddingProvider(_embedding_config())
 
     code_embeddings = provider.get_embed_model_code()
     docs_embeddings = provider.get_embed_model_docs()
+    code_client = cast(Any, code_embeddings._client)
+    docs_client = cast(Any, docs_embeddings._client)
 
     assert code_embeddings.model_name == "text-embedding-3-large"
     assert docs_embeddings.model_name == "text-embedding-3-small"
-    assert code_embeddings._client.model == "text-embedding-3-large"
-    assert docs_embeddings._client.model == "text-embedding-3-small"
+    assert code_client.model == "text-embedding-3-large"
+    assert docs_client.model == "text-embedding-3-small"
+    assert code_client.deployment == "code-embedding-deployment"
+    assert docs_client.deployment == "docs-embedding-deployment"
 
 
-def test_provider_accepts_callbacks_and_embedding_callback_manager() -> None:
-    provider = AzureOpenAIProvider(_config())
+def test_providers_accept_separate_chat_and_embedding_callbacks() -> None:
+    chat_provider = AzureOpenAIProvider(_chat_config())
+    embedding_provider = AzureOpenAIEmbeddingProvider(_embedding_config())
     callback_manager = CallbackManager([])
     callback = cast(BaseCallbackHandler, Mock(spec=BaseCallbackHandler))
 
-    chat = provider.get_chat_model(callbacks=[callback], response_format=None)
-    embeddings = provider.get_embed_model_code(callback_manager=callback_manager)
+    chat = chat_provider.get_chat_model(callbacks=[callback], response_format=None)
+    embeddings = embedding_provider.get_embed_model_code(
+        callback_manager=callback_manager
+    )
 
     assert isinstance(chat, AzureChatOpenAI)
     assert chat.callbacks == [callback]
     assert embeddings.callback_manager is callback_manager
 
 
-def test_provider_does_not_apply_chat_callbacks_to_embeddings() -> None:
-    provider = AzureOpenAIProvider(_config())
-    callback = cast(BaseCallbackHandler, Mock(spec=BaseCallbackHandler))
-
-    chat = provider.get_chat_model(callbacks=[callback], response_format=None)
-    code_embeddings = provider.get_embed_model_code()
-
-    assert isinstance(chat, AzureChatOpenAI)
-    assert chat.callbacks == [callback]
-    assert code_embeddings.callback_manager is not chat.callbacks
-
-
 def test_provider_passes_reasoning_effort_to_chat_model() -> None:
-    config = _config()
-    config["llama_query_reasoning_effort"] = "medium"
-    provider = AzureOpenAIProvider(config)
+    provider = AzureOpenAIProvider(_chat_config())
 
-    llm = provider.get_chat_model(response_format=None)
+    llm = provider.get_chat_model(response_format=None, reasoning_effort="medium")
 
     assert llm.reasoning_effort == "medium"
-    assert llm.use_responses_api is True
+    assert llm.use_responses_api is not True

--- a/tests/test_bedrock_mantle_provider.py
+++ b/tests/test_bedrock_mantle_provider.py
@@ -12,15 +12,9 @@ from metis.providers.bedrock_mantle import ChatBedrockMantle
 
 def _config(**overrides):
     config = {
-        "embedding_api_key": "embedding-key",
         "model": "anthropic.claude-example",
-        "llama_query_model": "anthropic.claude-example",
-        "llama_query_temperature": 0.2,
-        "llama_query_max_tokens": 256,
         "aws_profile": "example-profile",
         "aws_region": "example-region",
-        "code_embedding_model": "text-embedding-3-large",
-        "docs_embedding_model": "text-embedding-3-small",
     }
     config.update(overrides)
     return config
@@ -33,26 +27,8 @@ def test_chat_model_uses_generic_bedrock_mantle_configuration():
 
     assert isinstance(llm, ChatBedrockMantle)
     assert llm.model == "anthropic.claude-example"
-    assert llm.max_tokens == 256
-    assert llm.temperature is None
     assert llm.aws_profile == "example-profile"
     assert llm.aws_region == "example-region"
-
-
-def test_chat_model_can_opt_in_to_temperature():
-    provider = BedrockMantleProvider(_config(supports_temperature=True))
-
-    llm = provider.get_chat_model()
-
-    assert llm.temperature == 0.2
-
-
-def test_chat_model_drops_explicit_temperature_when_not_supported():
-    provider = BedrockMantleProvider(_config())
-
-    llm = provider.get_chat_model(temperature=0.1)
-
-    assert llm.temperature is None
 
 
 def test_chat_model_does_not_default_to_a_specific_region():
@@ -61,36 +37,3 @@ def test_chat_model_does_not_default_to_a_specific_region():
     llm = provider.get_chat_model()
 
     assert llm.aws_region is None
-
-
-def test_chat_model_passes_explicit_aws_credentials():
-    provider = BedrockMantleProvider(
-        _config(
-            aws_access_key_id="AKIA",
-            aws_secret_access_key="secret",
-            aws_session_token="token",
-        )
-    )
-
-    llm = provider.get_chat_model()
-
-    assert llm.aws_access_key == "AKIA"
-    assert llm.aws_secret_key == "secret"
-    assert llm.aws_session_token == "token"
-    params = llm._bedrock_client_params()
-    assert params["aws_access_key"] == "AKIA"
-    assert params["aws_secret_key"] == "secret"
-    assert params["aws_session_token"] == "token"
-
-
-def test_chat_model_omits_explicit_credentials_when_unset():
-    provider = BedrockMantleProvider(
-        _config(aws_access_key_id="", aws_secret_access_key="")
-    )
-
-    llm = provider.get_chat_model()
-
-    assert llm.aws_access_key is None
-    params = llm._bedrock_client_params()
-    assert "aws_access_key" not in params
-    assert "aws_secret_key" not in params

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
@@ -10,18 +11,24 @@ pytest.importorskip("langchain_aws")
 from langchain_core.callbacks.base import BaseCallbackHandler
 from llama_index.core.callbacks import CallbackManager
 
+from metis.providers.bedrock import BedrockEmbeddingProvider
 from metis.providers.bedrock import BedrockProvider
+from metis.providers.bedrock import _credential_kwargs
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
-from metis.providers.registry import _LOADERS, get_provider
 
 
-def _config(**overrides):
+def _chat_config(**overrides):
     config = {
-        "bedrock_region": "us-east-1",
+        "region": "us-east-1",
         "model": "us.anthropic.claude-opus-4-8-v1:0",
-        "llama_query_model": "us.anthropic.claude-opus-4-8-v1:0",
-        "llama_query_temperature": 0.2,
-        "llama_query_max_tokens": 256,
+    }
+    config.update(overrides)
+    return config
+
+
+def _embedding_config(**overrides):
+    config = {
+        "region": "us-east-1",
         "code_embedding_model": "amazon.titan-embed-text-v2:0",
         "docs_embedding_model": "amazon.titan-embed-text-v2:0",
     }
@@ -31,32 +38,22 @@ def _config(**overrides):
 
 @patch("metis.providers.bedrock.ChatBedrockConverse")
 def test_chat_model_uses_configured_model_and_region(mock_chat):
-    provider = BedrockProvider(_config())
+    provider = BedrockProvider(_chat_config())
 
-    provider.get_chat_model()
+    provider.get_chat_model(max_tokens=256)
 
     kwargs = mock_chat.call_args.kwargs
     assert kwargs["model"] == "us.anthropic.claude-opus-4-8-v1:0"
     assert kwargs["region_name"] == "us-east-1"
     assert kwargs["max_tokens"] == 256
-    assert "temperature" not in kwargs
     assert "credentials_profile_name" not in kwargs
     assert "aws_access_key_id" not in kwargs
 
 
 @patch("metis.providers.bedrock.ChatBedrockConverse")
-def test_chat_model_passes_temperature_when_supported(mock_chat):
-    provider = BedrockProvider(_config(supports_temperature=True))
-
-    provider.get_chat_model()
-
-    assert mock_chat.call_args.kwargs["temperature"] == 0.2
-
-
-@patch("metis.providers.bedrock.ChatBedrockConverse")
 def test_chat_model_passes_explicit_aws_credentials(mock_chat):
     provider = BedrockProvider(
-        _config(
+        _chat_config(
             aws_access_key_id="AKIA",
             aws_secret_access_key="secret",
             aws_session_token="token",
@@ -73,7 +70,7 @@ def test_chat_model_passes_explicit_aws_credentials(mock_chat):
 
 @patch("metis.providers.bedrock.ChatBedrockConverse")
 def test_chat_model_uses_profile_when_no_explicit_keys(mock_chat):
-    provider = BedrockProvider(_config(aws_profile="myprofile"))
+    provider = BedrockProvider(_chat_config(aws_profile="myprofile"))
 
     provider.get_chat_model()
 
@@ -84,35 +81,24 @@ def test_chat_model_uses_profile_when_no_explicit_keys(mock_chat):
 
 @patch("metis.providers.bedrock.ChatBedrockConverse")
 def test_chat_model_allows_runtime_overrides_and_callbacks(mock_chat):
-    provider = BedrockProvider(_config(supports_temperature=True))
+    provider = BedrockProvider(_chat_config())
     callback = Mock(spec=BaseCallbackHandler)
 
     provider.get_chat_model(
         model="anthropic.claude-haiku-4-5-v1:0",
         callbacks=[callback],
         max_tokens=128,
-        temperature=0.0,
     )
 
     kwargs = mock_chat.call_args.kwargs
     assert kwargs["model"] == "anthropic.claude-haiku-4-5-v1:0"
     assert kwargs["callbacks"] == [callback]
     assert kwargs["max_tokens"] == 128
-    assert kwargs["temperature"] == 0.0
-
-
-@patch("metis.providers.bedrock.ChatBedrockConverse")
-def test_chat_model_drops_explicit_temperature_when_not_supported(mock_chat):
-    provider = BedrockProvider(_config())
-
-    provider.get_chat_model(temperature=0.1)
-
-    assert "temperature" not in mock_chat.call_args.kwargs
 
 
 @patch("metis.providers.bedrock.BedrockEmbeddings")
 def test_embedding_adapter_wraps_bedrock_embeddings(mock_embed):
-    provider = BedrockProvider(_config())
+    provider = BedrockEmbeddingProvider(_embedding_config())
     callback_manager = CallbackManager([])
 
     code = provider.get_embed_model_code(callback_manager=callback_manager)
@@ -128,20 +114,18 @@ def test_embedding_adapter_wraps_bedrock_embeddings(mock_embed):
 
 
 def test_credential_kwargs_omit_explicit_keys_when_unset():
-    provider = BedrockProvider(
-        _config(aws_access_key_id="", aws_secret_access_key="", aws_session_token="")
+    kwargs = _credential_kwargs(
+        {
+            "region": "us-east-1",
+            "aws_access_key_id": "",
+            "aws_secret_access_key": "",
+            "aws_session_token": "",
+        }
     )
-
-    kwargs = provider._credential_kwargs()
 
     assert kwargs == {"region_name": "us-east-1"}
 
 
 def test_provider_raises_on_missing_region():
     with pytest.raises(ValueError, match="region"):
-        BedrockProvider(_config(bedrock_region=""))
-
-
-def test_lazy_loader_is_registered():
-    assert _LOADERS["bedrock"] == "metis.providers.bedrock:BedrockProvider"
-    assert get_provider("bedrock").__name__ == "BedrockProvider"
+        BedrockProvider(_chat_config(region=""))

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -385,121 +385,12 @@ def test_main_version_does_not_require_runtime_config(monkeypatch, capsys):
     assert "Metis" in capsys.readouterr().out
 
 
-def test_build_embedding_provider_reuses_llm_provider_when_same(monkeypatch):
-    args = SimpleNamespace(quiet=True)
-    llm_provider = object()
-    runtime = {
-        "llm_provider_name": "openai",
-        "embedding_provider_name": "openai",
-        "embedding_provider_config": {"llm_api_key": "k"},
-        "embedding_provider_raw_config": {
-            "name": "openai",
-            "code_embedding_model": "text-embedding-3-large",
-            "docs_embedding_model": "text-embedding-3-large",
-        },
-        "enabled_tools": {"index"},
-    }
-
-    result = entry._build_embedding_provider(args, runtime, llm_provider)
-
-    assert result is llm_provider
-
-
-def test_build_embedding_provider_validates_when_index_enabled(monkeypatch):
-    args = SimpleNamespace(quiet=True)
-    runtime = {
-        "llm_provider_name": "anthropic",
-        "embedding_provider_name": "anthropic",
-        "embedding_provider_config": {},
-        "embedding_provider_raw_config": {"name": "anthropic"},
-        "enabled_tools": {"index"},
-    }
-
-    with pytest.raises(ValueError) as exc_info:
-        entry._build_embedding_provider(args, runtime, object())
-
-    assert "llm_provider.code_embedding_model" in str(exc_info.value)
-
-
-def test_build_embedding_provider_skips_validation_when_index_disabled():
-    args = SimpleNamespace(quiet=True)
-    llm_provider = object()
-    runtime = {
-        "llm_provider_name": "anthropic",
-        "embedding_provider_name": "anthropic",
-        "embedding_provider_config": {},
-        "embedding_provider_raw_config": {"name": "anthropic"},
-        "enabled_tools": set(),
-    }
-
-    result = entry._build_embedding_provider(args, runtime, llm_provider)
-
-    assert result is llm_provider
-
-
-def test_build_embedding_provider_constructs_separate_provider(monkeypatch):
-    constructed = []
-
-    class FakeEmbedProvider:
-        def __init__(self, cfg):
-            constructed.append(cfg)
-
-    monkeypatch.setattr(entry, "get_provider", lambda name: FakeEmbedProvider)
-    args = SimpleNamespace(quiet=True)
-    runtime = {
-        "llm_provider_name": "anthropic",
-        "embedding_provider_name": "openai",
-        "embedding_provider_config": {
-            "llm_api_key": "embed-key",
-            "code_embedding_model": "text-embedding-3-large",
-        },
-        "embedding_provider_raw_config": {
-            "name": "openai",
-            "code_embedding_model": "text-embedding-3-large",
-            "docs_embedding_model": "text-embedding-3-large",
-        },
-        "enabled_tools": {"index"},
-    }
-
-    result = entry._build_embedding_provider(args, runtime, object())
-
-    assert isinstance(result, FakeEmbedProvider)
-    assert constructed[0]["llm_api_key"] == "embed-key"
-
-
-def test_build_embedding_provider_warns_on_incomplete_separate_when_index_off(
-    monkeypatch,
-):
-    captured = []
-    monkeypatch.setattr(
-        entry,
-        "print_console",
-        lambda message, *_args, **_kwargs: captured.append(str(message)),
-    )
-
-    class FakeEmbedProvider:
-        def __init__(self, cfg):
+def test_build_engine_defers_embedding_model_construction(monkeypatch, tmp_path):
+    class ChatProvider:
+        def __init__(self, _runtime):
             pass
 
-    monkeypatch.setattr(entry, "get_provider", lambda name: FakeEmbedProvider)
-    args = SimpleNamespace(quiet=True)
-    runtime = {
-        "llm_provider_name": "anthropic",
-        "embedding_provider_name": "openai",
-        "embedding_provider_config": {},
-        "embedding_provider_raw_config": {"name": "openai"},
-        "enabled_tools": set(),
-    }
-
-    result = entry._build_embedding_provider(args, runtime, object())
-
-    assert isinstance(result, FakeEmbedProvider)
-    assert any("Warning" in m for m in captured)
-    assert any("embedding_provider.code_embedding_model" in m for m in captured)
-
-
-def test_build_engine_defers_embedding_model_construction(monkeypatch, tmp_path):
-    class ProviderWithoutEmbeddings:
+    class EmbeddingProvider:
         def __init__(self, _runtime):
             pass
 
@@ -525,20 +416,32 @@ def test_build_engine_defers_embedding_model_construction(monkeypatch, tmp_path)
         chroma_dir=str(tmp_path / "chromadb"),
         codebase_path=str(tmp_path),
         custom_prompt=None,
+        enabled_tools={"index"},
     )
     runtime = {
         "llm_provider_name": "anthropic",
-        "embedding_provider_name": "anthropic",
-        "embedding_provider_config": {},
-        "embedding_provider_raw_config": {"name": "anthropic"},
+        "llm_provider": {
+            "api_key": "anthropic-key",
+            "model": "claude-opus-4-1-20250805",
+        },
+        "embedding_provider_raw_config": {
+            "api_key_env": "OPENAI_EMBEDDING_KEY",
+            "name": "openai",
+            "code_embedding_model": "text-embedding-3-large",
+            "docs_embedding_model": "text-embedding-3-large",
+        },
         "max_workers": 2,
         "max_token_length": 2048,
         "llama_query_model": "claude-opus-4-1-20250805",
         "similarity_top_k": 3,
         "response_mode": "compact",
     }
+    monkeypatch.setenv("OPENAI_EMBEDDING_KEY", "embedding-key")
 
-    monkeypatch.setattr(entry, "get_provider", lambda _name: ProviderWithoutEmbeddings)
+    monkeypatch.setattr(entry, "get_chat_provider", lambda _name: ChatProvider)
+    monkeypatch.setattr(
+        entry, "get_embedding_provider", lambda _name: EmbeddingProvider
+    )
     monkeypatch.setattr(entry, "build_chroma_backend", build_backend)
     monkeypatch.setattr(entry, "MetisEngine", DummyEngine)
 
@@ -546,4 +449,101 @@ def test_build_engine_defers_embedding_model_construction(monkeypatch, tmp_path)
 
     assert captured["embed_model_code"] is None
     assert captured["embed_model_docs"] is None
+    assert isinstance(
+        captured["engine_kwargs"]["embedding_provider"], EmbeddingProvider
+    )
     assert captured["engine_kwargs"]["usage_runtime"].codebase_path == str(tmp_path)
+
+
+def test_build_engine_skips_embedding_provider_when_index_tool_disabled(
+    monkeypatch, tmp_path
+):
+    class ChatProvider:
+        def __init__(self, _runtime):
+            pass
+
+    class DummyEngine:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    captured = {}
+
+    def build_backend(_args, _runtime, embed_model_code, embed_model_docs):
+        captured["embed_model_code"] = embed_model_code
+        captured["embed_model_docs"] = embed_model_docs
+        return SimpleNamespace(embed_model_code=None, embed_model_docs=None)
+
+    def fail_get_embedding_provider(_name):
+        raise AssertionError("embedding provider should not be loaded")
+
+    args = SimpleNamespace(
+        backend="chroma",
+        chroma_dir=str(tmp_path / "chromadb"),
+        codebase_path=str(tmp_path),
+        custom_prompt=None,
+        enabled_tools=set(),
+    )
+    runtime = {
+        "llm_provider_name": "anthropic",
+        "llm_provider": {
+            "api_key": "anthropic-key",
+            "model": "claude-opus-4-1-20250805",
+        },
+        "embedding_provider_raw_config": {
+            "name": "openai",
+            "code_embedding_model": "text-embedding-3-large",
+            "docs_embedding_model": "text-embedding-3-large",
+        },
+        "max_workers": 2,
+        "max_token_length": 2048,
+        "llama_query_model": "claude-opus-4-1-20250805",
+        "similarity_top_k": 3,
+        "response_mode": "compact",
+    }
+
+    monkeypatch.setattr(entry, "get_chat_provider", lambda _name: ChatProvider)
+    monkeypatch.setattr(entry, "get_embedding_provider", fail_get_embedding_provider)
+    monkeypatch.setattr(entry, "build_chroma_backend", build_backend)
+    monkeypatch.setattr(entry, "MetisEngine", DummyEngine)
+
+    engine, _backend = entry.build_engine(args, runtime)
+
+    assert captured["embed_model_code"] is None
+    assert captured["embed_model_docs"] is None
+    assert engine.kwargs["embedding_provider"] is None
+
+
+def test_build_engine_requires_embedding_config_when_index_tool_enabled(
+    monkeypatch, tmp_path
+):
+    class ChatProvider:
+        def __init__(self, _runtime):
+            pass
+
+    args = SimpleNamespace(
+        backend="chroma",
+        chroma_dir=str(tmp_path / "chromadb"),
+        codebase_path=str(tmp_path),
+        custom_prompt=None,
+        enabled_tools={"index"},
+    )
+    runtime = {
+        "llm_provider_name": "anthropic",
+        "llm_provider": {
+            "api_key": "anthropic-key",
+            "model": "claude-opus-4-1-20250805",
+        },
+        "embedding_provider_raw_config": None,
+        "max_workers": 2,
+        "max_token_length": 2048,
+        "llama_query_model": "claude-opus-4-1-20250805",
+        "similarity_top_k": 3,
+        "response_mode": "compact",
+    }
+
+    monkeypatch.setattr(entry, "get_chat_provider", lambda _name: ChatProvider)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        entry.build_engine(args, runtime)
+
+    assert "embedding_provider" in str(exc_info.value)

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -15,12 +15,6 @@ class _DummyProvider:
     def __init__(self, _config):
         pass
 
-    def get_embed_model_code(self, **_kwargs):
-        return object()
-
-    def get_embed_model_docs(self, **_kwargs):
-        return object()
-
 
 class _DummyEngine:
     def __init__(self, codebase_path=".", **_kwargs):
@@ -109,13 +103,20 @@ def _setup_cli(monkeypatch, tmp_path):
         "load_runtime_config",
         lambda enable_psql=False: {
             "llm_provider_name": "dummy",
+            "llm_provider": {"model": "gpt-test"},
+            "embedding_provider_raw_config": {
+                "name": "ollama",
+                "code_embedding_model": "embed-code-test",
+                "docs_embedding_model": "embed-docs-test",
+            },
             "max_workers": 2,
             "max_token_length": 2048,
             "llama_query_model": "gpt-test",
             "similarity_top_k": 3,
         },
     )
-    monkeypatch.setattr(entry, "get_provider", lambda _name: _DummyProvider)
+    monkeypatch.setattr(entry, "get_chat_provider", lambda _name: _DummyProvider)
+    monkeypatch.setattr(entry, "get_embedding_provider", lambda _name: _DummyProvider)
     monkeypatch.setattr(entry, "build_chroma_backend", lambda *args, **kwargs: object())
     monkeypatch.setattr(entry, "build_pg_backend", lambda *args, **kwargs: object())
     monkeypatch.setattr(entry, "MetisEngine", _DummyEngine)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,11 +1,17 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
+from metis.configuration import build_embedding_provider_config
 from metis.configuration import load_metis_config
 from metis.configuration import load_runtime_config
-from metis.configuration import validate_embedding_provider_config
 
-import pytest
+
+def _write_config(tmp_path, content: str):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(content, encoding="utf-8")
+    return config_path
 
 
 def test_load_metis_config_uses_yml_when_yaml_missing(tmp_path, monkeypatch):
@@ -27,131 +33,88 @@ def test_load_metis_config_prefers_yaml_over_yml(tmp_path, monkeypatch):
     assert config == {"selected": "yaml"}
 
 
-def test_load_runtime_config_reads_query_reasoning_effort(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: openai
-  model: gpt-test
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-metis_engine:
-  max_workers: 2
-query:
-  reasoning_effort: high
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llama_query_reasoning_effort"] == "high"
-    assert runtime["llama_query_max_tokens"] == 3072
-
-
-def test_load_runtime_config_accepts_query_reasoning_level_alias(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: openai
-  model: gpt-test
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-query:
-  reasoning_level: low
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llama_query_reasoning_effort"] == "low"
-
-
-def test_load_runtime_config_reads_openai_base_url_and_headers(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    base_url = "https://example.test/openai/v1"
-    config_path.write_text(
-        f"""
-llm_provider:
-  name: openai
-  base_url: {base_url}
-  default_headers:
-    X-Test-Header: test
-  model: gpt-test
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["openai_api_base"] == base_url
-    assert runtime["openai_default_headers"] == {"X-Test-Header": "test"}
-
-
-def test_load_runtime_config_reads_provider_reasoning_effort(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: openai
-  model: gpt-test
-  reasoning_effort: xhigh
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-query:
-  max_tokens: 1000
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llama_query_reasoning_effort"] == "xhigh"
-
-
-def test_load_runtime_config_query_reasoning_overrides_provider(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: openai
-  model: gpt-test
-  reasoning_effort: low
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-query:
-  reasoning_effort: high
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llama_query_reasoning_effort"] == "high"
-
-
-def test_load_runtime_config_reports_missing_openai_provider_keys(
+def test_load_runtime_config_accepts_chat_provider_without_embeddings(
     tmp_path, monkeypatch
 ):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
+    config_path = _write_config(
+        tmp_path,
+        """
+llm_provider:
+  name: openai
+  model: gpt-test
+  base_url: https://example.test/openai/v1
+  default_headers:
+    X-Test-Header: test
+query:
+  reasoning_effort: high
+""",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["llm_provider_name"] == "openai"
+    assert runtime["llm_provider"] == {
+        "api_key": "chat-key",
+        "base_url": "https://example.test/openai/v1",
+        "default_headers": {"X-Test-Header": "test"},
+        "model": "gpt-test",
+    }
+    assert runtime["chat_model_kwargs"] == {"reasoning_effort": "high"}
+    assert "embedding_provider" not in runtime
+    assert runtime["embedding_provider_raw_config"] is None
+    assert "llm_api_key" not in runtime
+
+
+def test_build_embedding_provider_config_resolves_openai_embedding_provider(
+    tmp_path, monkeypatch
+):
+    config_path = _write_config(
+        tmp_path,
+        """
+llm_provider:
+  name: anthropic
+  api_key: anthropic-key
+  model: claude-sonnet-4-6
+embedding_provider:
+  name: openai
+  api_key_env: CUSTOM_OPENAI_EMBEDDING_KEY
+  code_embedding_model: text-embedding-3-large
+  docs_embedding_model: text-embedding-3-small
+  default_headers:
+      X-Embedding: test
+  code_extra_kwargs:
+      dimensions: 1536
+""",
+    )
+    monkeypatch.setenv("CUSTOM_OPENAI_EMBEDDING_KEY", "embedding-key")
+
+    runtime = load_runtime_config(config_path)
+    assert "embedding_provider" not in runtime
+    assert runtime["embedding_provider_raw_config"]["name"] == "openai"
+
+    embedding_provider_config = build_embedding_provider_config(
+        runtime["embedding_provider_raw_config"]
+    )
+
+    assert embedding_provider_config == {
+        "name": "openai",
+        "api_key": "embedding-key",
+        "default_headers": {"X-Embedding": "test"},
+        "code_embedding_model": "text-embedding-3-large",
+        "docs_embedding_model": "text-embedding-3-small",
+        "code_extra_kwargs": {"dimensions": 1536},
+    }
+
+
+def test_load_runtime_config_reports_missing_openai_chat_keys(tmp_path, monkeypatch):
+    config_path = _write_config(
+        tmp_path,
         """
 llm_provider:
   name: openai
   model: ""
-  code_embedding_model: text-embedding-3-large
 """,
-        encoding="utf-8",
     )
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
@@ -164,776 +127,152 @@ llm_provider:
     assert "Required keys:" in message
 
 
-def test_load_runtime_config_reports_missing_openai_api_key(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
+def test_load_runtime_config_reports_missing_openai_llm_api_key(tmp_path, monkeypatch):
+    config_path = _write_config(
+        tmp_path,
         """
 llm_provider:
   name: openai
   model: gpt-test
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
 """,
-        encoding="utf-8",
     )
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     with pytest.raises(RuntimeError) as exc_info:
         load_runtime_config(config_path)
 
-    assert "OPENAI_API_KEY environment variable is required for OpenAI provider" in str(
-        exc_info.value
-    )
-
-
-def test_load_runtime_config_reports_missing_azure_openai_provider_keys(
-    tmp_path, monkeypatch
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: azure_openai
-  azure_endpoint: https://example.openai.azure.com/
-  azure_api_version: ""
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
-
-    with pytest.raises(ValueError) as exc_info:
-        load_runtime_config(config_path)
-
     message = str(exc_info.value)
-    assert (
-        "Azure OpenAI provider requires additional metis.yaml configuration" in message
-    )
-    assert "Missing: llm_provider.azure_api_version" in message
-    assert "llm_provider.engine" in message
-    assert "llm_provider.chat_deployment_model" in message
-    assert "Required keys:" in message
+    assert "OPENAI_API_KEY environment variable" in message
+    assert "llm_provider.api_key" in message
+    assert "OpenAI provider" in message
 
 
-def test_load_runtime_config_reports_missing_azure_openai_api_key(
+def test_build_embedding_provider_config_reports_missing_provider_keys(
     tmp_path, monkeypatch
 ):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
+    config_path = _write_config(
+        tmp_path,
         """
 llm_provider:
-  name: azure_openai
-  azure_endpoint: https://example.openai.azure.com/
-  azure_api_version: "2024-02-01"
-  engine: chat-deployment
-  chat_deployment_model: gpt-4o-mini
+  name: openai
+  model: gpt-test
+embedding_provider:
+  name: openai
   code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-  code_embedding_deployment: code-embedding-deployment
-  docs_embedding_deployment: docs-embedding-deployment
 """,
-        encoding="utf-8",
     )
-    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
-
-    with pytest.raises(RuntimeError) as exc_info:
-        load_runtime_config(config_path)
-
-    assert (
-        "AZURE_OPENAI_API_KEY environment variable is required for Azure OpenAI provider"
-        in str(exc_info.value)
-    )
-
-
-def test_load_runtime_config_reports_missing_vllm_provider_keys(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: vllm
-  model: test-model
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError) as exc_info:
-        load_runtime_config(config_path)
-
-    message = str(exc_info.value)
-    assert "vLLM provider requires additional metis.yaml configuration" in message
-    assert "Missing: llm_provider.base_url" in message
-    assert "Required keys:" in message
-
-
-def test_load_runtime_config_resolves_vllm_api_key_from_configured_env(
-    tmp_path, monkeypatch
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: vllm
-  base_url: http://localhost:8000/v1
-  api_key_env: CUSTOM_VLLM_KEY
-  model: test-model
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("CUSTOM_VLLM_KEY", "vllm-key")
-    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     runtime = load_runtime_config(config_path)
 
-    assert runtime["llm_api_key"] == "vllm-key"
-
-
-def test_load_runtime_config_reports_missing_ollama_provider_keys(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: ollama
-  model: ""
-""",
-        encoding="utf-8",
-    )
-
     with pytest.raises(ValueError) as exc_info:
-        load_runtime_config(config_path)
+        build_embedding_provider_config(runtime["embedding_provider_raw_config"])
 
     message = str(exc_info.value)
-    assert "Ollama provider requires additional metis.yaml configuration" in message
-    assert "Missing: llm_provider.model" in message
-    assert "Required keys:" in message
+    assert (
+        "OpenAI embeddings provider requires additional metis.yaml configuration"
+        in message
+    )
+    assert "Missing: embedding_provider.docs_embedding_model" in message
 
 
-def test_load_runtime_config_keeps_ollama_api_key_optional(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
+def test_build_embedding_provider_config_rejects_short_embedding_model_keys():
+    with pytest.raises(ValueError) as exc_info:
+        build_embedding_provider_config(
+            {
+                "name": "openai",
+                "api_key": "embedding-key",
+                "code_model": "text-embedding-3-large",
+                "docs_model": "text-embedding-3-large",
+            }
+        )
+
+    message = str(exc_info.value)
+    assert "Missing: embedding_provider.code_embedding_model" in message
+    assert "embedding_provider.docs_embedding_model" in message
+
+
+def test_load_runtime_config_accepts_anthropic_model_ids_without_embeddings(
+    tmp_path, monkeypatch
+):
+    config_path = _write_config(
+        tmp_path,
         """
 llm_provider:
-  name: ollama
-  model: llama3.1:8b
-  code_embedding_model: nomic-embed-text:v1.5
-  docs_embedding_model: nomic-embed-text:v1.5
+  name: anthropic
+  model: claude-opus-4-8
+  api_key_env: CUSTOM_ANTHROPIC_KEY
+query:
+  model: claude-sonnet-4-6
 """,
-        encoding="utf-8",
     )
+    monkeypatch.setenv("CUSTOM_ANTHROPIC_KEY", "anthropic-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
     runtime = load_runtime_config(config_path)
 
-    assert runtime["llm_api_key"] == ""
+    assert runtime["llm_provider_name"] == "anthropic"
+    assert runtime["model"] == "claude-opus-4-8"
+    assert runtime["llama_query_model"] == "claude-sonnet-4-6"
+    assert runtime["llm_provider"]["model"] == "claude-opus-4-8"
+    assert runtime["chat_model_kwargs"] == {}
+    assert "embedding_provider" not in runtime
 
 
-def test_load_runtime_config_accepts_complete_gemini_provider_config(
+def test_load_runtime_config_accepts_gemini_vertex_ai_without_api_key(
     tmp_path, monkeypatch
 ):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
+    config_path = _write_config(
+        tmp_path,
         """
 llm_provider:
   name: gemini
   model: gemini-2.5-flash
-  api_key_env: CUSTOM_GOOGLE_KEY
-  code_embedding_model: gemini-embedding-001
-  docs_embedding_model: gemini-embedding-001
-  base_url: https://example.test/gemini
-  additional_headers:
-    X-Test-Header: test
   project: test-project
   location: europe-west2
-  vertexai: false
-  client_args:
-    timeout: 30
-metis_engine:
-  embed_dim: 3072
-query:
-  model: gemini-2.5-pro
-  max_tokens: 5000
-  temperature: 0.0
+  vertexai: true
 """,
-        encoding="utf-8",
     )
-    monkeypatch.setenv("CUSTOM_GOOGLE_KEY", "google-key")
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
 
     runtime = load_runtime_config(config_path)
 
     assert runtime["llm_provider_name"] == "gemini"
-    assert runtime["llm_api_key"] == "google-key"
-    assert runtime["model"] == "gemini-2.5-flash"
-    assert runtime["llama_query_model"] == "gemini-2.5-pro"
-    assert runtime["code_embedding_model"] == "gemini-embedding-001"
-    assert runtime["docs_embedding_model"] == "gemini-embedding-001"
-    assert runtime["gemini_api_base"] == "https://example.test/gemini"
-    assert runtime["gemini_additional_headers"] == {"X-Test-Header": "test"}
-    assert runtime["gemini_project"] == "test-project"
-    assert runtime["gemini_location"] == "europe-west2"
-    assert runtime["gemini_vertexai"] is False
-    assert runtime["gemini_client_args"] == {"timeout": 30}
-    assert runtime["embed_dim"] == 3072
-    assert runtime["llama_query_max_tokens"] == 5000
+    assert "api_key" not in runtime["llm_provider"]
+    assert runtime["llm_provider"]["project"] == "test-project"
+    assert runtime["llm_provider"]["location"] == "europe-west2"
+    assert runtime["llm_provider"]["vertexai"] is True
 
 
-def test_load_runtime_config_reports_missing_gemini_provider_keys(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: gemini
-  model: ""
-  code_embedding_model: gemini-embedding-001
-""",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError) as exc_info:
-        load_runtime_config(config_path)
-
-    message = str(exc_info.value)
-    assert "Gemini provider requires additional metis.yaml configuration" in message
-    assert "Missing: llm_provider.model" in message
-    assert "Required keys:" in message
-
-
-def test_load_runtime_config_keeps_gemini_api_key_optional(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: gemini
-  model: gemini-2.5-flash
-  vertexai: true
-  project: test-project
-  location: europe-west2
-  code_embedding_model: gemini-embedding-001
-  docs_embedding_model: gemini-embedding-001
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llm_api_key"] == ""
-    assert runtime["gemini_vertexai"] is True
-
-
-def test_load_runtime_config_resolves_gemini_api_key_from_fallback_env(
-    tmp_path, monkeypatch
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: gemini
-  model: gemini-2.5-flash
-  code_embedding_model: gemini-embedding-001
-  docs_embedding_model: gemini-embedding-001
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llm_api_key"] == "gemini-key"
-    assert runtime["model"] == "gemini-2.5-flash"
-
-
-def test_load_runtime_config_accepts_complete_anthropic_provider_config(
-    tmp_path, monkeypatch
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: anthropic
-  model: opus
-  api_key_env: CUSTOM_ANTHROPIC_KEY
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-small
-  embedding_api_key_env: CUSTOM_EMBEDDING_KEY
-metis_engine:
-  embed_dim: 3072
-query:
-  max_tokens: 5000
-  temperature: 0.0
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("CUSTOM_ANTHROPIC_KEY", "anthropic-key")
-    monkeypatch.setenv("CUSTOM_EMBEDDING_KEY", "embedding-key")
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llm_provider_name"] == "anthropic"
-    assert runtime["llm_api_key"] == "anthropic-key"
-    assert runtime["embedding_api_key"] == "embedding-key"
-    assert runtime["model"] == "claude-opus-4-8"
-    assert runtime["llama_query_model"] == "claude-opus-4-8"
-    assert runtime["code_embedding_model"] == "text-embedding-3-large"
-    assert runtime["docs_embedding_model"] == "text-embedding-3-small"
-    assert runtime["embed_dim"] == 3072
-    assert runtime["llama_query_max_tokens"] == 5000
-
-
-def test_load_runtime_config_reports_missing_anthropic_provider_keys(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: anthropic
-  model: ""
-  code_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError) as exc_info:
-        load_runtime_config(config_path)
-
-    message = str(exc_info.value)
-    assert "Anthropic provider requires additional metis.yaml configuration" in message
-    assert "Missing: llm_provider.model" in message
-    assert "Required keys:" in message
-
-
-def test_load_runtime_config_reports_missing_anthropic_api_key(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: anthropic
-  model: claude-opus-4-1-20250805
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.setenv("OPENAI_API_KEY", "embedding-key")
-
-    with pytest.raises(RuntimeError) as exc_info:
-        load_runtime_config(config_path)
-
-    message = str(exc_info.value)
-    assert "ANTHROPIC_API_KEY environment variable" in message
-    assert "Anthropic provider" in message
-
-
-def test_load_runtime_config_allows_anthropic_without_embedding_api_key(
-    tmp_path, monkeypatch
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: anthropic
-  model: claude-opus-4-1-20250805
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llm_api_key"] == "anthropic-key"
-    assert runtime["embedding_api_key"] == ""
-
-
-def test_load_runtime_config_accepts_bedrock_mantle_provider_config(
-    tmp_path, monkeypatch
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
+def test_load_runtime_config_accepts_bedrock_mantle_chat_without_embeddings(tmp_path):
+    config_path = _write_config(
+        tmp_path,
         """
 llm_provider:
   name: bedrock_mantle
   model: anthropic.claude-example
   aws_profile: example-profile
   aws_region: example-region
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-small
-  embedding_api_key_env: CUSTOM_EMBEDDING_KEY
-query:
-  max_tokens: 5000
-  temperature: 0.0
 """,
-        encoding="utf-8",
     )
-    monkeypatch.setenv("CUSTOM_EMBEDDING_KEY", "embedding-key")
 
     runtime = load_runtime_config(config_path)
 
     assert runtime["llm_provider_name"] == "bedrock_mantle"
-    assert runtime["llm_api_key"] == ""
-    assert runtime["embedding_api_key"] == "embedding-key"
-    assert runtime["model"] == "anthropic.claude-example"
+    assert runtime["llm_provider"]["model"] == "anthropic.claude-example"
+    assert runtime["llm_provider"]["aws_profile"] == "example-profile"
+    assert runtime["llm_provider"]["aws_region"] == "example-region"
     assert runtime["llama_query_model"] == "anthropic.claude-example"
-    assert runtime["aws_profile"] == "example-profile"
-    assert runtime["aws_region"] == "example-region"
-    assert runtime["supports_temperature"] is False
-    assert runtime["code_embedding_model"] == "text-embedding-3-large"
-    assert runtime["docs_embedding_model"] == "text-embedding-3-small"
-    assert runtime["llama_query_max_tokens"] == 5000
+    assert runtime["llama_query_max_tokens"] is None
+    assert "embedding_provider" not in runtime
 
 
-def test_load_runtime_config_reports_missing_bedrock_provider_keys(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: bedrock
-  model: ""
-  code_embedding_model: amazon.titan-embed-text-v2:0
-""",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError) as exc_info:
-        load_runtime_config(config_path)
-
-    message = str(exc_info.value)
-    assert "AWS Bedrock provider requires additional metis.yaml" in message
-    assert "Missing: llm_provider.model" in message
-    assert "llm_provider.region" in message
-
-
-def test_load_runtime_config_bedrock_passes_credentials(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: bedrock
-  region: eu-west-2
-  model: us.anthropic.claude-opus-4-8-v1:0
-  code_embedding_model: amazon.titan-embed-text-v2:0
-  docs_embedding_model: amazon.titan-embed-text-v2:0
-  aws_profile: my-profile
-  aws_access_key_id: AKIA
-  aws_secret_access_key: secret
-  endpoint_url: https://vpce.example
-""",
-        encoding="utf-8",
-    )
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llm_provider_name"] == "bedrock"
-    assert runtime["bedrock_region"] == "eu-west-2"
-    assert runtime["model"] == "us.anthropic.claude-opus-4-8-v1:0"
-    assert runtime["aws_profile"] == "my-profile"
-    assert runtime["aws_access_key_id"] == "AKIA"
-    assert runtime["aws_secret_access_key"] == "secret"
-    assert runtime["bedrock_endpoint_url"] == "https://vpce.example"
-    assert runtime["supports_temperature"] is False
-
-
-def test_load_runtime_config_bedrock_falls_back_to_env(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: bedrock
-  region: us-east-1
-  model: us.anthropic.claude-opus-4-8-v1:0
-  code_embedding_model: amazon.titan-embed-text-v2:0
-  docs_embedding_model: amazon.titan-embed-text-v2:0
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-akia")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
-    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["aws_access_key_id"] == "env-akia"
-    assert runtime["aws_secret_access_key"] == "env-secret"
-    assert runtime["aws_session_token"] == ""
-
-
-def test_load_runtime_config_does_not_default_bedrock_mantle_region(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: bedrock_mantle
-  model: anthropic.claude-example
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-small
-""",
-        encoding="utf-8",
-    )
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["aws_region"] is None
-
-
-def test_load_runtime_config_accepts_anthropic_query_model_alias(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: anthropic
-  model: claude-opus-4-1-20250805
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-query:
-  model: sonnet
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
-    monkeypatch.setenv("OPENAI_API_KEY", "embedding-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["model"] == "claude-opus-4-1-20250805"
-    assert runtime["llama_query_model"] == "claude-sonnet-4-6"
-
-
-@pytest.mark.parametrize(
-    ("alias", "resolved"),
-    [
-        ("opus", "claude-opus-4-8"),
-        ("sonnet", "claude-sonnet-4-6"),
-        ("haiku", "claude-haiku-4-5"),
-        ("fable", "claude-fable-5"),
-        ("mythos", "claude-mythos-5"),
-    ],
-)
-def test_load_runtime_config_accepts_anthropic_model_aliases(
-    tmp_path, monkeypatch, alias, resolved
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        f"""
-llm_provider:
-  name: anthropic
-  model: {alias}
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
-    monkeypatch.setenv("OPENAI_API_KEY", "embedding-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["model"] == resolved
-    assert runtime["llama_query_model"] == resolved
-
-
-def test_load_runtime_config_rejects_unknown_anthropic_model_alias(
+def test_load_runtime_config_accepts_split_azure_chat_and_embedding_config(
     tmp_path, monkeypatch
 ):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: anthropic
-  model: unsupported-model-alias
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
-    monkeypatch.setenv("OPENAI_API_KEY", "embedding-key")
-
-    with pytest.raises(ValueError) as exc_info:
-        load_runtime_config(config_path)
-
-    assert "supported short alias" in str(exc_info.value)
-
-
-def test_load_runtime_config_reports_missing_llamacpp_provider_keys(tmp_path):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: llamacpp
-""",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError) as exc_info:
-        load_runtime_config(config_path)
-
-    message = str(exc_info.value)
-    assert "llama.cpp provider requires additional metis.yaml configuration" in message
-    assert "Missing: llm_provider.model" in message
-    assert "Required keys:" in message
-
-
-def test_load_runtime_config_keeps_llamacpp_api_key_optional(tmp_path, monkeypatch):
-    monkeypatch.delenv("LLAMACPP_API_KEY", raising=False)
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: llamacpp
-  model: llama3.1:8b
-  code_embedding_model: nomic-embed-text:v1.5
-  docs_embedding_model: nomic-embed-text:v1.5
-""",
-        encoding="utf-8",
-    )
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llm_api_key"] == ""
-    assert runtime["openai_api_base"] == ""
-    assert runtime["model"] == "llama3.1:8b"
-
-
-def test_load_runtime_config_resolves_llamacpp_api_key_from_env(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: llamacpp
-  base_url: http://custom:8080/v1
-  model: llama3.1:8b
-  code_embedding_model: nomic-embed-text:v1.5
-  docs_embedding_model: nomic-embed-text:v1.5
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("LLAMACPP_API_KEY", "my-secret-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llm_api_key"] == "my-secret-key"
-    assert runtime["openai_api_base"] == "http://custom:8080/v1"
-
-
-def test_load_runtime_config_embedding_provider_falls_back_to_llm_provider(
-    tmp_path, monkeypatch
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: openai
-  model: gpt-test
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["embedding_provider_name"] == "openai"
-    embed = runtime["embedding_provider_config"]
-    assert embed["llm_api_key"] == "test-key"
-    assert embed["code_embedding_model"] == "text-embedding-3-large"
-    assert runtime["embedding_provider_raw_config"]["name"] == "openai"
-
-
-def test_load_runtime_config_separate_embedding_provider(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: anthropic
-  model: claude-opus-4-8
-embedding_provider:
-  name: openai
-  code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-small
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
-    monkeypatch.setenv("OPENAI_API_KEY", "embed-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["llm_provider_name"] == "anthropic"
-    assert runtime["model"] == "claude-opus-4-8"
-    assert runtime["embedding_provider_name"] == "openai"
-    embed = runtime["embedding_provider_config"]
-    assert embed["llm_api_key"] == "embed-key"
-    assert embed["code_embedding_model"] == "text-embedding-3-large"
-    assert embed["docs_embedding_model"] == "text-embedding-3-small"
-    # llm runtime should not pick up embedding-provider keys
-    assert runtime["code_embedding_model"] == ""
-
-
-def test_load_runtime_config_anthropic_without_embeddings(tmp_path, monkeypatch):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
-        """
-llm_provider:
-  name: anthropic
-  model: opus
-""",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["model"] == "claude-opus-4-8"
-    assert runtime["code_embedding_model"] == ""
-    assert runtime["embedding_provider_name"] == "anthropic"
-
-
-def test_validate_embedding_provider_config_reports_missing_keys():
-    with pytest.raises(ValueError) as exc_info:
-        validate_embedding_provider_config(
-            "openai", {"code_embedding_model": "x"}, section="embedding_provider"
-        )
-
-    message = str(exc_info.value)
-    assert "OpenAI provider requires additional metis.yaml" in message
-    assert "Missing: embedding_provider.docs_embedding_model" in message
-
-
-def test_validate_embedding_provider_config_passes_when_complete():
-    validate_embedding_provider_config(
-        "openai",
-        {
-            "code_embedding_model": "text-embedding-3-large",
-            "docs_embedding_model": "text-embedding-3-large",
-        },
-    )
-
-
-def test_validate_embedding_provider_config_uses_llm_section_label():
-    with pytest.raises(ValueError) as exc_info:
-        validate_embedding_provider_config("ollama", {}, section="llm_provider")
-
-    message = str(exc_info.value)
-    assert "Missing: llm_provider.code_embedding_model" in message
-    assert "llm_provider.docs_embedding_model" in message
-
-
-def test_load_runtime_config_accepts_complete_azure_provider_config(
-    tmp_path, monkeypatch
-):
-    config_path = tmp_path / "metis.yaml"
-    config_path.write_text(
+    config_path = _write_config(
+        tmp_path,
         """
 llm_provider:
   name: azure_openai
@@ -941,22 +280,60 @@ llm_provider:
   azure_api_version: "2024-02-01"
   engine: chat-deployment
   chat_deployment_model: gpt-4o-mini
+  use_responses_api: true
+embedding_provider:
+  name: azure_openai
+  azure_endpoint: https://example.openai.azure.com/
+  azure_api_version: "2024-02-01"
   code_embedding_model: text-embedding-3-large
-  docs_embedding_model: text-embedding-3-large
-  code_embedding_deployment: code-embedding-deployment
-  docs_embedding_deployment: docs-embedding-deployment
-query:
-  max_tokens: 1000
+  docs_embedding_model: text-embedding-3-small
+  code_deployment: code-embedding-deployment
+  docs_deployment: docs-embedding-deployment
 """,
-        encoding="utf-8",
     )
     monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
 
     runtime = load_runtime_config(config_path)
 
-    assert runtime["azure_endpoint"] == "https://example.openai.azure.com/"
-    assert runtime["azure_api_version"] == "2024-02-01"
-    assert runtime["engine"] == "chat-deployment"
-    assert runtime["chat_deployment_model"] == "gpt-4o-mini"
-    assert runtime["code_embedding_deployment"] == "code-embedding-deployment"
-    assert runtime["docs_embedding_deployment"] == "docs-embedding-deployment"
+    assert runtime["llm_provider_name"] == "azure_openai"
+    assert runtime["llm_provider"]["engine"] == "chat-deployment"
+    assert runtime["llm_provider"]["chat_deployment_model"] == "gpt-4o-mini"
+    assert runtime["llm_provider"]["use_responses_api"] is True
+    assert "embedding_provider" not in runtime
+
+    embedding_provider_config = build_embedding_provider_config(
+        runtime["embedding_provider_raw_config"]
+    )
+
+    assert embedding_provider_config["code_embedding_model"] == "text-embedding-3-large"
+    assert embedding_provider_config["docs_embedding_model"] == "text-embedding-3-small"
+    assert embedding_provider_config["code_deployment"] == "code-embedding-deployment"
+    assert embedding_provider_config["docs_deployment"] == "docs-embedding-deployment"
+
+
+@pytest.mark.parametrize("provider_name", ["ollama", "llamacpp"])
+def test_load_runtime_config_keeps_local_provider_api_key_optional(
+    tmp_path, monkeypatch, provider_name
+):
+    monkeypatch.delenv("LLAMACPP_API_KEY", raising=False)
+    config_path = _write_config(
+        tmp_path,
+        f"""
+llm_provider:
+  name: {provider_name}
+  model: llama3.1:8b
+embedding_provider:
+  name: {provider_name}
+  code_embedding_model: nomic-embed-text:v1.5
+  docs_embedding_model: nomic-embed-text:v1.5
+""",
+    )
+
+    runtime = load_runtime_config(config_path)
+    embedding_provider_config = build_embedding_provider_config(
+        runtime["embedding_provider_raw_config"]
+    )
+
+    assert "api_key" not in runtime["llm_provider"]
+    assert "api_key" not in embedding_provider_config
+    assert embedding_provider_config["code_embedding_model"] == "nomic-embed-text:v1.5"

--- a/tests/test_engine_chroma.py
+++ b/tests/test_engine_chroma.py
@@ -20,13 +20,10 @@ def test_chroma_backend_indexing(tmp_path):
     os.makedirs(chroma_dir, exist_ok=True)
 
     runtime = {
-        "llm_api_key": "test-key",
         "max_workers": 2,
         "max_token_length": 2048,
         "llama_query_model": "gpt-test",
         "similarity_top_k": 5,
-        "code_embedding_model": "test-code-embed",
-        "docs_embedding_model": "test-docs-embed",
         "enabled_tools": {"index"},
     }
 
@@ -38,18 +35,11 @@ def test_chroma_backend_indexing(tmp_path):
         query_config=runtime,
     )
 
-    class _Provider:
-        def get_embed_model_code(self, *, callback_manager=None):
-            return embed
-
-        def get_embed_model_docs(self, *, callback_manager=None):
-            return embed
-
     engine = MetisEngine(
         codebase_path="tests/data",
         vector_backend=backend,
         language_plugin="c",
-        llm_provider=_Provider(),
+        llm_provider=object(),
         **runtime,
     )
 
@@ -117,10 +107,12 @@ def test_chroma_store_reset_recreates_collections(tmp_path):
     assert client.get_or_create_collection.call_count == 4
 
 
-def test_build_chroma_backend_receives_full_runtime_config(tmp_path):
-    base_url = "https://example.test/openai/v1"
+def test_build_chroma_backend_receives_retriever_query_config(tmp_path):
     runtime = {
-        "openai_api_base": base_url,
+        "llm_provider_name": "openai",
+        "llm_provider": {"api_key": "secret", "model": "gpt-test"},
+        "llama_query_model": "gpt-test",
+        "chat_model_kwargs": {"reasoning_effort": "low"},
         "similarity_top_k": 7,
     }
     embed = MockEmbedding(embed_dim=8)
@@ -130,5 +122,8 @@ def test_build_chroma_backend_receives_full_runtime_config(tmp_path):
 
     backend = build_chroma_backend(_Args(), runtime, embed, embed)
 
-    assert backend.query_config is runtime
-    assert backend.query_config["openai_api_base"] == base_url
+    assert backend.query_config == {
+        "llama_query_model": "gpt-test",
+        "chat_model_kwargs": {"reasoning_effort": "low"},
+        "similarity_top_k": 7,
+    }

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -14,6 +14,13 @@ from metis.exceptions import (
 from metis.usage import UsageRuntime
 
 
+def _embedding_provider(code_embedding_model=None, docs_embedding_model=None):
+    provider = Mock()
+    provider.get_embed_model_code.return_value = code_embedding_model or Mock()
+    provider.get_embed_model_docs.return_value = docs_embedding_model or Mock()
+    return provider
+
+
 def test_supported_languages():
     langs = MetisEngine.supported_languages()
     assert "c" in langs
@@ -39,6 +46,7 @@ def test_init_and_get_retrievers_raises_on_missing_backend():
     engine = MetisEngine(
         vector_backend=bad_backend,
         llm_provider=Mock(),
+        embedding_provider=_embedding_provider(),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -95,6 +103,7 @@ def test_init_and_get_retrievers_is_thread_safe():
     engine = MetisEngine(
         vector_backend=backend,
         llm_provider=Mock(),
+        embedding_provider=_embedding_provider(),
         max_workers=4,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -118,44 +127,10 @@ def test_init_and_get_retrievers_is_thread_safe():
     backend.get_retrievers.assert_called_once()
 
 
-def test_engine_builds_embed_models_lazily_with_usage_callback_manager():
+def test_index_context_builds_embed_models_lazily_with_usage_callback_manager():
     backend = Mock()
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
-    llm_provider = Mock()
-    code_embed_model = Mock()
-    docs_embed_model = Mock()
-    llm_provider.get_embed_model_code.return_value = code_embed_model
-    llm_provider.get_embed_model_docs.return_value = docs_embed_model
-
-    engine = MetisEngine(
-        vector_backend=backend,
-        llm_provider=llm_provider,
-        max_workers=2,
-        max_token_length=2048,
-        llama_query_model="gpt-test",
-        similarity_top_k=3,
-        enabled_tools={"index"},
-    )
-
-    llm_provider.get_embed_model_code.assert_not_called()
-    llm_provider.get_embed_model_docs.assert_not_called()
-
-    assert engine.get_embed_model_code() is code_embed_model
-    assert engine.get_embed_model_docs() is docs_embed_model
-    assert llm_provider.get_embed_model_code.call_args.kwargs == {
-        "callback_manager": engine.usage_runtime.hooks.callback_manager
-    }
-    assert llm_provider.get_embed_model_docs.call_args.kwargs == {
-        "callback_manager": engine.usage_runtime.hooks.callback_manager
-    }
-    assert backend.embed_model_code is code_embed_model
-    assert backend.embed_model_docs is docs_embed_model
-
-
-def test_engine_uses_separate_embedding_provider_when_supplied():
-    backend = Mock()
-    backend.init = Mock()
     llm_provider = Mock()
     embedding_provider = Mock()
     code_embed_model = Mock()
@@ -174,40 +149,32 @@ def test_engine_uses_separate_embedding_provider_when_supplied():
         enabled_tools={"index"},
     )
 
-    assert engine.embedding_provider is embedding_provider
-    assert engine.get_embed_model_code() is code_embed_model
-    assert engine.get_embed_model_docs() is docs_embed_model
-    llm_provider.get_embed_model_code.assert_not_called()
-    llm_provider.get_embed_model_docs.assert_not_called()
+    embedding_provider.get_embed_model_code.assert_not_called()
+    embedding_provider.get_embed_model_docs.assert_not_called()
 
-
-def test_engine_defaults_embedding_provider_to_llm_provider():
-    backend = Mock()
-    llm_provider = Mock()
-
-    engine = MetisEngine(
-        vector_backend=backend,
-        llm_provider=llm_provider,
-        max_workers=2,
-        max_token_length=2048,
-        llama_query_model="gpt-test",
-        similarity_top_k=3,
+    assert engine.index_context.get_embedding_models() == (
+        code_embed_model,
+        docs_embed_model,
     )
-
-    assert engine.embedding_provider is llm_provider
+    assert embedding_provider.get_embed_model_code.call_args.kwargs == {
+        "callback_manager": engine.usage_runtime.hooks.callback_manager
+    }
+    assert embedding_provider.get_embed_model_docs.call_args.kwargs == {
+        "callback_manager": engine.usage_runtime.hooks.callback_manager
+    }
+    assert backend.embed_model_code is code_embed_model
+    assert backend.embed_model_docs is docs_embed_model
 
 
 def test_create_retrievers_passes_usage_callback_manager():
     backend = Mock()
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
-    llm_provider = Mock()
-    llm_provider.get_embed_model_code.return_value = Mock()
-    llm_provider.get_embed_model_docs.return_value = Mock()
 
     engine = MetisEngine(
         vector_backend=backend,
-        llm_provider=llm_provider,
+        llm_provider=Mock(),
+        embedding_provider=_embedding_provider(),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -232,8 +199,6 @@ def test_review_graph_uses_usage_callbacks(monkeypatch):
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
     llm_provider = Mock()
-    llm_provider.get_embed_model_code.return_value = Mock()
-    llm_provider.get_embed_model_docs.return_value = Mock()
     llm_provider.get_chat_model.return_value = Mock(with_structured_output=Mock())
 
     engine = MetisEngine(
@@ -278,31 +243,31 @@ def test_engine_reuses_injected_runtime_and_backend_embed_models(tmp_path):
         codebase_path=str(tmp_path),
         vector_backend=backend,
         llm_provider=llm_provider,
+        embedding_provider=_embedding_provider(),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
         similarity_top_k=3,
         usage_runtime=runtime,
+        enabled_tools={"index"},
     )
 
     assert engine.usage_runtime is runtime
-    assert engine.get_embed_model_code() is backend.embed_model_code
-    assert engine.get_embed_model_docs() is backend.embed_model_docs
-    llm_provider.get_embed_model_code.assert_not_called()
-    llm_provider.get_embed_model_docs.assert_not_called()
+    assert engine.index_context.get_embedding_models() == (
+        backend.embed_model_code,
+        backend.embed_model_docs,
+    )
+    llm_provider.get_chat_model.assert_not_called()
 
 
 def test_engine_exposes_focused_services_without_compat_aliases():
     backend = Mock()
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
-    llm_provider = Mock()
-    llm_provider.get_embed_model_code.return_value = Mock()
-    llm_provider.get_embed_model_docs.return_value = Mock()
-
     engine = MetisEngine(
         vector_backend=backend,
-        llm_provider=llm_provider,
+        llm_provider=Mock(),
+        embedding_provider=_embedding_provider(),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -321,6 +286,7 @@ def test_engine_exposes_focused_services_without_compat_aliases():
     assert engine.review is not None
     assert engine.indexing is not None
     assert engine.indexing is engine.index_context.indexing
+    assert not hasattr(engine, "embedding_provider")
     assert not hasattr(engine, "review_service")
     assert not hasattr(engine, "indexing_service")
     assert results == [{"file": "a.py"}]
@@ -334,13 +300,12 @@ def test_index_prepare_nodes_resets_backend_index_when_supported(monkeypatch):
     backend.reset_index = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
 
-    llm_provider = Mock()
-    llm_provider.get_embed_model_code.return_value = Mock()
-    llm_provider.get_embed_model_docs.return_value = Mock()
+    embedding_provider = _embedding_provider()
 
     engine = MetisEngine(
         vector_backend=backend,
-        llm_provider=llm_provider,
+        llm_provider=Mock(),
+        embedding_provider=embedding_provider,
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -358,6 +323,8 @@ def test_index_prepare_nodes_resets_backend_index_when_supported(monkeypatch):
     monkeypatch.setattr("metis.engine.indexing_service.SimpleDirectoryReader", _Reader)
     engine.indexing.index_prepare_nodes()
 
+    embedding_provider.get_embed_model_code.assert_called_once()
+    embedding_provider.get_embed_model_docs.assert_called_once()
     backend.init.assert_called_once()
     backend.reset_index.assert_called_once()
 
@@ -367,13 +334,13 @@ def test_index_finalize_embeddings_delegates_node_writes_to_backend():
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
     backend.index_nodes = Mock()
-    llm_provider = Mock()
-    llm_provider.get_embed_model_code.return_value = Mock()
-    llm_provider.get_embed_model_docs.return_value = Mock()
+    code_embed_model = Mock()
+    docs_embed_model = Mock()
 
     engine = MetisEngine(
         vector_backend=backend,
-        llm_provider=llm_provider,
+        llm_provider=Mock(),
+        embedding_provider=_embedding_provider(code_embed_model, docs_embed_model),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -387,8 +354,8 @@ def test_index_finalize_embeddings_delegates_node_writes_to_backend():
     backend.index_nodes.assert_called_once_with(
         ["code-node"],
         ["docs-node"],
-        embed_model_code=engine.get_embed_model_code(),
-        embed_model_docs=engine.get_embed_model_docs(),
+        embed_model_code=code_embed_model,
+        embed_model_docs=docs_embed_model,
         callback_manager=engine.usage_runtime.hooks.callback_manager,
     )
     assert engine._state.pending_nodes is None
@@ -399,13 +366,11 @@ def test_close_clears_retriever_cache_and_closes_backend():
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
     backend.close = Mock()
-    llm_provider = Mock()
-    llm_provider.get_embed_model_code.return_value = Mock()
-    llm_provider.get_embed_model_docs.return_value = Mock()
 
     engine = MetisEngine(
         vector_backend=backend,
-        llm_provider=llm_provider,
+        llm_provider=Mock(),
+        embedding_provider=_embedding_provider(),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -431,13 +396,10 @@ def test_disabled_index_tool_blocks_required_index_access():
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
     backend.close = Mock()
-    llm_provider = Mock()
-    llm_provider.get_embed_model_code.return_value = Mock()
-    llm_provider.get_embed_model_docs.return_value = Mock()
 
     engine = MetisEngine(
         vector_backend=backend,
-        llm_provider=llm_provider,
+        llm_provider=Mock(),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -9,22 +9,14 @@ pytest.importorskip("langchain_google_genai")
 
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_google_genai import GoogleGenerativeAIEmbeddings
-from llama_index.core.callbacks import CallbackManager
 
-from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 from metis.providers.gemini import GeminiProvider
 
 
 def _config(**overrides):
     config = {
-        "llm_api_key": "google-key",
+        "api_key": "google-key",
         "model": "gemini-2.5-flash",
-        "llama_query_model": "gemini-2.5-flash",
-        "llama_query_temperature": 0.2,
-        "llama_query_max_tokens": 256,
-        "code_embedding_model": "gemini-embedding-001",
-        "docs_embedding_model": "gemini-embedding-001",
     }
     config.update(overrides)
     return config
@@ -37,8 +29,7 @@ def test_chat_model_uses_gemini_configuration():
 
     assert isinstance(llm, ChatGoogleGenerativeAI)
     assert llm.model == "gemini-2.5-flash"
-    assert llm.max_output_tokens == 256
-    assert llm.temperature == 0.2
+    assert llm.max_output_tokens is None
     assert llm.google_api_key.get_secret_value() == "google-key"
 
 
@@ -50,7 +41,6 @@ def test_chat_model_allows_runtime_overrides_and_callbacks():
         model="gemini-2.5-pro",
         callbacks=[callback],
         max_tokens=128,
-        temperature=0.0,
         top_p=0.8,
         top_k=32,
     )
@@ -58,7 +48,6 @@ def test_chat_model_allows_runtime_overrides_and_callbacks():
     assert llm.model == "gemini-2.5-pro"
     assert llm.callbacks == [callback]
     assert llm.max_output_tokens == 128
-    assert llm.temperature == 0.0
     assert llm.top_p == 0.8
     assert llm.top_k == 32
 
@@ -72,27 +61,26 @@ def test_chat_model_maps_openai_json_response_format():
 
 
 def test_chat_model_maps_supported_reasoning_effort_to_thinking_level():
-    provider = GeminiProvider(_config(llama_query_reasoning_effort="high"))
+    provider = GeminiProvider(_config())
 
-    llm = provider.get_chat_model()
+    llm = provider.get_chat_model(reasoning_effort="high")
 
     assert llm.thinking_level == "high"
 
 
-def test_common_backend_params_are_forwarded_to_chat_and_embeddings():
+def test_common_backend_params_are_forwarded_to_chat():
     provider = GeminiProvider(
         _config(
-            gemini_api_base="https://example.test/gemini",
-            gemini_additional_headers={"X-Test-Header": "test"},
-            gemini_project="test-project",
-            gemini_location="europe-west2",
-            gemini_vertexai=False,
-            gemini_client_args={"timeout": 30},
+            base_url="https://example.test/gemini",
+            additional_headers={"X-Test-Header": "test"},
+            project="test-project",
+            location="europe-west2",
+            vertexai=False,
+            client_args={"timeout": 30},
         )
     )
 
     llm = provider.get_chat_model()
-    embeddings = provider.get_embed_model_code()
 
     assert llm.base_url == "https://example.test/gemini"
     assert llm.additional_headers == {"X-Test-Header": "test"}
@@ -100,76 +88,31 @@ def test_common_backend_params_are_forwarded_to_chat_and_embeddings():
     assert llm.location == "europe-west2"
     assert llm.vertexai is False
     assert llm.client_args == {"timeout": 30}
-    assert embeddings._client.base_url == "https://example.test/gemini"
-    assert embeddings._client.additional_headers == {"X-Test-Header": "test"}
-    assert embeddings._client.project == "test-project"
-    assert embeddings._client.location == "europe-west2"
-    assert embeddings._client.vertexai is False
-    assert embeddings._client.client_args == {"timeout": 30}
-
-
-def test_provider_accepts_callback_manager_for_embeddings():
-    provider = GeminiProvider(_config())
-    callback_manager = CallbackManager([])
-
-    embeddings = provider.get_embed_model_code(callback_manager=callback_manager)
-
-    assert embeddings.callback_manager is callback_manager
-
-
-def test_embedding_models_use_native_gemini_embeddings():
-    provider = GeminiProvider(
-        _config(
-            code_embedding_extra_kwargs={"output_dimensionality": 1536},
-            docs_embedding_extra_kwargs={"task_type": "RETRIEVAL_DOCUMENT"},
-        )
-    )
-
-    code_embeddings = provider.get_embed_model_code()
-    docs_embeddings = provider.get_embed_model_docs()
-
-    assert isinstance(code_embeddings, LangChainEmbeddingAdapter)
-    assert isinstance(docs_embeddings, LangChainEmbeddingAdapter)
-    assert isinstance(code_embeddings._client, GoogleGenerativeAIEmbeddings)
-    assert isinstance(docs_embeddings._client, GoogleGenerativeAIEmbeddings)
-    assert code_embeddings.model_name == "gemini-embedding-001"
-    assert docs_embeddings.model_name == "gemini-embedding-001"
-    assert code_embeddings._client.model == "gemini-embedding-001"
-    assert docs_embeddings._client.model == "gemini-embedding-001"
-    assert code_embeddings._client.output_dimensionality == 1536
-    assert docs_embeddings._client.task_type == "RETRIEVAL_DOCUMENT"
 
 
 def test_provider_requires_api_key():
     with pytest.raises(ValueError) as exc_info:
-        GeminiProvider(_config(llm_api_key=""))
+        GeminiProvider(_config(api_key=""))
 
     assert "GOOGLE_API_KEY or GEMINI_API_KEY" in str(exc_info.value)
 
 
-def test_provider_allows_vertexai_without_api_key():
+def test_provider_allows_vertex_ai_without_api_key():
     provider = GeminiProvider(
         _config(
-            llm_api_key="",
-            gemini_vertexai=True,
-            gemini_project="test-project",
-            gemini_location="europe-west2",
+            api_key="",
+            project="test-project",
+            location="europe-west2",
+            vertexai=True,
         )
     )
 
-    llm = provider.get_chat_model()
-
-    assert llm.vertexai is True
-    assert llm.google_api_key is None
+    assert provider.api_key == ""
+    assert provider.vertexai is True
 
 
-def test_embedding_model_required_only_when_used():
-    provider = GeminiProvider(_config(code_embedding_model=""))
-
-    llm = provider.get_chat_model()
-    assert llm.model == "gemini-2.5-flash"
-
+def test_provider_requires_chat_model():
     with pytest.raises(ValueError) as exc_info:
-        provider.get_embed_model_code()
+        GeminiProvider(_config(model=""))
 
-    assert "code_embedding_model" in str(exc_info.value)
+    assert "chat model" in str(exc_info.value)

--- a/tests/test_llamacpp_provider.py
+++ b/tests/test_llamacpp_provider.py
@@ -3,142 +3,88 @@
 
 from typing import cast
 
+import pytest
 from langchain_openai import ChatOpenAI
-from metis.providers.base import OpenAICompatibleProviderConfig
-from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 
+from metis.providers.llamacpp import LlamaCppEmbeddingProvider
 from metis.providers.llamacpp import LlamaCppProvider
+from metis.providers.openai_compatible import OpenAICompatibleChatConfig
+from metis.providers.openai_compatible import OpenAICompatibleEmbeddingConfig
 
 
-def _config(**overrides: object) -> OpenAICompatibleProviderConfig:
+def _chat_config(**overrides: object) -> OpenAICompatibleChatConfig:
     config: dict[str, object] = {
-        "llm_api_key": "test-key",
+        "api_key": "test-key",
         "model": "llama3.1:8b",
-        "llama_query_model": "llama3.1:8b",
-        "llama_query_temperature": 0.0,
-        "llama_query_max_tokens": 256,
+    }
+    config.update(overrides)
+    return cast(OpenAICompatibleChatConfig, config)
+
+
+def _embedding_config(**overrides: object) -> OpenAICompatibleEmbeddingConfig:
+    config: dict[str, object] = {
+        "api_key": "test-key",
         "code_embedding_model": "nomic-embed-text:v1.5",
         "docs_embedding_model": "nomic-embed-text:v1.5",
     }
     config.update(overrides)
-    return cast(OpenAICompatibleProviderConfig, config)
+    return cast(OpenAICompatibleEmbeddingConfig, config)
 
 
 def test_defaults_base_url_when_not_configured() -> None:
-    config = _config()
-    config.pop("llm_api_key", None)
+    config = _chat_config()
+    config.pop("api_key", None)
     provider = LlamaCppProvider(config)
 
     assert provider.base_url == "http://localhost:8080/v1"
 
 
 def test_uses_configured_base_url() -> None:
-    provider = LlamaCppProvider(_config(openai_api_base="http://custom:9000/v1"))
+    provider = LlamaCppProvider(_chat_config(base_url="http://custom:9000/v1"))
 
     assert provider.base_url == "http://custom:9000/v1"
 
 
 def test_uses_placeholder_api_key_when_none_provided() -> None:
-    config = _config()
-    config.pop("llm_api_key", None)
+    config = _chat_config()
+    config.pop("api_key", None)
     provider = LlamaCppProvider(config)
 
     assert provider.api_key == "sk-no-key-required"
 
 
 def test_uses_configured_api_key() -> None:
-    provider = LlamaCppProvider(_config(llm_api_key="my-secret-key"))
+    provider = LlamaCppProvider(_chat_config(api_key="my-secret-key"))
 
     assert provider.api_key == "my-secret-key"
 
 
-def test_raises_on_missing_query_model_when_used() -> None:
-    config = _config()
-    config["model"] = ""
-    config["llama_query_model"] = ""
-    config.pop("llm_api_key", None)
+def test_raises_on_missing_query_model() -> None:
+    config = _chat_config(model="")
+    config.pop("api_key", None)
 
-    provider = LlamaCppProvider(config)
-    try:
-        provider.get_chat_model()
-        assert False, "Expected ValueError"
-    except ValueError as exc:
-        assert "chat model" in str(exc)
+    with pytest.raises(ValueError) as exc_info:
+        LlamaCppProvider(config)
+
+    assert "chat model" in str(exc_info.value)
 
 
-def test_raises_on_missing_embedding_models_when_used() -> None:
-    config = _config()
-    config["code_embedding_model"] = ""
-    config.pop("llm_api_key", None)
+def test_raises_on_missing_embedding_models() -> None:
+    config = _embedding_config(code_embedding_model="")
+    config.pop("api_key", None)
 
-    provider = LlamaCppProvider(config)
-    try:
-        provider.get_embed_model_code()
-        assert False, "Expected ValueError"
-    except ValueError as exc:
-        assert "code_embedding_model" in str(exc)
+    with pytest.raises(ValueError) as exc_info:
+        LlamaCppEmbeddingProvider(config)
+
+    assert "embedding model" in str(exc_info.value)
 
 
 def test_chat_model_uses_configured_base_url() -> None:
     provider = LlamaCppProvider(
-        _config(openai_api_base="http://custom:9000/v1", llm_api_key="test-key")
+        _chat_config(base_url="http://custom:9000/v1", api_key="test-key")
     )
 
     llm = provider.get_chat_model()
 
     assert isinstance(llm, ChatOpenAI)
     assert llm.openai_api_base == "http://custom:9000/v1"
-
-
-def test_reasoning_effort_propagated_to_chat_model() -> None:
-    provider = LlamaCppProvider(
-        _config(
-            llama_query_reasoning_effort="high",
-            llm_api_key="test-key",
-        )
-    )
-
-    llm = provider.get_chat_model()
-
-    assert llm.reasoning_effort == "high"
-
-
-def test_embed_model_code_returns_langchain_embedding_adapter() -> None:
-    provider = LlamaCppProvider(_config(llm_api_key="test-key"))
-
-    embed = provider.get_embed_model_code()
-
-    assert isinstance(embed, LangChainEmbeddingAdapter)
-    assert embed.model_name == "nomic-embed-text:v1.5"
-    assert embed._client.model == "nomic-embed-text:v1.5"
-
-
-def test_embed_model_docs_returns_langchain_embedding_adapter() -> None:
-    provider = LlamaCppProvider(_config(llm_api_key="test-key"))
-
-    embed = provider.get_embed_model_docs()
-
-    assert isinstance(embed, LangChainEmbeddingAdapter)
-    assert embed.model_name == "nomic-embed-text:v1.5"
-    assert embed._client.model == "nomic-embed-text:v1.5"
-
-
-def test_lazy_loader_is_registered() -> None:
-    from metis.providers.registry import _LOADERS, get_provider
-
-    # Lazy loader entry must exist
-    assert _LOADERS.get("llamacpp") == "metis.providers.llamacpp:LlamaCppProvider"
-
-    # get_provider must return the class (lazy loader triggers on first call)
-    cls = get_provider("llamacpp")
-    assert cls.__name__ == "LlamaCppProvider"
-    assert cls.__module__ == "metis.providers.llamacpp"
-
-
-def test_ollama_lazy_loader_is_registered() -> None:
-    from metis.providers.registry import _LOADERS, get_provider
-
-    assert _LOADERS.get("ollama") == "metis.providers.ollama:OllamaProvider"
-    cls = get_provider("ollama")
-    assert cls.__name__ == "OllamaProvider"
-    assert cls.__module__ == "metis.providers.ollama"

--- a/tests/test_metisignore.py
+++ b/tests/test_metisignore.py
@@ -9,10 +9,18 @@ from metis.engine import MetisEngine
 
 
 def _build_engine(tmp_path, dummy_backend, dummy_llm):
+    class _EmbeddingProvider:
+        def get_embed_model_code(self, **_kwargs):
+            return object()
+
+        def get_embed_model_docs(self, **_kwargs):
+            return object()
+
     return MetisEngine(
         codebase_path=str(tmp_path),
         vector_backend=dummy_backend,
         llm_provider=dummy_llm,
+        embedding_provider=_EmbeddingProvider(),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",

--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -1,70 +1,52 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import cast
+from typing import Any, cast
 
 from langchain_openai import ChatOpenAI
-from metis.providers.base import OpenAICompatibleProviderConfig
 
-from metis.providers.openai_compatible import OpenAICompatibleProvider
+from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
+from metis.providers.openai_compatible import OpenAICompatibleChatConfig
+from metis.providers.openai_compatible import OpenAICompatibleChatProvider
+from metis.providers.openai_compatible import OpenAICompatibleEmbeddingConfig
+from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
 
 
-def _config(**overrides: object) -> OpenAICompatibleProviderConfig:
+def _chat_config(**overrides: object) -> OpenAICompatibleChatConfig:
     config: dict[str, object] = {
-        "llm_api_key": "test-key",
+        "api_key": "test-key",
         "model": "gpt-test",
-        "llama_query_model": "gpt-test",
-        "llama_query_temperature": 0.0,
-        "llama_query_max_tokens": 256,
-        "code_embedding_model": "text-embedding-3-large",
-        "docs_embedding_model": "text-embedding-3-large",
     }
     config.update(overrides)
-    return cast(OpenAICompatibleProviderConfig, config)
+    return cast(OpenAICompatibleChatConfig, config)
 
 
-def test_chat_model_uses_configured_reasoning_effort() -> None:
-    provider = OpenAICompatibleProvider(_config(llama_query_reasoning_effort="high"))
+def _embedding_config(**overrides: object) -> OpenAICompatibleEmbeddingConfig:
+    config: dict[str, object] = {
+        "api_key": "test-key",
+        "code_embedding_model": "text-embedding-3-large",
+        "docs_embedding_model": "text-embedding-3-small",
+    }
+    config.update(overrides)
+    return cast(OpenAICompatibleEmbeddingConfig, config)
 
-    llm = provider.get_chat_model()
+
+def test_chat_model_forwards_supported_runtime_options() -> None:
+    provider = OpenAICompatibleChatProvider(_chat_config())
+
+    llm = provider.get_chat_model(reasoning_effort="high", max_tokens=256)
 
     assert isinstance(llm, ChatOpenAI)
     assert llm.reasoning_effort == "high"
+    assert llm.max_tokens == 256
     assert llm.use_responses_api is True
 
 
-def test_chat_model_uses_configured_max_tokens() -> None:
-    provider = OpenAICompatibleProvider(_config())
-
-    llm = provider.get_chat_model()
-
-    assert isinstance(llm, ChatOpenAI)
-    assert llm.max_tokens == 256
-
-
-def test_chat_model_uses_default_max_tokens() -> None:
-    config = dict(_config())
-    config.pop("llama_query_max_tokens")
-    provider = OpenAICompatibleProvider(cast(OpenAICompatibleProviderConfig, config))
-
-    llm = provider.get_chat_model()
-
-    assert llm.max_tokens == 3072
-
-
-def test_reasoning_effort_is_omitted_when_unconfigured() -> None:
-    provider = OpenAICompatibleProvider(_config())
-
-    llm = provider.get_chat_model()
-
-    assert getattr(llm, "reasoning_effort", None) is None
-
-
 def test_chat_model_uses_custom_base_and_headers() -> None:
-    provider = OpenAICompatibleProvider(
-        _config(
-            openai_api_base="https://example.test/v1",
-            openai_default_headers={"X-Test-Header": "test"},
+    provider = OpenAICompatibleChatProvider(
+        _chat_config(
+            base_url="https://example.test/v1",
+            default_headers={"X-Test-Header": "test"},
         )
     )
 
@@ -72,3 +54,28 @@ def test_chat_model_uses_custom_base_and_headers() -> None:
 
     assert llm.openai_api_base == "https://example.test/v1"
     assert llm.default_headers == {"X-Test-Header": "test"}
+
+
+def test_embedding_provider_builds_separate_code_and_docs_models() -> None:
+    provider = OpenAICompatibleEmbeddingProvider(
+        _embedding_config(
+            base_url="https://example.test/v1",
+            default_headers={"X-Test-Header": "test"},
+            code_extra_kwargs={"dimensions": 1536},
+        )
+    )
+
+    code_embeddings = provider.get_embed_model_code()
+    docs_embeddings = provider.get_embed_model_docs()
+    code_client = cast(Any, code_embeddings._client)
+    docs_client = cast(Any, docs_embeddings._client)
+
+    assert isinstance(code_embeddings, LangChainEmbeddingAdapter)
+    assert isinstance(docs_embeddings, LangChainEmbeddingAdapter)
+    assert code_embeddings.model_name == "text-embedding-3-large"
+    assert docs_embeddings.model_name == "text-embedding-3-small"
+    assert code_client.model == "text-embedding-3-large"
+    assert docs_client.model == "text-embedding-3-small"
+    assert code_client.openai_api_base == "https://example.test/v1"
+    assert code_client.default_headers == {"X-Test-Header": "test"}
+    assert code_client.dimensions == 1536

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,37 +1,78 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib.util
-
 import pytest
 
-from metis.providers.registry import _LOADERS, get_provider
+import metis.providers.registry as registry
+from metis.providers.registry import get_chat_provider
+from metis.providers.registry import get_embedding_provider
 
 
 @pytest.mark.parametrize(
-    ("name", "dotted_path", "module"),
+    ("name", "class_name", "module_name"),
     [
+        ("openai", "OpenAIProvider", "metis.providers.openai"),
         (
-            "anthropic",
-            "metis.providers.anthropic:AnthropicProvider",
-            "langchain_anthropic",
+            "azure_openai",
+            "AzureOpenAIProvider",
+            "metis.providers.azure_openai",
         ),
-        ("bedrock", "metis.providers.bedrock:BedrockProvider", "langchain_aws"),
-        (
-            "bedrock_mantle",
-            "metis.providers.bedrock_mantle:BedrockMantleProvider",
-            "anthropic",
-        ),
-        ("gemini", "metis.providers.gemini:GeminiProvider", "langchain_google_genai"),
+        ("vllm", "VLLMProvider", "metis.providers.vllm"),
+        ("ollama", "OllamaProvider", "metis.providers.ollama"),
+        ("llamacpp", "LlamaCppProvider", "metis.providers.llamacpp"),
+        ("anthropic", "AnthropicProvider", "metis.providers.anthropic"),
+        ("gemini", "GeminiProvider", "metis.providers.gemini"),
+        ("bedrock", "BedrockProvider", "metis.providers.bedrock"),
+        ("bedrock_mantle", "BedrockMantleProvider", "metis.providers.bedrock_mantle"),
     ],
 )
-def test_registry_loads_optional_provider(name, dotted_path, module):
-    assert _LOADERS[name] == dotted_path
+def test_registry_loads_chat_providers(name, class_name, module_name):
+    provider_cls = get_chat_provider(name)
 
-    if importlib.util.find_spec(module) is None:
-        with pytest.raises(ModuleNotFoundError, match="required dependencies"):
-            get_provider(name)
-    else:
-        provider_cls = get_provider(name)
-        assert provider_cls.__module__ == dotted_path.split(":", 1)[0]
-        assert provider_cls.__name__ == dotted_path.split(":", 1)[1]
+    assert provider_cls.__name__ == class_name
+    assert provider_cls.__module__ == module_name
+
+
+@pytest.mark.parametrize(
+    ("name", "class_name", "module_name"),
+    [
+        ("openai", "OpenAIEmbeddingProvider", "metis.providers.openai"),
+        (
+            "azure_openai",
+            "AzureOpenAIEmbeddingProvider",
+            "metis.providers.azure_openai",
+        ),
+        ("vllm", "VLLMEmbeddingProvider", "metis.providers.vllm"),
+        ("ollama", "OllamaEmbeddingProvider", "metis.providers.ollama"),
+        ("llamacpp", "LlamaCppEmbeddingProvider", "metis.providers.llamacpp"),
+        ("bedrock", "BedrockEmbeddingProvider", "metis.providers.bedrock"),
+    ],
+)
+def test_registry_loads_embedding_providers(name, class_name, module_name):
+    provider_cls = get_embedding_provider(name)
+
+    assert provider_cls.__name__ == class_name
+    assert provider_cls.__module__ == module_name
+
+
+@pytest.mark.parametrize("name", ["anthropic", "bedrock_mantle", "gemini"])
+def test_registry_rejects_embedding_for_chat_only_providers(name):
+    with pytest.raises(ValueError, match="Unsupported embedding provider"):
+        get_embedding_provider(name)
+
+
+def test_registry_loads_source_tree_providers_without_installed_entry_points(
+    monkeypatch,
+):
+    class _NoEntryPoints:
+        def select(self, **_kwargs):
+            return []
+
+    monkeypatch.setattr(registry.metadata, "entry_points", lambda: _NoEntryPoints())
+    monkeypatch.setattr(registry, "_CHAT_PROVIDERS", {})
+    monkeypatch.setattr(registry, "_EMBEDDING_PROVIDERS", {})
+    monkeypatch.setattr(registry, "_PROVIDER_LOADERS", {})
+    monkeypatch.setattr(registry, "_PROVIDER_LOADERS_DISCOVERED", False)
+
+    assert get_chat_provider("openai").__name__ == "OpenAIProvider"
+    assert get_embedding_provider("openai").__name__ == "OpenAIEmbeddingProvider"

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -77,14 +77,11 @@ def test_review_code_propagates_usage_context_into_worker_threads():
     backend = Mock()
     backend.init = Mock()
     backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
-    llm_provider = Mock()
-    llm_provider.get_embed_model_code.return_value = Mock()
-    llm_provider.get_embed_model_docs.return_value = Mock()
 
     engine = MetisEngine(
         codebase_path="./tests/data",
         vector_backend=backend,
-        llm_provider=llm_provider,
+        llm_provider=Mock(),
         max_workers=2,
         max_token_length=2048,
         llama_query_model="gpt-test",
@@ -214,11 +211,15 @@ def test_index_codebase_records_embedding_usage(tmp_path):
             callback_manager=runtime.hooks.callback_manager,
         ),
     )
+    embedding_provider = Mock()
+    embedding_provider.get_embed_model_code.return_value = backend.embed_model_code
+    embedding_provider.get_embed_model_docs.return_value = backend.embed_model_docs
 
     engine = MetisEngine(
         codebase_path=str(codebase),
         vector_backend=backend,
         llm_provider=Mock(),
+        embedding_provider=embedding_provider,
         usage_runtime=runtime,
         max_workers=2,
         max_token_length=2048,


### PR DESCRIPTION
- Decouple chat and embedding provider setup so chat-only configs do not require embedding credentials.

- Use explicit code_embedding_model/docs_embedding_model keys and pass model IDs through unchanged.