### PR TITLE
feat(plugins): add AArch64 assembly .hs extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .coverage
 .env
 build/
+chroma/
 chromadb/
 dist/
 **/__pycache__/

--- a/src/metis/plugins/manifests/aarch64_assembly.yaml
+++ b/src/metis/plugins/manifests/aarch64_assembly.yaml
@@ -3,7 +3,7 @@ aliases:
 - aarch64_assembly
 extensions:
 - .s
-- .s
+- .hs
 - .asm
 - .a64
 filename_patterns: []


### PR DESCRIPTION
Add .hs to the AArch64 assembly language plugin manifest so those files are reviewed as assembly.