### PR TITLE
fix(providers): provider-aware token counting

### DIFF
--- a/src/metis/engine/diff_utils.py
+++ b/src/metis/engine/diff_utils.py
@@ -19,7 +19,8 @@ def extract_content_from_diff(file_diff):
     return "".join(content_lines)
 
 
-def process_diff_file(codebase_path, file_diff, max_token_length):
+def process_diff_file(codebase_path, file_diff, max_token_length, token_counter=None):
+    counter = token_counter or count_tokens
     changed_lines = []
     for hunk in file_diff:
         for line in hunk:
@@ -32,7 +33,7 @@ def process_diff_file(codebase_path, file_diff, max_token_length):
     original_content = read_file_content(original_file_path)
     if original_content:
         logger.info(f"Fetched original content for {file_diff.path}.")
-        total_tokens = count_tokens(original_content) + count_tokens(snippet)
+        total_tokens = counter(original_content) + counter(snippet)
         if total_tokens <= max_token_length:
             snippet = f"ORIGINAL_FILE:\n{original_content}\n\nFILE_CHANGES:\n{snippet}"
         else:

--- a/src/metis/engine/graphs/review.py
+++ b/src/metis/engine/graphs/review.py
@@ -256,7 +256,9 @@ class ReviewGraph:
             smap = SourceMap.for_text(rel_path, original_file)
         else:
             smap = None
-        chunks = split_snippet(snippet, self.max_token_length)
+        chunks = split_snippet(
+            snippet, self.max_token_length, self.llm_provider.count_tokens
+        )
         accumulated = []
         app = self._build_app(language_prompts, default_prompt_key)
         for chunk, chunk_start in chunks:

--- a/src/metis/engine/review_service.py
+++ b/src/metis/engine/review_service.py
@@ -316,7 +316,10 @@ class ReviewService:
             if not plugin:
                 continue
             snippet = process_diff_file(
-                self._config.codebase_path, file_diff, self._config.max_token_length
+                self._config.codebase_path,
+                file_diff,
+                self._config.max_token_length,
+                token_counter=self._config.llm_provider.count_tokens,
             )
             if not snippet:
                 continue

--- a/src/metis/providers/anthropic.py
+++ b/src/metis/providers/anthropic.py
@@ -10,6 +10,7 @@ from langchain_core.callbacks import Callbacks
 from metis.providers.base import ChatProvider
 from metis.providers.config import ApiKeySources
 from metis.providers.config import ProviderConfigSpec
+from metis.utils import anthropic_token_count
 
 
 class AnthropicProvider(ChatProvider):
@@ -32,6 +33,9 @@ class AnthropicProvider(ChatProvider):
             raise ValueError(
                 "ANTHROPIC_API_KEY environment variable is required for Anthropic provider but not set."
             )
+
+    def count_tokens(self, text: str) -> int:
+        return anthropic_token_count(text)
 
     def get_chat_model(
         self,

--- a/src/metis/providers/azure_openai.py
+++ b/src/metis/providers/azure_openai.py
@@ -16,6 +16,7 @@ from metis.providers.base import EmbeddingProvider
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 from metis.providers.config import ApiKeySources
 from metis.providers.config import ProviderConfigSpec
+from metis.utils import tiktoken_token_count
 
 
 class AzureOpenAIChatConfig(TypedDict, total=False):
@@ -78,6 +79,9 @@ class AzureOpenAIProvider(ChatProvider):
                 "Missing 'chat_deployment_model' "
                 "Azure calls must specify a deployment model."
             )
+
+    def count_tokens(self, text: str) -> int:
+        return tiktoken_token_count(text, self.chat_deployment_model)
 
     def get_chat_model(
         self,

--- a/src/metis/providers/base.py
+++ b/src/metis/providers/base.py
@@ -10,6 +10,8 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.callbacks import CallbackManager
 
+from metis.utils import heuristic_token_count
+
 
 class EmbedModelKwargs(TypedDict, total=False):
     callback_manager: CallbackManager
@@ -36,6 +38,15 @@ class ChatProvider(ABC):
     ) -> BaseChatModel:
         """Return a LangChain chat model instance."""
         pass
