### PR TITLE
feat(memory): Add memory backend

### DIFF
--- a/docs/repository-memory.md
+++ b/docs/repository-memory.md
@@ -1,0 +1,122 @@
+# Repository Memory
+
+Repository memory is the small persistence layer Metis uses for facts that are
+worth carrying across commands. It keeps structured records outside the model
+context window so later workflows can reload them when they are still fresh.
+
+The first backend is SQLite.
+
+## What It Is For
+
+- Keeping reusable repository facts in a local store
+- Tracking where a fact came from and whether it is still fresh
+- Looking up records by namespace and key
+- Searching explicit recall text in a bounded way
+- Keeping local development and CI free of new service dependencies
+
+## What It Is Not For
+
+- It is not a vulnerability database
+- It is not a broad search layer for bug classes or CWE names
+- It does not replace current source evidence
+- SQLite memory is not a shared team service
+
+Use a separate backend with access control before memory is shared across users
+or machines.
+
+## Record Shape
+
+Records use `MemoryRecord` in `src/metis/memory/schemas.py`.
+
+Each record has identity fields, freshness fields, payload fields, and retrieval
+text.
+
+- `namespace` and `key` identify a record
+- `artifact_type` names the stored artifact
+- `schema_version` and `tool_version` help callers understand compatibility
+- `repo_fingerprint` ties a record to repository state
+- `input_fingerprint` ties a record to the source input that produced it
+- `summary_text` and `search_text` are the only text used for local recall
+- `body_json` and `body_markdown` hold the actual payload
+- `metadata` holds source specific attributes
+
+The lifecycle fields describe how a caller should treat a record.
+
+- `memory_type` groups records as semantic, episodic, or procedural
+- `authority` captures the trust level of the source
+- `source_kind` records where the memory came from
+
+## Memory Types
+
+Metis uses repository memory as long term memory. It is for reusable repository
+facts and lessons. It is not for per run graph state, message history, streaming
+progress, or checkpoint replay.
+
+Metis maps common memory categories onto `memory_type`.
+
+| `memory_type` | What Metis stores | Examples | Retrieval posture |
+| --- | --- | --- | --- |
+| `semantic` | Stable repository facts and profiles | threat model summaries, trust boundaries, entry points, deployment assumptions, source inventory, build facts | Load early to ground analysis, then verify against current source and freshness fingerprints |
+| `episodic` | Prior review experience | user confirmed false positives, benchmark outcomes, corrective commit lessons, past examples used as guidance | Load narrowly when a new task resembles the old one |
+| `procedural` | Project specific rules for how Metis should work | approved review policy, repository specific triage rules, prompt and tool routing guidance | Use only when the source is authoritative and current |
+
+Authority matters. A record from project security guidance can constrain
+triage. A record inferred from history is useful context, but it should not beat
+current code or authoritative project input.
+
+## Storage
+
+`SQLiteMemoryStore` implements the LangGraph store interface used by Metis. It
+stores the record payload as JSON. The table keeps only the record identity and
+store timestamps outside that JSON payload.
+
+The `MemoryRecord` model owns the JSON shape. SQLite does not project freshness
+or lifecycle fields into separate columns in this first storage layer.
+
+Store timestamps live in SQLite metadata columns. They are not duplicated inside
+the JSON payload.
+
+SQLite FTS keeps a separate text index over the explicit recall fields. That
+lets local search use `artifact_type`, `summary_text`, and `search_text` without
+turning every structured field into a SQL column.
+
+SQLite opens the database in WAL mode and uses a busy timeout. That is enough
+for normal local read and write overlap. It is still a local store.
+
+## Retrieval
+
+The store supports exact lookup and bounded search by namespace prefix, text
+query, and exact filters.
+
+Text search uses SQLite FTS5 over `summary_text` and `search_text`. Structured
+payload fields are stored for lookup and audit. They are not implicitly indexed
+for recall.
+
+Raw store level `search()` has no side effects.
+
+## Configuration
+
+Repository memory is configured in `metis.yaml` under `memory`.
+
+The packaged config keeps memory disabled until an engine workflow wires it in.
+It sets `enabled` to `false`, `backend` to `sqlite`, and `location` to
+`.metis/memory/metis_memory.sqlite3`.
+
+The backend comes from `metis.yaml`. The location is passed to that backend as
+plain backend data. Other backends can be added through the memory store
+registry without changing callers.
+
+## Tests
+
+Focused backend coverage is in `tests/test_memory_backend.py`.
+
+The tests cover namespace and key round trips, text search, filters, delete
+behavior, freshness checks, invalidation, and stable `created_at` metadata on
+overwrite.
+
+## Current Limits
+
+- SQLite is the only implemented repository memory backend
+- SQLite FTS5 is required for text search
+- Vector retrieval is not part of the memory store
+- Shared service deployment needs a separate backend and access control model

--- a/src/metis/cli/commands.py
+++ b/src/metis/cli/commands.py
@@ -5,7 +5,6 @@
 from importlib.metadata import version as package_version
 import inspect
 import json
