### PR TITLE
feat(providers): configurable LLM retries

### DIFF
--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -74,6 +74,7 @@ def load_runtime_config(config_path=None, enable_psql=False):
     runtime["triage_tool_timeout_seconds"] = engine_cfg.get(
         "triage_tool_timeout_seconds", 12
     )
+    runtime["llm_max_retries"] = int(engine_cfg.get("llm_max_retries", 5))
     runtime["hnsw_kwargs"] = engine_cfg.get(
         "hnsw_kwargs",
         {
@@ -124,6 +125,7 @@ def load_runtime_config(config_path=None, enable_psql=False):
     if runtime["llama_query_reasoning_effort"]:
         chat_model_kwargs["reasoning_effort"] = runtime["llama_query_reasoning_effort"]
     runtime["chat_model_kwargs"] = chat_model_kwargs
+    llm_provider_config["max_retries"] = runtime["llm_max_retries"]
     runtime["llm_provider"] = llm_provider_config
 
     embedding_provider_raw_config = dict(cfg.get("embedding_provider") or {})

--- a/src/metis/engine/llm_runner.py
+++ b/src/metis/engine/llm_runner.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import time
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -39,9 +40,18 @@ class JsonPromptRequest:
 
 
 class JsonPromptRunner:
-    def __init__(self, llm_provider, usage_runtime=None):
+    def __init__(
+        self,
+        llm_provider,
+        usage_runtime=None,
+        *,
+        max_attempts: int = 2,
+        retry_backoff_seconds: float = 1.0,
+    ):
         self._llm_provider = llm_provider
         self._usage_runtime = usage_runtime
+        self._max_attempts = max(1, int(max_attempts))
+        self._retry_backoff_seconds = float(retry_backoff_seconds)
 
     def invoke(self, request: JsonPromptRequest):
         last_failure = "unknown failure"
@@ -50,7 +60,7 @@ class JsonPromptRunner:
             if request.model_tools
             else None
         )
-        for attempt in range(2):
+        for attempt in range(self._max_attempts):
             try:
                 usage_chat_kwargs = (
                     self._usage_runtime.hooks.chat_model_kwargs()
@@ -118,13 +128,17 @@ class JsonPromptRunner:
                 if isinstance(exc, ModelToolConfigurationError):
                     raise
                 last_failure = str(exc)
-            if attempt == 0:
+            if attempt < self._max_attempts - 1:
                 request.logger.warning(
-                    "%s failed for %d candidates; retrying once: %s",
+                    "%s failed for %d candidates; retrying (attempt %d/%d): %s",
                     request.label,
                     request.batch_size,
+                    attempt + 1,
+                    self._max_attempts,
                     last_failure,
                 )
+                if self._retry_backoff_seconds > 0:
+                    time.sleep(min(self._retry_backoff_seconds * (2**attempt), 30.0))
         request.logger.warning(
             "%s failed for %d candidates; %s: %s",
             request.label,

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -12,6 +12,7 @@ metis_engine:
   max_workers: 5
   triage_checkpoint_every: 50
   triage_tool_timeout_seconds: 12
+  llm_max_retries: 5
   embed_dim: 3072
   hnsw_kwargs:
     hnsw_m: 16

--- a/src/metis/providers/anthropic.py
+++ b/src/metis/providers/anthropic.py
@@ -26,6 +26,7 @@ class AnthropicProvider(ChatProvider):
         self.default_model = config.get("model")
         self.supports_temperature = bool(config.get("supports_temperature", False))
         self.base_url = config.get("base_url")
+        self.max_retries = int(config.get("max_retries", 5))
 
         if not self.api_key:
             raise ValueError(
@@ -54,6 +55,7 @@ class AnthropicProvider(ChatProvider):
         params: dict[str, Any] = {
             "model": model_name,
             "api_key": self.api_key,
+            "max_retries": self.max_retries,
         }
         max_tokens = kwargs.get("max_tokens")
         if max_tokens is not None:

--- a/src/metis/providers/azure_openai.py
+++ b/src/metis/providers/azure_openai.py
@@ -27,6 +27,7 @@ class AzureOpenAIChatConfig(TypedDict, total=False):
     model: NotRequired[str]
     supports_temperature: NotRequired[bool]
     use_responses_api: NotRequired[bool]
+    max_retries: NotRequired[int]
 
 
 class AzureOpenAIEmbeddingConfig(TypedDict, total=False):
@@ -68,6 +69,7 @@ class AzureOpenAIProvider(ChatProvider):
         self.chat_deployment_model = config["chat_deployment_model"]
         self.supports_temperature = config.get("supports_temperature", False)
         self.use_responses_api = config.get("use_responses_api")
+        self.max_retries = int(config.get("max_retries", 5))
 
         if not self.engine:
             raise ValueError("Missing 'engine' (Azure deployment name).")
@@ -92,6 +94,7 @@ class AzureOpenAIProvider(ChatProvider):
             "api_version": self.api_version,
             "azure_deployment": deployment,
             "model": self.chat_deployment_model,
+            "max_retries": self.max_retries,
         }
         if self.use_responses_api is not None:
             params["use_responses_api"] = bool(self.use_responses_api)

--- a/src/metis/providers/bedrock.py
+++ b/src/metis/providers/bedrock.py
@@ -43,6 +43,7 @@ class BedrockChatConfig(TypedDict, total=False):
     aws_secret_access_key: str
     aws_session_token: str
     endpoint_url: str
+    max_retries: int
 
 
 class BedrockEmbeddingConfig(TypedDict, total=False):
@@ -97,6 +98,7 @@ class BedrockProvider(ChatProvider):
         self.config = config
         self.default_model = config.get("model")
         self.supports_temperature = bool(config.get("supports_temperature", False))
+        self.max_retries = int(config.get("max_retries", 5))
         self._credentials = _credential_kwargs(config)
 
     def get_chat_model(
@@ -117,6 +119,7 @@ class BedrockProvider(ChatProvider):
 
         params: dict[str, object] = {
             "model": model_name,
+            "max_retries": self.max_retries,
             **self._credentials,
         }
         max_tokens = kwargs.get("max_tokens")

--- a/src/metis/providers/bedrock_mantle.py
+++ b/src/metis/providers/bedrock_mantle.py
@@ -88,6 +88,7 @@ class BedrockMantleProvider(ChatProvider):
         self.aws_profile = config.get("aws_profile")
         self.base_url = config.get("base_url")
         self.default_headers = dict(config.get("default_headers", {}))
+        self.max_retries = int(config.get("max_retries", 5))
 
     def get_chat_model(
         self,
@@ -110,6 +111,7 @@ class BedrockMantleProvider(ChatProvider):
             "model": model_name,
             "aws_region": self.aws_region,
             "aws_profile": self.aws_profile,
+            "max_retries": self.max_retries,
         }
         max_tokens = kwargs.get("max_tokens")
         if max_tokens is not None:

--- a/src/metis/providers/gemini.py
+++ b/src/metis/providers/gemini.py
@@ -22,6 +22,7 @@ class GeminiChatConfig(TypedDict, total=False):
     location: str
     vertexai: bool | None
     client_args: Mapping[str, object]
+    max_retries: int
 
 
 class GeminiProvider(ChatProvider):
@@ -54,6 +55,7 @@ class GeminiProvider(ChatProvider):
         self.location = config.get("location")
         self.vertexai = config.get("vertexai")
         self.client_args = dict(config.get("client_args", {}))
+        self.max_retries = int(config.get("max_retries", 5))
 
         if not self.api_key and not self.vertexai:
             raise ValueError(
@@ -103,6 +105,7 @@ class GeminiProvider(ChatProvider):
         response_format = kwargs.pop("response_format", None)
         params: dict[str, object] = {
             "model": model_name,
+            "max_retries": self.max_retries,
             **self._common_params(),
         }
         temperature = kwargs.get("temperature")

--- a/src/metis/providers/openai_compatible.py
+++ b/src/metis/providers/openai_compatible.py
@@ -22,6 +22,7 @@ class OpenAICompatibleChatConfig(TypedDict, total=False):
     base_url: str
     default_headers: Mapping[str, str]
     model: Required[str]
+    max_retries: int
 
 
 class OpenAICompatibleEmbeddingConfig(TypedDict, total=False):
@@ -44,6 +45,7 @@ class OpenAICompatibleChatProvider(ChatProvider):
         self.base_url = config.get("base_url") or self.DEFAULT_BASE_URL
         self.default_headers = dict(config.get("default_headers") or {})
         self.default_model = config.get("model")
+        self.max_retries = int(config.get("max_retries", 5))
 
         if not self.default_model:
             raise ValueError("Missing chat model configuration")
@@ -62,6 +64,7 @@ class OpenAICompatibleChatProvider(ChatProvider):
 
         params: dict[str, object] = {
             "model": model_name,
+            "max_retries": self.max_retries,
             "use_responses_api": True,
         }
         temperature = kwargs.get("temperature")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -62,7 +62,9 @@ query:
         "base_url": "https://example.test/openai/v1",
         "default_headers": {"X-Test-Header": "test"},
         "model": "gpt-test",
+        "max_retries": 5,
     }
+    assert runtime["llm_max_retries"] == 5
     assert runtime["chat_model_kwargs"] == {"reasoning_effort": "high"}
     assert runtime["model_tool_max_rounds"] == 9
     assert runtime["index_search_config"] == {}

--- a/tests/test_llm_runner_retry.py
+++ b/tests/test_llm_runner_retry.py
@@ -1,0 +1,66 @@
+import logging
+
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableLambda
+
+from metis.engine.llm_runner import JsonPromptRequest, JsonPromptRunner
+
+
+class _CountingProvider:
+    def __init__(self):
+        self.calls = 0
+
+    def get_chat_model(self, **_params):
+        def _respond(_messages):
+            self.calls += 1
+            return AIMessage(content="not-json")
+
+        return RunnableLambda(_respond)
+
+
+def _request(logger):
+    return JsonPromptRequest(
+        model="test-model",
+        system_prompt="system",
+        user_prompt="user {x}",
+        variables={"x": "v"},
+        parse=lambda _raw: None,
+        logger=logger,
+        label="Test prompt",
+        batch_size=3,
+        invalid_message="bad payload",
+        final_keep_message="giving up",
+    )
+
+
+def test_retries_configured_attempts_with_backoff(monkeypatch, caplog):
+    sleeps = []
+    monkeypatch.setattr("metis.engine.llm_runner.time.sleep", sleeps.append)
+    provider = _CountingProvider()
+    logger = logging.getLogger("metis.test.retry")
+
+    with caplog.at_level(logging.WARNING, logger="metis.test.retry"):
+        result = JsonPromptRunner(
+            provider, max_attempts=4, retry_backoff_seconds=0.5
+        ).invoke(_request(logger))
+
+    assert result is None
+    assert provider.calls == 4
+    assert sleeps == [0.5, 1.0, 2.0]
+    assert "retrying (attempt 1/4)" in caplog.text
+    assert "retrying (attempt 3/4)" in caplog.text
+    assert "giving up" in caplog.text
+
+
+def test_zero_backoff_skips_sleep(monkeypatch):
+    monkeypatch.setattr(
+        "metis.engine.llm_runner.time.sleep",
+        lambda _s: (_ for _ in ()).throw(AssertionError("should not sleep")),
+    )
+    logger = logging.getLogger("metis.test.retry.zero")
+
+    result = JsonPromptRunner(
+        _CountingProvider(), max_attempts=2, retry_backoff_seconds=0
+    ).invoke(_request(logger))
+
+    assert result is None

--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -42,6 +42,30 @@ def test_chat_model_forwards_supported_runtime_options() -> None:
     assert llm.use_responses_api is True
 
 
+def test_chat_model_applies_configured_max_retries() -> None:
+    provider = OpenAICompatibleChatProvider(_chat_config(max_retries=7))
+
+    llm = provider.get_chat_model()
+
+    assert llm.max_retries == 7
+
+
+def test_chat_model_caller_can_override_max_retries() -> None:
+    provider = OpenAICompatibleChatProvider(_chat_config(max_retries=7))
+
+    llm = provider.get_chat_model(max_retries=1)
+
+    assert llm.max_retries == 1
+
+
+def test_chat_model_default_max_retries() -> None:
+    provider = OpenAICompatibleChatProvider(_chat_config())
+
+    llm = provider.get_chat_model()
+
+    assert llm.max_retries == 5
+
+
 def test_chat_model_uses_custom_base_and_headers() -> None:
     provider = OpenAICompatibleChatProvider(
         _chat_config(


### PR DESCRIPTION
Default max_retries on ChatOpenAI/AzureChatOpenAI from metis_engine.llm_max_retries (default 5) so the openai client retries rate-limit/connection/5xx errors with backoff across all call sites.