### PR TITLE
feat(devcontainer): Add Devcontainer Support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  "name": "metis-dev",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": "../",
+    "target": "dev",
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "configureZshAsDefaultShell": "true",
+      "username": "metisuser",
+      "userUid": "${localEnv:UID:1000}",
+      "userGid": "${localEnv:GID:1000}",
+    },
+  },
+  "updateContentCommand": ["uv", "sync", "--extra=dev", "--extra=postgres"],
+  "postCreateCommand": ["uv", "run", "pre-commit", "install"],
+  "updateRemoteUserUID": true,
+  "containerUser": "metisuser",
+  "remoteUser": "metisuser",
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 .pytest_cache/
 .ruff_cache/
 .coverage
+.devcontainer/devcontainer-lock.json
 .python-version
 uv.lock
 results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,21 @@
 
 FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim@sha256:69ef6514bf9b7de044514258356fa68a2d94df2e5dc807b5bfbf88fbb35f3a58 AS builder
 
+RUN groupadd -r metisuser && useradd -r -m -d /home/metisuser -g metisuser metisuser
+USER metisuser
+
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 WORKDIR /app
 
-COPY src/ pyproject.toml MANIFEST.in ./
+COPY --chown=metisuser:metisuser src/ pyproject.toml MANIFEST.in ./
 RUN uv sync --no-dev --no-editable
+
+
+FROM builder AS dev
+
+WORKDIR /app
+USER metisuser
+RUN uv sync --extra dev --extra postgres
 
 
 FROM python:3.13-slim-trixie@sha256:47b6eb1efcabc908e264051140b99d08ebb37fd2b0bf62273e2c9388911490c1 AS runtime


### PR DESCRIPTION
- Devcontainer can be used via `devcontainer up` and attached to with an IDE of choice
- Added missing Apache 2.0 license header to `Dockerfile`

Tested with rootless `podman` and confirmed `uv run pytest` and `uv run pre-commit run -a` complete successfully.