-import os
 from pathlib import Path
 from rich.markup import escape
 
@@ -107,9 +106,10 @@ def run_file_review(engine, file_path, args, runtime: CommandRuntime):
 
 
 def run_dir_review(engine, dir_path, args, runtime: CommandRuntime):
-    if not check_dir_exists(os.path.join(engine.codebase_path, dir_path)):
+    review_dir_path = str(Path(engine.codebase_path) / dir_path)
+    if not check_dir_exists(review_dir_path):
         return
-    code_files = list(engine.review.get_code_files(dir_path=dir_path))
+    code_files = list(engine.review.get_code_files(dir_path=review_dir_path))
     _review_code(engine, code_files, args, runtime)
 
 

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import yaml
 
+from metis.memory.registry import parse_memory_store_spec
 from metis.providers.config import build_provider_config
 from metis.providers.registry import get_chat_provider
 from metis.providers.registry import get_embedding_provider
@@ -107,6 +108,8 @@ def load_runtime_config(config_path=None, enable_psql=False):
     runtime["index_search_config"] = (
         dict(index_search_cfg) if isinstance(index_search_cfg, dict) else {}
     )
+    memory_cfg = cfg.get("memory") or {}
+    runtime["memory"] = _memory_config(memory_cfg)
     runtime.update(collect_reachability_config(cfg, engine_cfg))
 
     query_cfg = cfg.get("query", {})
@@ -202,6 +205,22 @@ def pgvector_use_halfvec_setting(value: object, embed_dim: object) -> bool:
     except (TypeError, ValueError):
         return False
     return parsed_embed_dim > 2000
+
+
+def _memory_config(raw_config: object) -> dict[str, object]:
+    if not isinstance(raw_config, dict):
+        raw_config = {}
+    location = str(raw_config.get("location") or ".metis/memory/metis_memory.sqlite3")
+    backend = str(raw_config.get("backend") or "sqlite")
+    spec = parse_memory_store_spec(
+        location,
+        backend=backend,
+    )
+    return {
+        "enabled": bool(raw_config.get("enabled", False)),
+        "backend": spec.backend,
+        "location": spec.location,
+    }
 
 
 def load_plugin_config(plugins_path: str | Path | None = None):

--- a/src/metis/memory/__init__.py
+++ b/src/metis/memory/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from .schemas import MemoryRecord
+from .service import MemoryService
+from .sqlite_store import SQLiteMemoryStore
+
+__all__ = [
+    "MemoryRecord",
+    "MemoryService",
+    "SQLiteMemoryStore",
+]

