### PR TITLE
feat(container): Cache Tiktoken for Offline Container Inference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim@sha256:69ef6514bf9b7de044514258356fa68a2d94df2e5dc807b5bfbf88fbb35f3a58 AS builder
 
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
@@ -16,6 +19,12 @@ WORKDIR /app
 COPY --from=builder --chown=metisuser:metisuser /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /cache
+
+ADD --chown=metisuser:metisuser https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken 9b5ad71b2ce5302211f9c61530b329a4922fc6a4
+
+ENV TIKTOKEN_CACHE_DIR="/cache"
 
 WORKDIR /metis
 


### PR DESCRIPTION
The following runtime error occurs in an isolated offline container environment:

```
HTTPSConnectionPool(host='[openaipublic.blob.core.windows.net](http://openaipublic.blob.core.windows.net/)', port=443): Max retries exceeded with url: /encodings/cl100k_base.tiktoken (Caused by NameResolutionError("HTTPSConnection(host='[openaipublic.blob.core.windows.net](http://openaipublic.blob.core.windows.net/)', port=443): Failed to resolve '[openaipublic.blob.core.windows.net](http://openaipublic.blob.core.windows.net/)' ([Errno -2] Name or service not known)"))
```

These additions to the `Dockerfile` were inspired by this [discussion](https://stackoverflow.com/questions/76106366/how-to-use-tiktoken-in-offline-mode-computer).