### PR TITLE
feat(pgvector): support pgvector halfvec indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,17 @@ metis \
   --backend postgres
 ```
 
+For embedding models above pgvector's normal-vector HNSW limit, such as
+3072-dimensional embeddings, Metis automatically enables pgvector `halfvec`
+storage for the PostgreSQL backend so HNSW indexes can still be created. You
+can override this in `metis.yaml`:
+
+```yaml
+metis_engine:
+  embed_dim: 3072
+  pgvector_use_halfvec: auto  # auto, true, or false
+```
+
 #### Example 3: Usage and output
 
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -28,6 +28,7 @@ embedding_provider:
 
 metis_engine:
   embed_dim: 3072
+  pgvector_use_halfvec: auto
 
 query:
   max_tokens: 5000
@@ -44,6 +45,9 @@ query:
   without retrieval.
 - `metis_engine.embed_dim` must match the configured embedding model output
   dimension.
+- For the PostgreSQL backend, `metis_engine.pgvector_use_halfvec: auto` uses
+  pgvector `halfvec` storage for 3072-dimensional embeddings so HNSW indexing
+  remains available.
 
 Run Metis normally after the service credentials are available:
 

--- a/docs/providers/embedding-provider.md
+++ b/docs/providers/embedding-provider.md
@@ -24,6 +24,11 @@ metis_engine:
   tools: [index]
 ```
 
+For the PostgreSQL backend, `pgvector_use_halfvec` defaults to `auto`. This
+uses pgvector `halfvec` storage when `embed_dim` is above the normal-vector
+HNSW limit, for example 3072-dimensional embeddings. Set it to `true` or
+`false` to force a specific behavior.
+
 The `embedding_provider` block uses the embedding provider's own config keys.
 For OpenAI-compatible providers (`openai`, `ollama`, `llamacpp`, `vllm`) use
 `code_embedding_model` and `docs_embedding_model`. Azure OpenAI also requires

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -28,6 +28,7 @@ embedding_provider:
 
 metis_engine:
   embed_dim: 3072
+  pgvector_use_halfvec: auto
 
 query:
   max_tokens: 5000
@@ -41,6 +42,9 @@ query:
   the `index` tool.
 - `metis_engine.embed_dim` must match the configured embedding provider output
   dimension.
+- For the PostgreSQL backend, `metis_engine.pgvector_use_halfvec: auto` uses
+  pgvector `halfvec` storage for 3072-dimensional embeddings so HNSW indexing
+  remains available.
 - `query.reasoning_effort` values `minimal`, `low`, `medium`, and `high` are
   forwarded as Gemini `thinking_level`.
 

--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -119,6 +119,7 @@ embedding_provider:
 
 metis_engine:
   embed_dim: <embedding-dimension>  # must match embedding model output
+  pgvector_use_halfvec: auto        # PostgreSQL backend: auto, true, or false
 
 query:
   model: "<chat-model-id>"

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -648,6 +648,7 @@ def build_pg_backend(args, runtime, embed_model_code, embed_model_docs, quiet=Fa
         embed_dim=runtime["embed_dim"],
         query_config=retriever_query_config(runtime),
         hnsw_kwargs=runtime.get("hnsw_kwargs", {}),
+        use_halfvec=bool(runtime.get("pgvector_use_halfvec", False)),
     )
 
 

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -84,6 +84,10 @@ def load_runtime_config(config_path=None, enable_psql=False):
             "hnsw_dist_method": "vector_cosine_ops",
         },
     )
