### PR TITLE
Include Java in Supported Languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Metis includes support for the following languages:
 |------------|------------------------------------------|------------------|
 | C          | Tree-sitter + Flow Analysis + tools      | Built-in plugin  |
 | C++        | Tree-sitter + Flow Analysis + tools      | Built-in plugin  |
+| Java       | Tree-sitter + Structural Analysis + tools| Built-in plugin  |
 | Python     | Tree-sitter + Structural Analysis + tools| Built-in plugin  |
 | Rust       | Tree-sitter + Structural Analysis + tools| Built-in plugin  |
 | TypeScript | Tree-sitter + Structural Analysis + tools| Built-in plugin  |


### PR DESCRIPTION
Update the README now that support for Java was added by @mpekatsoula in #241 The value for "Triage Analysis" is an educated guess.