--- a/src/metis/memory/base.py
+++ b/src/metis/memory/base.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol
+
+from langgraph.store.base import BaseStore
+from langgraph.store.base import Item
+from langgraph.store.base import SearchItem
+
+
+Namespace = tuple[str, ...]
+JsonValue = dict[str, Any]
+
+
+class StoreLike(Protocol):
+    def put(
+        self,
+        namespace: Namespace,
+        key: str,
+        value: JsonValue,
+        index: Literal[False] | list[str] | None = None,
+    ) -> None: ...
+
+    def get(self, namespace: Namespace, key: str) -> Item | None: ...
+
+    def search(
+        self,
+        namespace_prefix: Namespace,
+        *,
+        query: str | None = None,
+        filter: dict[str, Any] | None = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> list[SearchItem]: ...
+
+    def delete(self, namespace: Namespace, key: str) -> None: ...
+
+    def list_namespaces(
+        self,
+        *,
+        prefix: Namespace | None = None,
+        suffix: Namespace | None = None,
+        max_depth: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Namespace]: ...
+
+
+__all__ = [
+    "BaseStore",
+    "Item",
+    "JsonValue",
+    "Namespace",
+    "SearchItem",
+    "StoreLike",
+]

--- a/src/metis/memory/fingerprints.py
+++ b/src/metis/memory/fingerprints.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+from typing import Any
+
+
+def stable_json_hash(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def input_fingerprint(value: Any) -> str:
+    return stable_json_hash(value)
+
+
+def file_fingerprint(path: str | Path) -> str:
+    target = Path(path)
+    digest = hashlib.sha256()
+    with target.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def repo_fingerprint(repo_root: str | Path) -> str:
+    root = Path(repo_root).resolve()
+    head = _git_output(root, "rev-parse", "HEAD")
+    if head:
+        return f"git:{head}"
+    return f"nogit:{stable_json_hash(str(root))}"
+
+
+def _git_output(cwd: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None

--- a/src/metis/memory/registry.py
+++ b/src/metis/memory/registry.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .base import StoreLike
+from .sqlite_store import SQLiteMemoryStore
+
+
+@dataclass(frozen=True)
+class MemoryStoreSpec:
+    backend: str
+    location: str
+
+
+MemoryStoreFactory = Callable[[MemoryStoreSpec], StoreLike]
+
+_MEMORY_STORE_FACTORIES: dict[str, MemoryStoreFactory] = {}
+
+
+def build_memory_store(
+    location: str | Path,
+    *,
+    backend: str | None = None,
+) -> StoreLike:
+    spec = parse_memory_store_spec(location, backend=backend)
+    factory = get_memory_store_backend(spec.backend)
+    return factory(spec)
+
+
+def parse_memory_store_spec(
+    location: str | Path,
+    *,
+    backend: str | None = None,
+) -> MemoryStoreSpec:
+    raw = str(location)
+    backend_name = _normalize_backend_name(backend or "sqlite")
+    return MemoryStoreSpec(
+        backend=backend_name,
+        location=raw,
+    )
+
+
+def register_memory_store_backend(
+    name: str,
+    factory: MemoryStoreFactory,
+) -> None:
+    _MEMORY_STORE_FACTORIES[_normalize_backend_name(name)] = factory
+
+
+def get_memory_store_backend(name: str) -> MemoryStoreFactory:
+    key = _normalize_backend_name(name)
+    if key in _MEMORY_STORE_FACTORIES:
+        return _MEMORY_STORE_FACTORIES[key]
+    raise ValueError(f"Unsupported memory store backend: {name}")
+
+
+def _normalize_backend_name(name: str) -> str:
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("Memory store backend name must not be empty.")
+    return normalized
+
+
+def _build_sqlite_memory_store(spec: MemoryStoreSpec) -> SQLiteMemoryStore:
+    return SQLiteMemoryStore(Path(spec.location).expanduser())
+
+
+register_memory_store_backend("sqlite", _build_sqlite_memory_store)

--- a/src/metis/memory/schemas.py
+++ b/src/metis/memory/schemas.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from dataclasses import fields
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from .base import Namespace
+
+_STORE_METADATA_FIELDS = frozenset({"namespace", "key", "created_at"})
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(slots=True)
+class MemoryRecord:
+    namespace: Namespace
+    key: str
+    artifact_type: str
+    schema_version: int
+    tool_version: str
+    repo_fingerprint: str
+    input_fingerprint: str
+    created_at: str
+    memory_type: str
+    authority: str = ""
+    source_kind: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    body_json: dict[str, Any] | list[Any] | None = None
+    body_markdown: str = ""
+    summary_text: str = ""
+    search_text: str = ""
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        namespace: Namespace,
+        key: str,
+        tool_version: str,
+        **value: Any,
+    ) -> "MemoryRecord":
+        record_value = dict(value)
+        record_value["tool_version"] = tool_version
+        if "schema_version" not in record_value:
+            record_value["schema_version"] = 1
+        return cls.from_store_value(
+            namespace=namespace,
+            key=key,
+            value=record_value,
+            created_at=utc_now_iso(),
+        )
+
+    def to_store_value(self) -> dict[str, Any]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if field.name not in _STORE_METADATA_FIELDS
+        }
+
+    @classmethod
+    def from_store_value(
+        cls,
+        *,
+        namespace: Namespace,
+        key: str,
+        value: dict[str, Any],
+        created_at: str,
+    ) -> "MemoryRecord":
+        values = {
+            field.name: value[field.name]
+            for field in fields(cls)
+            if field.name not in _STORE_METADATA_FIELDS and field.name in value
+        }
+        return cls(
+            namespace=namespace,
+            key=key,
+            created_at=created_at,
+            **values,
+        )

--- a/src/metis/memory/service.py
+++ b/src/metis/memory/service.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from metis.version import __version__ as METIS_VERSION
+
+from .base import Namespace
+from .base import StoreLike
+from .schemas import MemoryRecord
+
+
+class MemoryService:
+    def __init__(
+        self,
+        store: StoreLike,
+        *,
+        repo_root: str = "",
+        tool_version: str = METIS_VERSION,
+    ):
+        self.store = store
+        self.repo_root = repo_root
+        self.tool_version = tool_version
+
+    def put_record(self, record: MemoryRecord) -> None:
+        self.store.put(record.namespace, record.key, record.to_store_value())
+
+    def create_record(
+        self,
+        *,
+        namespace: Namespace,
+        key: str,
+        **value: Any,
+    ) -> MemoryRecord:
+        record = MemoryRecord.create(
+            namespace=namespace,
+            key=key,
+            tool_version=self.tool_version,
+            **value,
+        )
+        self.put_record(record)
+        return self.get_record(namespace, key) or record
+
+    def get_record(self, namespace: Namespace, key: str) -> MemoryRecord | None:
+        item = self.store.get(namespace, key)
+        if item is None:
+            return None
+        return _record_from_item(item)
+
+    def search_records(
+        self,
+        namespace_prefix: Namespace,
+        *,
+        query: str | None = None,
+        filter: dict[str, Any] | None = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> list[MemoryRecord]:
+        items = self.store.search(
+            namespace_prefix,
+            query=query,
+            filter=filter,
+            limit=limit,
+            offset=offset,
+        )
+        return _records_from_items(items)
+
+    def iter_records(
+        self,
+        namespace_prefix: Namespace = (),
+        *,
+        query: str | None = None,
+        filter: dict[str, Any] | None = None,
+        batch_size: int = 500,
+    ) -> Iterator[MemoryRecord]:
+        offset = 0
+        batch_size = max(1, int(batch_size or 500))
+        while True:
+            items = self.store.search(
+                namespace_prefix,
+                query=query,
+                filter=filter,
+                limit=batch_size,
+                offset=offset,
+            )
+            records = _records_from_items(items)
+            yield from records
+            if len(items) < batch_size:
+                return
+            offset += batch_size
+
+    def invalidate(self, namespace: Namespace, key: str) -> None:
+        self.store.delete(namespace, key)
+
+    def reset_records(
+        self,
+        namespace_prefix: Namespace = (),
+    ) -> int:
+        records = list(self.iter_records(namespace_prefix))
+        for record in records:
+            self.invalidate(record.namespace, record.key)
+        return len(records)
+
+    def delete_stale_records(
+        self,
+        namespace_prefix: Namespace = (),
+        *,
+        repo_fingerprint: str | None = None,
+        input_fingerprint: str | None = None,
+        tool_version: str | None = None,
+    ) -> int:
+        if (
+            repo_fingerprint is None
+            and input_fingerprint is None
+            and tool_version is None
+        ):
+            return 0
+        deleted = 0
+        for record in list(self.iter_records(namespace_prefix)):
+            if self.is_fresh(
+                record,
+                repo_fingerprint=repo_fingerprint,
+                input_fingerprint=input_fingerprint,
+                tool_version=tool_version,
+            ):
+                continue
+            self.invalidate(record.namespace, record.key)
+            deleted += 1
+        return deleted
+
+    def is_fresh(
+        self,
+        record: MemoryRecord,
+        *,
+        repo_fingerprint: str | None = None,
+        input_fingerprint: str | None = None,
+        tool_version: str | None = None,
+    ) -> bool:
+        if repo_fingerprint is not None and record.repo_fingerprint != repo_fingerprint:
+            return False
+        if (
+            input_fingerprint is not None
+            and record.input_fingerprint != input_fingerprint
+        ):
+            return False
+        if tool_version is not None and record.tool_version != tool_version:
+            return False
+        return True
+
+
+def _record_from_item(item: Any) -> MemoryRecord:
+    return MemoryRecord.from_store_value(
+        namespace=item.namespace,
+        key=item.key,
+        value=item.value,
+        created_at=_datetime_to_iso(item.created_at),
+    )
+
+
+def _records_from_items(items: list[Any]) -> list[MemoryRecord]:
+    return [_record_from_item(item) for item in items]
+
+
+def _datetime_to_iso(value: object) -> str:
+    if not isinstance(value, datetime):
+        raise TypeError(f"Expected datetime, got {type(value).__name__}")
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")

--- a/src/metis/memory/sqlite_records.py
+++ b/src/metis/memory/sqlite_records.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+_FTS_COLUMNS = ("artifact_type", "summary_text", "search_text")
+
+
+def fts_column_values(record_value: dict[str, Any]) -> tuple[str, ...]:
+    return tuple(str(record_value.get(column) or "") for column in _FTS_COLUMNS)
+
+
+class MemoryRecordsTable:
+    def ensure_schema(self, conn: sqlite3.Connection) -> None:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS memory_records (
+                namespace TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (namespace, key)
+            )
+            """
+        )
+
+    def ensure_fts(self, conn: sqlite3.Connection) -> bool:
+        conn.execute(
+            """
+            CREATE VIRTUAL TABLE IF NOT EXISTS memory_records_fts
+            USING fts5(namespace, key, artifact_type, summary_text, search_text)
+            """
+        )
+        return True
+
+    def created_at(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        namespace_json: str,
+        key: str,
+    ) -> str | None:
+        row = conn.execute(
+            "SELECT created_at FROM memory_records WHERE namespace = ? AND key = ?",
+            (namespace_json, key),
+        ).fetchone()
+        if row is None:
+            return None
+        return str(row["created_at"])
+
+    def upsert(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        namespace_json: str,
+        key: str,
+        value_json: str,
+        created_at: str,
+        updated_at: str,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO memory_records (
+                namespace,
+                key,
+                value_json,
+                created_at,
+                updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(namespace, key) DO UPDATE SET
+                value_json = excluded.value_json,
+                updated_at = excluded.updated_at
+            """,
+            (
+                namespace_json,
+                key,
+                value_json,
+                created_at,
+                updated_at,
+            ),
+        )
+
+    def upsert_fts(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        namespace_json: str,
+        key: str,
+        values: tuple[str, ...],
+    ) -> None:
+        conn.execute(
+            "DELETE FROM memory_records_fts WHERE namespace = ? AND key = ?",
+            (namespace_json, key),
+        )
+        conn.execute(
+            """
+            INSERT INTO memory_records_fts (
+                namespace, key, artifact_type, summary_text, search_text
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                namespace_json,
+                key,
+                *values,
+            ),
+        )
+
+    def delete(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        namespace_json: str,
+        key: str,
+        include_fts: bool,
+    ) -> None:
+        conn.execute(
+            "DELETE FROM memory_records WHERE namespace = ? AND key = ?",
+            (namespace_json, key),
+        )
+        if include_fts:
+            conn.execute(
+                "DELETE FROM memory_records_fts WHERE namespace = ? AND key = ?",
+                (namespace_json, key),
+            )
+
+    def get(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        namespace_json: str,
+        key: str,
+    ) -> sqlite3.Row | None:
+        return conn.execute(
+            """
+            SELECT namespace, key, value_json, created_at, updated_at
+            FROM memory_records
+            WHERE namespace = ? AND key = ?
+            """,
+            (namespace_json, key),
+        ).fetchone()
+
+    def rows(self, conn: sqlite3.Connection) -> list[sqlite3.Row]:
+        return conn.execute(
+            """
+            SELECT namespace, key, value_json, created_at, updated_at
+            FROM memory_records
+            """
+        ).fetchall()
+
+    def fts_rows(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        query: str,
+    ) -> list[sqlite3.Row]:
+        return conn.execute(
+            """
+            SELECT r.namespace, r.key, r.value_json, r.created_at, r.updated_at
+            FROM memory_records_fts f
+            JOIN memory_records r
+              ON r.namespace = f.namespace AND r.key = f.key
+            WHERE memory_records_fts MATCH ?
+            """,
+            (query,),
+        ).fetchall()
+
+    def distinct_namespaces(self, conn: sqlite3.Connection) -> list[sqlite3.Row]:
+        return conn.execute("SELECT DISTINCT namespace FROM memory_records").fetchall()

--- a/src/metis/memory/sqlite_store.py
+++ b/src/metis/memory/sqlite_store.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+import json
+from pathlib import Path
+import re
+import sqlite3
+from threading import RLock
+from typing import Any, Iterable
+
+from langgraph.store.base import BaseStore
+from langgraph.store.base import GetOp
+from langgraph.store.base import Item
+from langgraph.store.base import ListNamespacesOp
+from langgraph.store.base import Op
+from langgraph.store.base import PutOp
+from langgraph.store.base import Result
+from langgraph.store.base import SearchItem
+from langgraph.store.base import SearchOp
+
+from .schemas import utc_now_iso
+from .sqlite_records import fts_column_values
+from .sqlite_records import MemoryRecordsTable
+
+
+class SQLiteMemoryStore(BaseStore):
+    supports_ttl = False
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self._records = MemoryRecordsTable()
+        self._lock = RLock()
+        self._initialized = False
+        self._fts_enabled = False
+
+    def batch(self, ops: Iterable[Op]) -> list[Result]:
+        with self._lock:
+            self._ensure_schema()
+            with self._connect() as conn:
+                results = [self._execute_op(conn, op) for op in ops]
+                conn.commit()
+                return results
+
+    async def abatch(self, ops: Iterable[Op]) -> list[Result]:
+        return await asyncio.to_thread(self.batch, list(ops))
+
+    def _execute_op(self, conn: sqlite3.Connection, op: Op) -> Result:
+        if isinstance(op, PutOp):
+            if op.value is None:
+                self._delete(conn, op.namespace, op.key)
+            else:
+                self._put(conn, op.namespace, op.key, op.value)
+            return None
+        if isinstance(op, GetOp):
+            return self._get(conn, op.namespace, op.key)
+        if isinstance(op, SearchOp):
+            return self._search(
+                conn,
+                op.namespace_prefix,
+                query=op.query,
+                filter=op.filter,
+                limit=op.limit,
+                offset=op.offset,
+            )
+        if isinstance(op, ListNamespacesOp):
+            return self._list_namespaces(
+                conn,
+                match_conditions=op.match_conditions,
+                max_depth=op.max_depth,
+                limit=op.limit,
+                offset=op.offset,
+            )
+        raise TypeError(f"Unsupported memory store operation: {type(op).__name__}")
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.path))
+        conn.row_factory = sqlite3.Row
+        try:
+            conn.execute("PRAGMA busy_timeout = 5000")
+            conn.execute("PRAGMA journal_mode = WAL")
+        except sqlite3.DatabaseError:
+            pass
+        return conn
+
+    def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            self._records.ensure_schema(conn)
+            self._fts_enabled = self._records.ensure_fts(conn)
+            conn.commit()
+        self._initialized = True
+
+    def _put(
+        self,
+        conn: sqlite3.Connection,
+        namespace: tuple[str, ...],
+        key: str,
+        value: dict[str, Any],
+    ) -> None:
+        namespace_json = _encode_namespace(namespace)
+        now = utc_now_iso()
+        existing_created_at = self._records.created_at(
+            conn,
+            namespace_json=namespace_json,
+            key=key,
+        )
+        created_at = existing_created_at or now
+        value_to_store = dict(value)
+        value_to_store.pop("created_at", None)
+        value_json = json.dumps(value_to_store, sort_keys=True, separators=(",", ":"))
+        self._records.upsert(
+            conn,
+            namespace_json=namespace_json,
+            key=key,
+            value_json=value_json,
+            created_at=created_at,
+            updated_at=now,
+        )
+        if self._fts_enabled:
+            self._records.upsert_fts(
+                conn,
+                namespace_json=namespace_json,
+                key=key,
+                values=fts_column_values(value_to_store),
+            )
+
+    def _delete(
+        self,
+        conn: sqlite3.Connection,
+        namespace: tuple[str, ...],
+        key: str,
+    ) -> None:
+        namespace_json = _encode_namespace(namespace)
+        self._records.delete(
+            conn,
+            namespace_json=namespace_json,
+            key=key,
+            include_fts=self._fts_enabled,
+        )
+
+    def _get(
+        self,
+        conn: sqlite3.Connection,
+        namespace: tuple[str, ...],
+        key: str,
+    ) -> Item | None:
+        row = self._records.get(
+            conn,
+            namespace_json=_encode_namespace(namespace),
+            key=key,
+        )
+        if row is None:
+            return None
+        return _item_from_row(row)
+
+    def _search(
+        self,
+        conn: sqlite3.Connection,
+        namespace_prefix: tuple[str, ...],
+        *,
+        query: str | None,
+        filter: dict[str, Any] | None,
+        limit: int,
+        offset: int,
+    ) -> list[SearchItem]:
+        rows = self._candidate_rows(conn, query)
+        matches: list[SearchItem] = []
+        for row in rows:
+            namespace = _decode_namespace(str(row["namespace"]))
+            if not _namespace_startswith(namespace, namespace_prefix):
+                continue
+            value = json.loads(str(row["value_json"]))
+            if not _matches_filter(value, filter):
+                continue
+            matches.append(_search_item_from_row(row, value=value))
+        matches.sort(key=lambda item: (item.namespace, item.key))
+        return matches[max(0, offset) : max(0, offset) + max(0, limit)]
+
+    def _candidate_rows(
+        self,
+        conn: sqlite3.Connection,
+        query: str | None,
+    ) -> list[sqlite3.Row]:
+        if not query:
+            return self._records.rows(conn)
+        fts_query = _fts_query(query)
+        if not fts_query:
+            return []
+        if not self._fts_enabled:
+            raise RuntimeError("SQLite FTS5 is required for memory text search.")
+        return self._records.fts_rows(conn, query=fts_query)
+
+    def _list_namespaces(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        match_conditions,
+        max_depth: int | None,
+        limit: int,
+        offset: int,
+    ) -> list[tuple[str, ...]]:
+        rows = self._records.distinct_namespaces(conn)
+        namespaces: set[tuple[str, ...]] = set()
+        for row in rows:
+            namespace = _decode_namespace(str(row["namespace"]))
+            if not _matches_namespace_conditions(namespace, match_conditions):
+                continue
+            if max_depth is not None:
+                namespace = namespace[: max(0, int(max_depth))]
+            namespaces.add(namespace)
+        ordered = sorted(namespaces)
+        return ordered[max(0, offset) : max(0, offset) + max(0, limit)]
+
+
+def _item_from_row(row: sqlite3.Row) -> Item:
+    return Item(
+        namespace=_decode_namespace(str(row["namespace"])),
+        key=str(row["key"]),
+        value=json.loads(str(row["value_json"])),
+        created_at=_parse_datetime(str(row["created_at"])),
+        updated_at=_parse_datetime(str(row["updated_at"])),
+    )
+
+
+def _search_item_from_row(
+    row: sqlite3.Row,
+    *,
+    value: dict[str, Any],
+) -> SearchItem:
+    return SearchItem(
+        namespace=_decode_namespace(str(row["namespace"])),
+        key=str(row["key"]),
+        value=value,
+        created_at=_parse_datetime(str(row["created_at"])),
+        updated_at=_parse_datetime(str(row["updated_at"])),
+        score=None,
+    )
+
+
+def _encode_namespace(namespace: tuple[str, ...]) -> str:
+    return json.dumps(list(namespace), separators=(",", ":"))
+
+
+def _decode_namespace(value: str) -> tuple[str, ...]:
+    raw = json.loads(value)
+    return tuple(str(part) for part in raw)
+
+
+def _namespace_startswith(
+    namespace: tuple[str, ...],
+    prefix: tuple[str, ...],
+) -> bool:
+    return namespace[: len(prefix)] == prefix
+
+
+def _matches_namespace_conditions(namespace, match_conditions) -> bool:
+    if not match_conditions:
+        return True
+    for condition in match_conditions:
+        path = tuple(str(part) for part in condition.path)
+        if condition.match_type == "prefix" and not _namespace_startswith(
+            namespace, path
+        ):
+            return False
+        if condition.match_type == "suffix" and namespace[-len(path) :] != path:
+            return False
+    return True
+
+
+def _matches_filter(value: dict[str, Any], filter_value: dict[str, Any] | None) -> bool:
+    if not filter_value:
+        return True
+    for key, expected in filter_value.items():
+        if _value_at_path(value, str(key).split(".")) != expected:
+            return False
+    return True
+
+
+def _value_at_path(value: Any, path: list[str]) -> Any:
+    current = value
+    for part in path:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _fts_query(query: str) -> str:
+    return " ".join(_query_terms(query))
+
+
+def _query_terms(query: str) -> list[str]:
+    return [term.lower() for term in re.findall(r"[A-Za-z0-9_]+", query)]
+
+
+def _parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -34,6 +34,11 @@ metis_engine:
   model_tools:
     max_rounds: 6
 
+memory:
+  enabled: false
+  backend: "sqlite"
+  location: ".metis/memory/metis_memory.sqlite3"
+
 llm_provider:
   name: "openai"
   model: "gpt-5.5"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -68,9 +68,39 @@ query:
     assert runtime["chat_model_kwargs"] == {"reasoning_effort": "high"}
     assert runtime["model_tool_max_rounds"] == 9
     assert runtime["index_search_config"] == {}
+    assert runtime["memory"] == {
+        "enabled": False,
+        "backend": "sqlite",
+        "location": ".metis/memory/metis_memory.sqlite3",
+    }
     assert "embedding_provider" not in runtime
     assert runtime["embedding_provider_raw_config"] is None
     assert "llm_api_key" not in runtime
+
+
+def test_load_runtime_config_accepts_memory_config(tmp_path, monkeypatch):
+    config_path = _write_config(
+        tmp_path,
+        """
+memory:
+  enabled: true
+  backend: sqlite
+  location: custom/memory.sqlite3
+llm_provider:
+  name: openai
+  model: gpt-test
+  base_url: https://example.test/openai/v1
+""",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
+
+    runtime = load_runtime_config(config_path)
+
+    assert runtime["memory"] == {
+        "enabled": True,
+        "backend": "sqlite",
+        "location": "custom/memory.sqlite3",
+    }
 
 
 def test_load_runtime_config_accepts_index_search_overrides(tmp_path, monkeypatch):

--- a/tests/test_memory_backend.py
+++ b/tests/test_memory_backend.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from metis.memory import MemoryService
+from metis.memory import SQLiteMemoryStore
+from metis.memory.fingerprints import input_fingerprint
+
+
+def test_sqlite_memory_store_round_trips_namespace_key_value(tmp_path):
+    store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
+    namespace = ("metis", "profiles", "repo")
+    value = {
+        "artifact_type": "target_profile",
+        "schema_version": 1,
+        "repo_fingerprint": "repo1",
+        "input_fingerprint": "input1",
+        "memory_type": "semantic",
+        "metadata": {"authority": "documented"},
+        "summary_text": "Documented trust boundary",
+        "search_text": "trust boundary cli filesystem",
+    }
+
+    store.put(namespace, "active", value)
+
+    item = store.get(namespace, "active")
+    assert item is not None
+    assert item.namespace == namespace
+    assert item.key == "active"
+    assert item.value == value
+
+
+def test_sqlite_memory_store_search_filter_namespaces_and_delete(tmp_path):
+    store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
+    store.put(
+        ("metis", "profiles", "repo1"),
+        "target_profile",
+        {
+            "artifact_type": "target_profile",
+            "schema_version": 1,
+            "repo_fingerprint": "repo1",
+            "input_fingerprint": "input1",
+            "memory_type": "semantic",
+            "metadata": {"authority": "documented"},
+            "summary_text": "CLI accepts untrusted SARIF files",
+            "search_text": "cli sarif trust boundary",
+        },
+    )
+    store.put(
+        ("metis", "history", "repo1"),
+        "snapshot",
+        {
+            "artifact_type": "history_snapshot",
+            "schema_version": 1,
+            "repo_fingerprint": "repo1",
+            "input_fingerprint": "input2",
+            "memory_type": "episodic",
+            "metadata": {"authority": "history"},
+            "summary_text": "Churn hotspot in parser",
+            "search_text": "parser churn corrective commits",
+        },
+    )
+
+    results = store.search(
+        ("metis",),
+        query="sarif boundary",
+        filter={"metadata.authority": "documented"},
+    )
+
+    assert [(item.namespace, item.key) for item in results] == [
+        (("metis", "profiles", "repo1"), "target_profile")
+    ]
+    assert store.list_namespaces(prefix=("metis",), max_depth=2) == [
+        ("metis", "history"),
+        ("metis", "profiles"),
+    ]
+
+    store.delete(("metis", "profiles", "repo1"), "target_profile")
+
+    assert store.get(("metis", "profiles", "repo1"), "target_profile") is None
+
+
+def test_memory_service_freshness_and_invalidation(tmp_path):
+    store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
+    service = MemoryService(store, repo_root="/repo", tool_version="metis-test")
+
+    record = service.create_record(
+        namespace=("metis", "profiles", "repo1"),
+        key="target_profile",
+        artifact_type="target_profile",
+        repo_fingerprint="repo1",
+        input_fingerprint=input_fingerprint({"docs": ["SECURITY.md"]}),
+        memory_type="semantic",
+        authority="documented",
+        body_json={"authority": "documented"},
+        metadata={"authority": "documented"},
+        summary_text="Documented profile",
+        search_text="security docs profile",
+    )
+
+    loaded = service.get_record(record.namespace, record.key)
+    assert loaded is not None
+    assert loaded.authority == "documented"
+    assert loaded.body_json == {"authority": "documented"}
+    assert service.is_fresh(
+        loaded,
+        repo_fingerprint="repo1",
+        input_fingerprint=record.input_fingerprint,
+        tool_version="metis-test",
+    )
+    assert not service.is_fresh(loaded, repo_fingerprint="other")
+    assert not service.is_fresh(
+        loaded,
+        input_fingerprint="other",
+    )
+
+    service.invalidate(record.namespace, record.key)
+    assert service.get_record(record.namespace, record.key) is None
+
+
+def test_memory_service_keeps_created_at_stable_on_overwrite(tmp_path):
+    store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
+    service = MemoryService(store, repo_root="/repo", tool_version="metis-test")
+
+    first = service.create_record(
+        namespace=("metis", "profiles", "repo1"),
+        key="target_profile",
+        artifact_type="target_profile",
+        repo_fingerprint="repo1",
+        input_fingerprint="input1",
+        memory_type="semantic",
+        body_json={},
+        summary_text="Initial profile",
+    )
+    service.create_record(
+        namespace=("metis", "profiles", "repo1"),
+        key="target_profile",
+        artifact_type="target_profile",
+        repo_fingerprint="repo1",
+        input_fingerprint="input2",
+        memory_type="semantic",
+        body_json={},
+        summary_text="Updated profile",
+    )
+
+    loaded = service.get_record(("metis", "profiles", "repo1"), "target_profile")
+    store_item = store.get(("metis", "profiles", "repo1"), "target_profile")
+
+    assert loaded is not None
+    assert store_item is not None
+    assert loaded.created_at == first.created_at
+    assert "created_at" not in store_item.value
+    assert store_item.created_at.isoformat().replace("+00:00", "Z") == first.created_at
+
+
+def test_memory_service_deletes_stale_records(tmp_path):
+    store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
+    service = MemoryService(store, repo_root="/repo", tool_version="metis-test")
+    for key, repo_fingerprint in (
+        ("fresh-profile", "fresh"),
+        ("old-profile", "old"),
+    ):
+        service.create_record(
+            namespace=("metis", "profiles", "repo1"),
+            key=key,
+            artifact_type="target_profile",
+            repo_fingerprint=repo_fingerprint,
+            input_fingerprint=f"input-{key}",
+            memory_type="semantic",
+            body_json={},
+            summary_text=key,
+        )
+
+    deleted = service.delete_stale_records(
+        ("metis",),
+        repo_fingerprint="fresh",
+    )
+
+    remaining = list(service.iter_records(("metis",)))
+    assert deleted == 1
+    assert [(record.key, record.repo_fingerprint) for record in remaining] == [
+        ("fresh-profile", "fresh")
+    ]

--- a/tests/test_memory_registry.py
+++ b/tests/test_memory_registry.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from metis.memory import SQLiteMemoryStore
+from metis.memory.registry import build_memory_store
+from metis.memory.registry import MemoryStoreSpec
+from metis.memory.registry import parse_memory_store_spec
+from metis.memory.registry import register_memory_store_backend
+
+
+def test_memory_store_factory_uses_explicit_backend(tmp_path):
+    path = tmp_path / "memory.sqlite3"
+
+    spec = parse_memory_store_spec(path, backend="sqlite")
+    store = build_memory_store(path, backend="sqlite")
+
+    assert spec.backend == "sqlite"
+    assert spec.location == str(path)
+    assert isinstance(store, SQLiteMemoryStore)
+    assert store.path == path
+
+
+def test_memory_store_factory_uses_registered_backend():
+    captured: list[MemoryStoreSpec] = []
+    expected_store = object()
+
+    def _factory(spec: MemoryStoreSpec):
+        captured.append(spec)
+        return expected_store
+
+    register_memory_store_backend("unit-test-backend", _factory)
+
+    store = build_memory_store("unit-test-location", backend="unit-test-backend")
+
+    assert store is expected_store
+    assert captured == [
+        MemoryStoreSpec(backend="unit-test-backend", location="unit-test-location")
+    ]


### PR DESCRIPTION
- Added repository memory data model and MemoryService.
- Added SQLite-backed memory store with Full-Text Search and lifecycle/freshness tracking.
- Added metis-memory CLI for inspect, export, cleanup, and reset.
- Added swappable memory backend registry/factory.