+    runtime["pgvector_use_halfvec"] = pgvector_use_halfvec_setting(
+        engine_cfg.get("pgvector_use_halfvec", "auto"),
+        runtime["embed_dim"],
+    )
     runtime["metisignore_file"] = engine_cfg.get("metisignore_file", None)
     runtime["review_code_include_paths"] = engine_cfg.get(
         "review_code_include_paths", []
@@ -176,6 +180,26 @@ def _positive_int(value: object, *, fallback: int) -> int:
     if parsed <= 0:
         return fallback
     return parsed
+
+
+def pgvector_use_halfvec_setting(value: object, embed_dim: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "yes", "on", "1"}:
+            return True
+        if normalized in {"false", "no", "off", "0"}:
+            return False
+        if normalized != "auto":
+            raise ValueError(
+                "metis_engine.pgvector_use_halfvec must be true, false, or auto."
+            )
+    try:
+        parsed_embed_dim = int(embed_dim)
+    except (TypeError, ValueError):
+        return False
+    return parsed_embed_dim > 2000
 
 
 def load_plugin_config(plugins_path: str | Path | None = None):

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -185,6 +185,8 @@ def _positive_int(value: object, *, fallback: int) -> int:
 def pgvector_use_halfvec_setting(value: object, embed_dim: object) -> bool:
     if isinstance(value, bool):
         return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
     if isinstance(value, str):
         normalized = value.strip().lower()
         if normalized in {"true", "yes", "on", "1"}:

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -14,6 +14,9 @@ metis_engine:
   triage_tool_timeout_seconds: 12
   llm_max_retries: 5
   embed_dim: 3072
+  # For the PostgreSQL backend, use pgvector halfvec storage automatically when
+  # embed_dim exceeds normal vector HNSW limits. Set true or false to override.
+  pgvector_use_halfvec: auto
   hnsw_kwargs:
     hnsw_m: 16
     hnsw_ef_construction: 64

--- a/src/metis/vector_store/pgvector_store.py
+++ b/src/metis/vector_store/pgvector_store.py
@@ -20,6 +20,30 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+HALFVEC_HNSW_DIST_METHODS = {
+    "vector_l2_ops": "halfvec_l2_ops",
+    "vector_ip_ops": "halfvec_ip_ops",
+    "vector_cosine_ops": "halfvec_cosine_ops",
+}
+
+
+def normalize_hnsw_kwargs(hnsw_kwargs, *, use_halfvec):
+    if hnsw_kwargs is None:
+        return None
+    normalized = dict(hnsw_kwargs)
+    if use_halfvec:
+        dist_method = normalized.get("hnsw_dist_method")
+        if dist_method in HALFVEC_HNSW_DIST_METHODS:
+            normalized["hnsw_dist_method"] = HALFVEC_HNSW_DIST_METHODS[dist_method]
+    return normalized
+
+
+def copy_hnsw_kwargs(hnsw_kwargs):
+    if hnsw_kwargs is None:
+        return None
+    return hnsw_kwargs.copy()
+
+
 class PGVectorStoreImpl(BaseVectorStore):
     def __init__(
         self,
@@ -30,6 +54,7 @@ class PGVectorStoreImpl(BaseVectorStore):
         embed_dim,
         query_config=None,
         hnsw_kwargs=None,
+        use_halfvec=False,
     ):
         self.connection_string = connection_string
         self.project_schema = project_schema
@@ -37,7 +62,11 @@ class PGVectorStoreImpl(BaseVectorStore):
         self.embed_model_docs = embed_model_docs
         self.embed_dim = embed_dim
         self.query_config = query_config or {}
-        self.hnsw_kwargs = hnsw_kwargs or {}
+        self.use_halfvec = bool(use_halfvec)
+        self.hnsw_kwargs = normalize_hnsw_kwargs(
+            hnsw_kwargs,
+            use_halfvec=self.use_halfvec,
+        )
         self._initialized = False
 
     def init(self):
@@ -56,7 +85,8 @@ class PGVectorStoreImpl(BaseVectorStore):
                 table_name="code",
                 schema_name=self.project_schema,
                 embed_dim=self.embed_dim,
-                hnsw_kwargs=self.hnsw_kwargs.copy(),
+                hnsw_kwargs=copy_hnsw_kwargs(self.hnsw_kwargs),
+                use_halfvec=self.use_halfvec,
             )
             self.vector_store_docs = PGVectorStore.from_params(
                 database=db_name,
@@ -67,7 +97,8 @@ class PGVectorStoreImpl(BaseVectorStore):
                 table_name="docs",
                 schema_name=self.project_schema,
                 embed_dim=self.embed_dim,
-                hnsw_kwargs=self.hnsw_kwargs.copy(),
+                hnsw_kwargs=copy_hnsw_kwargs(self.hnsw_kwargs),
+                use_halfvec=self.use_halfvec,
             )
 
             self.storage_context_code = StorageContext.from_defaults(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -103,6 +103,87 @@ llm_provider:
     }
 
 
