### PR TITLE
chore(pre-commit): Fix python version mismatch between venv and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.12
+  python: python3
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Without this change the following error occurs when the `venv` python version is not `3.12`.

```sh
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.12'
```

Since the `Dockerfile` currently uses `python:3.13-slim-trixie` and `pyproject.toml` uses `requires-python = ">=3.12"`, the `pre-commit` python version requirement should be relaxed.