+
+    def count_tokens(self, text: str) -> int:
+        """Estimate token count for ``text`` under this provider's tokenizer.
+
+        The base implementation is a chars-per-token heuristic suitable for
+        providers without a published offline tokenizer; override when an
+        exact encoder is available (e.g. tiktoken for OpenAI).
+        """
+        return heuristic_token_count(text)
 
 
 class EmbeddingProvider(ABC):

--- a/src/metis/providers/bedrock.py
+++ b/src/metis/providers/bedrock.py
@@ -13,6 +13,7 @@ from metis.providers.base import ChatProvider
 from metis.providers.base import EmbeddingProvider
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 from metis.providers.config import ProviderConfigSpec
+from metis.utils import count_tokens as count_tokens_for_model
 
 
 AWS_CREDENTIAL_CONFIG = {
@@ -100,6 +101,9 @@ class BedrockProvider(ChatProvider):
         self.supports_temperature = bool(config.get("supports_temperature", False))
         self.max_retries = int(config.get("max_retries", 5))
         self._credentials = _credential_kwargs(config)
+
+    def count_tokens(self, text: str) -> int:
+        return count_tokens_for_model(text, self.default_model)
 
     def get_chat_model(
         self,

--- a/src/metis/providers/bedrock_mantle.py
+++ b/src/metis/providers/bedrock_mantle.py
@@ -11,6 +11,7 @@ from pydantic import Field
 
 from metis.providers.base import ChatProvider
 from metis.providers.config import ProviderConfigSpec
+from metis.utils import anthropic_token_count
 
 AnthropicBedrockMantle: Any
 AsyncAnthropicBedrockMantle: Any
@@ -89,6 +90,9 @@ class BedrockMantleProvider(ChatProvider):
         self.base_url = config.get("base_url")
         self.default_headers = dict(config.get("default_headers", {}))
         self.max_retries = int(config.get("max_retries", 5))
+
+    def count_tokens(self, text: str) -> int:
+        return anthropic_token_count(text)
 
     def get_chat_model(
         self,

--- a/src/metis/providers/llamacpp.py
+++ b/src/metis/providers/llamacpp.py
@@ -19,6 +19,7 @@ from metis.providers.openai_compatible import OpenAICompatibleChatProvider
 from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
 from metis.providers.config import ApiKeySources
 from metis.providers.config import ProviderConfigSpec
+from metis.utils import count_tokens as count_tokens_for_model
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,9 @@ class LlamaCppProvider(OpenAICompatibleChatProvider):
                 "llama.cpp base URL not configured, defaulting to %s",
                 self.DEFAULT_BASE_URL,
             )
+
+    def count_tokens(self, text: str) -> int:
+        return count_tokens_for_model(text, self.default_model)
 
 
 class LlamaCppEmbeddingProvider(OpenAICompatibleEmbeddingProvider):

--- a/src/metis/providers/ollama.py
+++ b/src/metis/providers/ollama.py
@@ -14,6 +14,7 @@ import logging
 from metis.providers.openai_compatible import OpenAICompatibleChatProvider
 from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
 from metis.providers.config import ProviderConfigSpec
+from metis.utils import count_tokens as count_tokens_for_model
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,9 @@ class OllamaProvider(OpenAICompatibleChatProvider):
                 "using a default."
             )
         super().__init__(config)
+
+    def count_tokens(self, text: str) -> int:
+        return count_tokens_for_model(text, self.default_model)
 
 
 class OllamaEmbeddingProvider(OpenAICompatibleEmbeddingProvider):

--- a/src/metis/providers/openai_compatible.py
+++ b/src/metis/providers/openai_compatible.py
@@ -15,6 +15,7 @@ from pydantic import SecretStr
 from metis.providers.base import ChatProvider
 from metis.providers.base import EmbeddingProvider
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
+from metis.utils import tiktoken_token_count
 
 
 class OpenAICompatibleChatConfig(TypedDict, total=False):
@@ -49,6 +50,9 @@ class OpenAICompatibleChatProvider(ChatProvider):
 
         if not self.default_model:
             raise ValueError("Missing chat model configuration")
+
+    def count_tokens(self, text: str) -> int:
+        return tiktoken_token_count(text, self.default_model)
 
     def get_chat_model(
         self,

--- a/src/metis/providers/vllm.py
+++ b/src/metis/providers/vllm.py
@@ -7,6 +7,7 @@ from metis.providers.openai_compatible import OpenAICompatibleChatProvider
 from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
 from metis.providers.config import ApiKeySources
 from metis.providers.config import ProviderConfigSpec
+from metis.utils import count_tokens as count_tokens_for_model
 
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,9 @@ class VLLMProvider(OpenAICompatibleChatProvider):
 
         if not self.api_key:
             logger.debug("vLLM provider running without API key")
+
+    def count_tokens(self, text: str) -> int:
+        return count_tokens_for_model(text, self.default_model)
 
 
 class VLLMEmbeddingProvider(OpenAICompatibleEmbeddingProvider):

--- a/src/metis/usage/llamaindex.py
+++ b/src/metis/usage/llamaindex.py
@@ -129,10 +129,7 @@ class UsageLlamaIndexHandler(BaseCallbackHandler):
             text = str(chunk or "")
             if not text:
                 continue
-            try:
-                input_tokens += count_tokens(text, model=model_name)
-            except Exception:
-                input_tokens += count_tokens(text)
+            input_tokens += count_tokens(text, model=model_name)
         if input_tokens <= 0:
             return
         self._collector.record(

--- a/src/metis/utils.py
+++ b/src/metis/utils.py
@@ -3,10 +3,39 @@
 
 import codecs
 import json
+import math
 import os
 import sys
+from collections.abc import Callable
+from functools import lru_cache
 
 import tiktoken
+
+TokenCounter = Callable[[str], int]
+
+_ANTHROPIC_MODEL_MARKERS = ("claude", "anthropic")
+_ANTHROPIC_CHARS_PER_TOKEN = 3.5
+_HEURISTIC_CHARS_PER_TOKEN = 4.0
+_DEFAULT_TIKTOKEN_ENCODING = "cl100k_base"
+
+# Approximate chars-per-token for families without an offline tokenizer.
+# Order matters: more specific markers first. Sources: Meta Llama 3 paper
+# (arXiv:2407.21783), Mistral tokenization docs, Qwen2 tech report
+# (arXiv:2407.10671), Google Gemini token docs, HF tokenizer configs.
+_MODEL_FAMILY_CHARS_PER_TOKEN: tuple[tuple[tuple[str, ...], float], ...] = (
+    (("llama-3", "llama3", "meta.llama3"), 3.9),
+    (("llama-2", "llama2", "meta.llama2", "codellama"), 3.2),
+    (("llama",), 3.9),
+    (("mixtral", "mistral-7b", "mistral:7b"), 3.2),
+    (("mistral",), 3.9),
+    (("qwen",), 4.0),
+    (("deepseek",), 4.0),
+    (("gemma", "gemini"), 4.0),
+    (("phi-3", "phi3"), 3.5),
+    (("phi",), 4.0),
+    (("command", "cohere"), 4.0),
+    (("titan", "amazon."), 4.0),
+)
 
 
 def safe_decode_unicode(s):
@@ -15,13 +44,80 @@ def safe_decode_unicode(s):
     return s
 
 
-def count_tokens(text, model="gpt-4"):
-    encoding = tiktoken.encoding_for_model(model)
-    return len(encoding.encode(text))
+def _is_anthropic_model(model: str | None) -> bool:
+    if not model:
+        return False
+    lowered = model.lower()
+    return any(marker in lowered for marker in _ANTHROPIC_MODEL_MARKERS)
 
 
-def split_snippet(snippet, max_tokens, model="gpt-4"):
+@lru_cache(maxsize=None)
+def _tiktoken_encoding_for(model: str | None):
+    if model:
+        try:
+            return tiktoken.encoding_for_model(model)
+        except KeyError:
+            pass
+    return tiktoken.get_encoding(_DEFAULT_TIKTOKEN_ENCODING)
+
+
+def _chars_per_token_for(model: str | None) -> float:
+    if model:
+        lowered = model.lower()
+        for markers, ratio in _MODEL_FAMILY_CHARS_PER_TOKEN:
+            if any(m in lowered for m in markers):
+                return ratio
+    return _HEURISTIC_CHARS_PER_TOKEN
+
+
+def heuristic_token_count(
+    text: str,
+    chars_per_token: float | None = None,
+    *,
+    model: str | None = None,
+) -> int:
+    if not text:
+        return 0
+    ratio = (
+        chars_per_token if chars_per_token is not None else _chars_per_token_for(model)
+    )
+    return max(1, math.ceil(len(text) / ratio))
+
+
+def anthropic_token_count(text: str) -> int:
+    return heuristic_token_count(text, _ANTHROPIC_CHARS_PER_TOKEN)
+
+
+def tiktoken_token_count(text: str, model: str | None = None) -> int:
+    return len(_tiktoken_encoding_for(model).encode(text))
+
+
+def count_tokens(text: str, model: str | None = None) -> int:
+    """Estimate token count for ``text`` from ``model`` name alone.
+
+    Prefer :meth:`ChatProvider.count_tokens` when a provider instance is
+    available; this standalone form is for call sites (e.g. usage callbacks)
+    that only see a model id string. Anthropic/Claude ids and recognised
+    open-weight families use chars-per-token heuristics; OpenAI ids use their
+    native tiktoken encoding; unknown ids fall back to ``cl100k_base``.
+    """
+    if _is_anthropic_model(model):
+        return anthropic_token_count(text)
+    if model:
+        lowered = model.lower()
+        for markers, ratio in _MODEL_FAMILY_CHARS_PER_TOKEN:
+            if any(m in lowered for m in markers):
+                return heuristic_token_count(text, ratio)
+    return tiktoken_token_count(text, model)
+
+
+def split_snippet(
+    snippet: str,
+    max_tokens: int,
+    token_counter: TokenCounter | None = None,
+) -> list[tuple[str, int]]:
     """Split text into token-bounded chunks, returning (chunk, start_line) pairs."""
+    counter = token_counter or count_tokens
     lines = snippet.splitlines(keepends=True)
     chunks: list[tuple[str, int]] = []
     current_chunk = ""
@@ -30,7 +126,7 @@ def split_snippet(snippet, max_tokens, model="gpt-4"):
     current_token_count = 0
 
     for line in lines:
-        line_token_count = count_tokens(line, model)
+        line_token_count = counter(line)
         if current_token_count + line_token_count > max_tokens:
             if current_chunk:
                 chunks.append((current_chunk, current_start))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,7 @@ def dummy_backend():
 def dummy_llm():
     llm = Mock()
     llm.get_chat_model.return_value = MagicMock()
+    llm.count_tokens = lambda text: len(text)
     return llm
 
 

--- a/tests/test_provider_token_count.py
+++ b/tests/test_provider_token_count.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from metis.providers.base import ChatProvider
+from metis.utils import (
+    anthropic_token_count,
+    heuristic_token_count,
+    tiktoken_token_count,
+)
+
+
+TEXT = "def add(a, b):\n    return a + b\n"
+
+
+class _StubProvider(ChatProvider):
+    def get_chat_model(self, *args, callbacks=None, **kwargs):
+        raise NotImplementedError
+
+
+def test_base_provider_uses_chars_per_token_heuristic():
+    assert _StubProvider({}).count_tokens(TEXT) == heuristic_token_count(TEXT)
+    assert _StubProvider({}).count_tokens("") == 0
+
+
+def test_openai_compatible_provider_uses_tiktoken():
+    from metis.providers.openai_compatible import OpenAICompatibleChatProvider
+
+    provider = OpenAICompatibleChatProvider({"api_key": "k", "model": "gpt-4o"})
+    assert provider.count_tokens(TEXT) == tiktoken_token_count(TEXT, "gpt-4o")
+
+
+def test_azure_openai_provider_uses_tiktoken():
+    from metis.providers.azure_openai import AzureOpenAIProvider
+
+    provider = AzureOpenAIProvider(
+        {
+            "api_key": "k",
+            "azure_endpoint": "https://example",
+            "azure_api_version": "2024-01-01",
+            "engine": "deploy",
+            "chat_deployment_model": "gpt-4o",
+        }
+    )
+    assert provider.count_tokens(TEXT) == tiktoken_token_count(TEXT, "gpt-4o")
+
+
+def test_anthropic_provider_uses_anthropic_heuristic():
+    pytest.importorskip("langchain_anthropic")
+    from metis.providers.anthropic import AnthropicProvider
+
+    provider = AnthropicProvider({"api_key": "k", "model": "claude-sonnet-4-6"})
+    assert provider.count_tokens(TEXT) == anthropic_token_count(TEXT)
+
+
+def test_bedrock_mantle_provider_uses_anthropic_heuristic():
+    pytest.importorskip("langchain_anthropic")
+    from metis.providers.bedrock_mantle import BedrockMantleProvider
+
+    provider = BedrockMantleProvider({"model": "claude-sonnet-4-6"})
+    assert provider.count_tokens(TEXT) == anthropic_token_count(TEXT)
+
+
+def test_bedrock_provider_dispatches_on_model_id():
+    pytest.importorskip("langchain_aws")
+    from metis.providers.bedrock import BedrockProvider
+
+    claude = BedrockProvider(
+        {"region": "us-east-1", "model": "us.anthropic.claude-3-5-sonnet-v2:0"}
+    )
+    assert claude.count_tokens(TEXT) == anthropic_token_count(TEXT)
+
+    titan = BedrockProvider(
+        {"region": "us-east-1", "model": "amazon.titan-text-express-v1"}
+    )
+    assert titan.count_tokens(TEXT) == heuristic_token_count(
+        TEXT, model="amazon.titan-text-express-v1"
+    )
+
+    mistral = BedrockProvider(
+        {"region": "us-east-1", "model": "mistral.mixtral-8x7b-instruct-v0:1"}
+    )
+    assert mistral.count_tokens(TEXT) == heuristic_token_count(TEXT, 3.2)
+
+
+@pytest.mark.parametrize(
+    ("module", "cls", "config"),
+    [
+        ("metis.providers.ollama", "OllamaProvider", {"model": "llama3:8b"}),
+        (
+            "metis.providers.vllm",
+            "VLLMProvider",
+            {"model": "mistralai/Mixtral-8x7B", "base_url": "http://x"},
+        ),
+        ("metis.providers.llamacpp", "LlamaCppProvider", {"model": "qwen2.5-coder"}),
+    ],
+)
+def test_local_oai_compatible_providers_use_model_family_heuristic(module, cls, config):
+    import importlib
+
+    provider_cls = getattr(importlib.import_module(module), cls)
+    provider = provider_cls(config)
+    assert provider.count_tokens(TEXT) == heuristic_token_count(
+        TEXT, model=config["model"]
+    )
+
+
+def test_gemini_provider_inherits_base_heuristic():
+    pytest.importorskip("langchain_google_genai")
+    from metis.providers.gemini import GeminiProvider
+
+    provider = GeminiProvider({"api_key": "k", "model": "gemini-2.0-flash"})
+    assert provider.count_tokens(TEXT) == heuristic_token_count(TEXT)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,16 @@
 import json
+import math
 
-from metis.utils import extract_json_content
+import pytest
+
+from metis.utils import (
+    anthropic_token_count,
+    count_tokens,
+    extract_json_content,
+    heuristic_token_count,
+    split_snippet,
+    tiktoken_token_count,
+)
 
 
 # ============================================================
@@ -253,3 +263,99 @@ def test_extract_json_content_json_without_markdown():
     parsed = json.loads(result)
     assert parsed["status"] == "complete"
     assert parsed["issues"] == 0
+
+
+# ============================================================
+# Token counting Tests
+# ============================================================
+def test_heuristic_token_count_default_ratio():
+    text = "hello world!"
+    assert heuristic_token_count(text) == math.ceil(len(text) / 4.0)
+    assert heuristic_token_count("") == 0
+    assert heuristic_token_count("x") == 1
+
+
+def test_anthropic_token_count_uses_anthropic_ratio():
+    text = "def f():\n    return 42\n"
+    assert anthropic_token_count(text) == math.ceil(len(text) / 3.5)
+    assert anthropic_token_count("") == 0
+
+
+@pytest.mark.parametrize(
+    ("model", "ratio"),
+    [
+        ("llama3:8b", 3.9),
+        ("meta-llama/Llama-2-7b-hf", 3.2),
+        ("codellama:13b", 3.2),
+        ("meta.llama3-1-70b-instruct-v1:0", 3.9),
+        ("mixtral:8x7b", 3.2),
+        ("mistralai/Mistral-7B-Instruct-v0.2", 3.2),
+        ("mistral-large-latest", 3.9),
+        ("qwen2.5-coder:7b", 4.0),
+        ("deepseek-r1:32b", 4.0),
+        ("gemma2:9b", 4.0),
+        ("gemini-2.0-flash", 4.0),
+        ("phi3:mini", 3.5),
+        ("microsoft/phi-2", 4.0),
+        ("cohere.command-r-plus-v1:0", 4.0),
+        ("amazon.titan-text-express-v1", 4.0),
+    ],
+)
+def test_heuristic_token_count_model_family_ratios(model, ratio):
+    text = "x" * 200
+    assert heuristic_token_count(text, model=model) == math.ceil(len(text) / ratio)
+    assert count_tokens(text, model=model) == math.ceil(len(text) / ratio)
+
+
+def test_heuristic_token_count_unknown_model_uses_default():
+    text = "x" * 200
+    assert heuristic_token_count(text, model="some-future-model") == math.ceil(
+        len(text) / 4.0
+    )
+
+
+def test_tiktoken_token_count_known_model():
+    text = "x" * 100
+    n = tiktoken_token_count(text, "gpt-4o")
+    assert n > 0
+    assert n != math.ceil(len(text) / 3.5)
+
+
+def test_tiktoken_token_count_unknown_model_falls_back_to_cl100k():
+    text = "hello world"
+    assert tiktoken_token_count(text, "amazon.titan-embed-text-v2:0") == (
+        tiktoken_token_count(text, None)
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-sonnet-4-6",
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2",
+    ],
+)
+def test_count_tokens_dispatches_anthropic_ids_to_heuristic(model):
+    text = "def f():\n    return 42\n"
+    assert count_tokens(text, model=model) == anthropic_token_count(text)
+
+
+def test_count_tokens_default_matches_legacy_gpt4():
+    """No-model default must preserve the previous gpt-4 behaviour."""
+    text = "hello world, this is a tokenizer test"
+    assert count_tokens(text) == tiktoken_token_count(text, "gpt-4")
+
+
+def test_split_snippet_uses_supplied_token_counter():
+    text = "alpha\nbeta\ngamma\ndelta\n"
+    chunks = split_snippet(text, max_tokens=2, token_counter=lambda line: 1)
+    assert [s for _, s in chunks] == [1, 3]
+    assert "".join(c for c, _ in chunks) == text
+
+
+def test_split_snippet_default_counter():
+    text = "a\nb\nc\nd\n"
+    chunks = split_snippet(text, max_tokens=1)
+    assert "".join(c for c, _ in chunks) == text


### PR DESCRIPTION
Token counting was hardcoded to tiktoken/gpt-4 regardless of the configured provider, so Anthropic (direct, Bedrock, Bedrock Mantle), Gemini, and local-model providers all chunked and accounted using the OpenAI tokenizer.

ChatProvider now exposes count_tokens() with a chars/4 default heuristic. OpenAI/Azure override with tiktoken; Anthropic and Bedrock Mantle use a 3.5 chars/token heuristic; Bedrock, Ollama, vLLM and llama.cpp dispatch on the configured model id against a per-family ratio table (Llama 2/3, Mistral/Mixtral, Qwen, DeepSeek, Gemma/Gemini, Phi, Cohere, Titan) sourced from the Llama 3 paper, Mistral docs, Qwen2 tech report, Google token docs and HF tokenizer configs.

split_snippet and process_diff_file accept a token_counter callable; ReviewGraph and ReviewService pass llm_provider.count_tokens. The embedding-usage callback keeps the model-name dispatch in utils.count_tokens since it only sees a model id string.