### PR TITLE
chore(gitignore): Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.egg-info
-.venv
+.venv/
+.coverage
 .env
 build/
+chromadb/
 dist/
 **/__pycache__/
 *.DS_Store
@@ -12,5 +14,5 @@ dist/
 uv.lock
 results/
 /local-tests/
-/metis.local.yaml
-/metis.local.yml
+/metis*.yaml
+/metis*.yml


### PR DESCRIPTION
- `.coverage` is generated when running `uv run pre-commit run -a`
- `chromadb/` is created when running `metis` on itself during testing
- `metis.yaml` is created by `podman` when using a volume mount to override and an empty file remains as an artifact (updated the existing `metis.local.yaml` to a catch-all)