+def test_load_runtime_config_accepts_pgvector_halfvec_flag(tmp_path, monkeypatch):
+    config_path = _write_config(
+        tmp_path,
+        """
+metis_engine:
+  pgvector_use_halfvec: true
+llm_provider:
+  name: openai
+  model: gpt-test
+  base_url: https://example.test/openai/v1
+""",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["pgvector_use_halfvec"] is True
+
+
+def test_load_runtime_config_auto_enables_pgvector_halfvec_for_large_embeddings(
+    tmp_path, monkeypatch
+):
+    config_path = _write_config(
+        tmp_path,
+        """
+metis_engine:
+  embed_dim: 3072
+llm_provider:
+  name: openai
+  model: gpt-test
+  base_url: https://example.test/openai/v1
+""",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["pgvector_use_halfvec"] is True
+
+
+def test_load_runtime_config_auto_keeps_pgvector_full_precision_for_small_embeddings(
+    tmp_path, monkeypatch
+):
+    config_path = _write_config(
+        tmp_path,
+        """
+metis_engine:
+  embed_dim: 1536
+llm_provider:
+  name: openai
+  model: gpt-test
+  base_url: https://example.test/openai/v1
+""",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["pgvector_use_halfvec"] is False
+
+
+def test_load_runtime_config_allows_forcing_pgvector_halfvec_off(tmp_path, monkeypatch):
+    config_path = _write_config(
+        tmp_path,
+        """
+metis_engine:
+  embed_dim: 3072
+  pgvector_use_halfvec: false
+llm_provider:
+  name: openai
+  model: gpt-test
+  base_url: https://example.test/openai/v1
+""",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["pgvector_use_halfvec"] is False
+
+
 def test_build_embedding_provider_config_resolves_openai_embedding_provider(
     tmp_path, monkeypatch
 ):

--- a/tests/test_pg_backend_mocked_unit.py
+++ b/tests/test_pg_backend_mocked_unit.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
+from types import SimpleNamespace
 from unittest.mock import Mock
+
+import pytest
 
 
 @pytest.mark.postgres
@@ -34,3 +36,104 @@ def test_pg_vectorstore_mocked_init(monkeypatch):
     assert pg._initialized is True
     assert from_params.call_count == 2
     assert context_from_defaults.call_count == 2
+    assert from_params.call_args_list[0].kwargs["use_halfvec"] is False
+    assert from_params.call_args_list[1].kwargs["use_halfvec"] is False
+
+
+@pytest.mark.postgres
+def test_pg_vectorstore_passes_halfvec_and_rewrites_hnsw_dist_method(monkeypatch):
+    from metis.vector_store import pgvector_store
+    from metis.vector_store.pgvector_store import PGVectorStoreImpl
+
+    from_params = Mock(side_effect=[Mock(), Mock()])
+    monkeypatch.setattr(pgvector_store.PGVectorStore, "from_params", from_params)
+    monkeypatch.setattr(
+        pgvector_store.StorageContext,
+        "from_defaults",
+        Mock(side_effect=["code_ctx", "docs_ctx"]),
+    )
+
+    pg = PGVectorStoreImpl(
+        connection_string="postgresql://metis_user:metis_password@localhost:5432/metis_db",
+        project_schema="test_schema",
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        embed_dim=3072,
+        hnsw_kwargs={
+            "hnsw_m": 16,
+            "hnsw_ef_construction": 64,
+            "hnsw_dist_method": "vector_cosine_ops",
+        },
+        use_halfvec=True,
+    )
+
+    pg.init()
+
+    assert from_params.call_count == 2
+    for call in from_params.call_args_list:
+        assert call.kwargs["embed_dim"] == 3072
+        assert call.kwargs["use_halfvec"] is True
+        assert call.kwargs["hnsw_kwargs"]["hnsw_dist_method"] == "halfvec_cosine_ops"
+
+
+@pytest.mark.postgres
+def test_pg_vectorstore_preserves_none_hnsw_kwargs(monkeypatch):
+    from metis.vector_store import pgvector_store
+    from metis.vector_store.pgvector_store import PGVectorStoreImpl
+
+    from_params = Mock(side_effect=[Mock(), Mock()])
+    monkeypatch.setattr(pgvector_store.PGVectorStore, "from_params", from_params)
+    monkeypatch.setattr(
+        pgvector_store.StorageContext,
+        "from_defaults",
+        Mock(side_effect=["code_ctx", "docs_ctx"]),
+    )
+
+    pg = PGVectorStoreImpl(
+        connection_string="postgresql://metis_user:metis_password@localhost:5432/metis_db",
+        project_schema="test_schema",
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+        embed_dim=3072,
+        hnsw_kwargs=None,
+        use_halfvec=True,
+    )
+
+    pg.init()
+
+    assert from_params.call_args_list[0].kwargs["hnsw_kwargs"] is None
+    assert from_params.call_args_list[1].kwargs["hnsw_kwargs"] is None
+
+
+@pytest.mark.postgres
+def test_build_pg_backend_passes_halfvec_runtime_flag(monkeypatch):
+    from metis.cli import utils
+
+    constructed = {}
+
+    class FakePGVectorStoreImpl:
+        def __init__(self, **kwargs):
+            constructed.update(kwargs)
+
+    monkeypatch.setattr(utils, "PG_SUPPORTED", True)
+    monkeypatch.setattr(utils, "PGVectorStoreImpl", FakePGVectorStoreImpl)
+
+    backend = utils.build_pg_backend(
+        SimpleNamespace(project_schema="test_schema"),
+        {
+            "pg_username": "metis_user",
+            "pg_password": "metis_password",
+            "pg_host": "localhost",
+            "pg_port": 5432,
+            "pg_db_name": "metis_db",
+            "embed_dim": 3072,
+            "pgvector_use_halfvec": True,
+            "hnsw_kwargs": {"hnsw_m": 16},
+        },
+        Mock(),
+        Mock(),
+    )
+
+    assert isinstance(backend, FakePGVectorStoreImpl)
+    assert constructed["use_halfvec"] is True
+    assert constructed["embed_dim"] == 3072


### PR DESCRIPTION
## Summary

Adds PostgreSQL pgvector `halfvec` support for Metis vector stores so large embedding dimensions, such as 3072-dimensional embeddings, can still use HNSW indexes.

## Root Cause

Metis already allows `metis_engine.embed_dim: 3072`, but its PostgreSQL backend always created normal `vector` stores and forwarded HNSW settings using normal vector operator classes such as `vector_cosine_ops`. pgvector normal-vector HNSW indexes cannot be created above the supported dimension limit, so large embeddings could fall back to unindexed vector search or log HNSW setup failures.

## Changes

- Adds `metis_engine.pgvector_use_halfvec` with `auto`, `true`, and `false` behavior.
- Defaults `auto` to halfvec for `embed_dim > 2000` and full-precision vector storage for smaller embeddings.
- Passes `use_halfvec` through to both code and docs `PGVectorStore` instances.
- Rewrites configured HNSW operator classes from `vector_*_ops` to matching `halfvec_*_ops` when halfvec is enabled.
- Preserves `hnsw_kwargs: null` as disabled HNSW instead of converting it to an empty dict.
- Documents the setting in README, provider docs, and packaged `metis.yaml`.

## Validation

- `uv run --extra lint ruff format --check .`
- `uv run --extra lint ruff check .`
- `uv run pytest`
- `uv run --extra postgres pytest --postgres tests/test_pg_backend_real_integration.py tests/test_pg_backend_mocked_unit.py`
- `uv run --extra postgres pytest --postgres`

The full Postgres-enabled suite passed against a local `pgvector/pgvector:pg16` container after creating the expected `metis_user` role, `metis_db` database, and `vector` extension.