### PR TITLE
feat(memory): apply threat-model context to review and triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ planned tree-sitter, model-tool, MCP, and private-tool extension path.
 ### `init`
 Initializes Metis repository context. When repository memory is enabled, this
 loads threat-model memory first: configured
-`metis_engine.threat_model.source_paths`/`source_globs` and well-known files such
-as `SECURITY.md` or `THREAT_MODEL.md` are stored as authoritative project data.
+`metis_engine.threat_model.source_patterns` are stored as authoritative project
+data. The packaged configuration includes common `SECURITY.*` and threat-model
+filename patterns.
 Metis distills those files into repository memory with the configured LLM. If
 `--tools index` is enabled, `init` also runs vector indexing; otherwise indexing
 is skipped.

--- a/docs/repository-memory.md
+++ b/docs/repository-memory.md
@@ -158,26 +158,24 @@ Use top-level `source_kind` for indexed coarse provenance and
   "content_type": "text/plain",
   "text_origin": "repo_file",
   "input_fingerprint": "<sha256 hex digest>",
-  "source_method": "configured_path"
+  "source_method": "configured_pattern"
 }
 ```
 
-Configured and well-known threat-model files are authoritative and binding in
-this initialization path.
+Configured threat-model files are authoritative and binding in this
+initialization path.
 
 ## Init Flow
 
 When repository memory is enabled, `init` gathers threat-model memory before
 other repository setup. The intended order is:
 
-1. Load configured authoritative threat-model sources from
-   `metis_engine.threat_model.source_paths` and `source_globs`.
-2. Load well-known security and threat-model documents when
-   `include_well_known` is enabled.
-3. Store source records with authoritative provenance.
-4. Ask the configured LLM to distill concise threat-model claims and compile
+1. Load authoritative threat-model sources from
+   `metis_engine.threat_model.source_patterns`.
+2. Store source records with authoritative provenance.
+3. Ask the configured LLM to distill concise threat-model claims and compile
    explicit policy and caller contracts from the source files.
-5. Build the vector index only when the user enables `--tools index`.
+4. Build the vector index only when the user enables `--tools index`.
 
 Indexing is a subset of `init`; it is not required for repository memory.
 
@@ -214,13 +212,32 @@ memory:
 
 metis_engine:
   threat_model:
-    include_well_known: true
-    source_paths: []
-    source_globs: []
+    source_patterns:
+      - "SECURITY.*"
+      - "THREAT_MODEL.*"
+      - "THREATMODEL.*"
+      - "threat_model.*"
+      - ".github/SECURITY.*"
+      - "docs/SECURITY.*"
+      - "docs/THREAT_MODEL.*"
+      - "docs/threat_model.*"
+      - "docs/**/*threat*model*.*"
 ```
 
 Use `--config PATH` to select a configuration with a different threat-model
 source set.
+
+## Review And Triage
+
+Review uses threat-model memory to calibrate project scope before asking for
+findings. Authoritative project policy can prevent out-of-scope issues from
+being reported as project vulnerabilities.
+
+Triage uses the same authoritative contract when it evaluates a SARIF finding.
+An explicit binding out-of-scope policy can mark a finding invalid and store the
+applied policy in the SARIF result. Caller contracts and integration-risk
+clauses guide semantic review and triage instead of automatically invalidating
+a finding.
 
 ## Testing
 

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -229,11 +229,7 @@ def _memory_config(raw_config: object) -> dict[str, object]:
 
 def _threat_model_config(value: object) -> dict[str, object]:
     config = value if isinstance(value, dict) else {}
-    return {
-        "include_well_known": bool(config.get("include_well_known", True)),
-        "source_paths": string_list(config.get("source_paths")),
-        "source_globs": string_list(config.get("source_globs")),
-    }
+    return {"source_patterns": string_list(config.get("source_patterns"))}
 
 
 def load_plugin_config(plugins_path: str | Path | None = None):

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -203,6 +203,7 @@ class MetisEngine:
             model_tool_max_rounds=self.tools.triage_model_tool_max_rounds(),
             reachability_service=self.reachability,
             reachability_settings=self.reachability_settings,
+            memory_service=self._config.memory_service,
         )
 
     @property

--- a/src/metis/engine/graphs/review.py
+++ b/src/metis/engine/graphs/review.py
@@ -11,6 +11,10 @@ from langgraph.cache.memory import InMemoryCache
 
 from metis.engine.llm_runner import JsonPromptRequest, JsonPromptRunner
 from metis.engine.source import SourceMap
+from metis.engine.threat_context_retrieval import (
+    format_threat_model_context,
+    threat_model_review_scope_guidance,
+)
 from metis.utils import split_snippet, parse_json_output
 from .schemas import ReviewResponseModel, review_schema_prompt
 from .utils import (
@@ -57,12 +61,21 @@ def _build_body_text(state: ReviewState) -> str:
     """
     snippet = state.get("snippet", "") or ""
     mode = state.get("mode", "file")
+    threat_records = state.get("threat_model_context", [])
+    threat_model_context = format_threat_model_context(threat_records)
+    scope_guidance = threat_model_review_scope_guidance(threat_records)
+    threat_sections = []
+    if threat_model_context:
+        threat_sections.extend(["THREAT_MODEL_CONTEXT:", threat_model_context, ""])
+    if scope_guidance:
+        threat_sections.extend(["THREAT_MODEL_SCOPE_GUIDANCE:", scope_guidance, ""])
 
     if mode == "file":
         file_path = state.get("file_path", "") or ""
         chunk_start = state.get("chunk_start") or 1
         sections = [
             f"FILE: {file_path}",
+            *threat_sections,
             "SNIPPET:",
             SourceMap.number_text(snippet, chunk_start),
             "",
@@ -73,6 +86,7 @@ def _build_body_text(state: ReviewState) -> str:
             "ORIGINAL_FILE:",
             SourceMap.number_text(original_file, 1) if original_file else "",
             "",
+            *threat_sections,
             "FILE_CHANGES:",
             snippet,
             "",
@@ -183,7 +197,7 @@ class ReviewGraph:
                 "Unable to create review runnable; LangChain chat provider required."
             )
         self._prompt_runner = JsonPromptRunner(self.llm_provider)
-        self._app_cache = {}
+        self._app_cache: dict[tuple[int, str], Any] = {}
 
     def _invoke_review_model(self, system_prompt, body_text):
         return self._prompt_runner.invoke(
@@ -248,6 +262,7 @@ class ReviewGraph:
         relative_file = request.get("relative_file")
         mode = request.get("mode", "file")
         original_file = request.get("original_file")
+        threat_model_context = request.get("threat_model_context", [])
 
         rel_path = relative_file or file_path
         if mode == "file":
@@ -259,7 +274,7 @@ class ReviewGraph:
         chunks = split_snippet(
             snippet, self.max_token_length, self.llm_provider.count_tokens
         )
-        accumulated = []
+        accumulated: list[dict] = []
         app = self._build_app(language_prompts, default_prompt_key)
         for chunk, chunk_start in chunks:
             chunk_end = chunk_start + chunk.count("\n")
@@ -272,6 +287,7 @@ class ReviewGraph:
                 "relative_file": relative_file,
                 "mode": mode,
                 "original_file": original_file,
+                "threat_model_context": threat_model_context,
             }
             out = app.invoke(state)
             chunk_reviews = out.get("parsed_reviews", []) or []
@@ -280,7 +296,7 @@ class ReviewGraph:
 
         if not accumulated:
             file_display = relative_file if relative_file else file_path
-            result = {
+            result: dict[str, Any] = {
                 "file": file_display,
                 "file_path": file_path,
                 "reviews": [],

--- a/src/metis/engine/graphs/triage/evidence.py
+++ b/src/metis/engine/graphs/triage/evidence.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import re
+from typing import cast
+
 
 from . import constants as C
 from ..types import TriageState
@@ -121,7 +123,7 @@ def _finalize_evidence_pack_state(
     evidence_pack = "\n\n".join(sections)
     if len(evidence_pack) > C.EVIDENCE_PACK_MAX_CHARS:
         evidence_pack = evidence_pack[: C.EVIDENCE_PACK_MAX_CHARS] + "\n...[truncated]"
-    new_state: TriageState = dict(state)
+    new_state = cast(TriageState, dict(state))
     new_state["evidence_pack"] = evidence_pack
     return new_state
 

--- a/src/metis/engine/graphs/triage/graph.py
+++ b/src/metis/engine/graphs/triage/graph.py
@@ -140,6 +140,7 @@ class TriageGraph:
                 "finding_explanation": request.get("finding_explanation", ""),
                 "triage_language": request.get("triage_language", ""),
                 "triage_language_guidance": request.get("triage_language_guidance", ""),
+                "threat_model_context": request.get("threat_model_context", []),
                 "debug_callback": request.get("debug_callback"),
                 "triage_system_prompt": self.triage_system_prompt,
                 "triage_decision_prompt": self.triage_decision_prompt,

--- a/src/metis/engine/graphs/triage/llm.py
+++ b/src/metis/engine/graphs/triage/llm.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+from metis.engine.threat_context_retrieval import format_threat_model_context
+
 from .debug import _emit_debug
 from ..types import TriageState
 
@@ -29,6 +31,17 @@ def _build_user_prompt(state: TriageState) -> str:
         if guidance:
             sections.append(f"- navigation guidance: {guidance}\n")
         sections.append("\n")
+    threat_model_context = format_threat_model_context(
+        state.get("threat_model_context", [])
+    )
+    if threat_model_context:
+        sections.extend(
+            [
+                "Authoritative Threat-Model Context:\n",
+                threat_model_context,
+                "\n\n",
+            ]
+        )
     return "".join(sections)
 
 

--- a/src/metis/engine/graphs/types.py
+++ b/src/metis/engine/graphs/types.py
@@ -20,6 +20,7 @@ class ReviewRequest(TypedDict):
     mode: NotRequired[str]
     # Optional original file contents for patch mode
     original_file: NotRequired[str | None]
+    threat_model_context: NotRequired[list[dict[str, Any]]]
     debug_callback: NotRequired[Any]
 
 
@@ -40,6 +41,7 @@ class ReviewState(TypedDict, total=False):
     relative_file: str | None
     mode: str
     original_file: str | None
+    threat_model_context: list[dict[str, Any]]
     debug_callback: Any
     # Derived
     system_prompt: str
@@ -70,6 +72,7 @@ class TriageRequest(TypedDict):
     debug_callback: NotRequired[Any]
     triage_language: NotRequired[str]
     triage_language_guidance: NotRequired[str]
+    threat_model_context: NotRequired[list[dict[str, Any]]]
 
 
 class TriageState(TypedDict, total=False):
@@ -84,6 +87,7 @@ class TriageState(TypedDict, total=False):
     debug_callback: Any
     triage_language: str
     triage_language_guidance: str
+    threat_model_context: list[dict[str, Any]]
     triage_system_prompt: str
     triage_decision_prompt: str
     evidence_pack: str

--- a/src/metis/engine/reachability/triage.py
+++ b/src/metis/engine/reachability/triage.py
@@ -37,6 +37,7 @@ class ReachabilityTriageRequest:
     snippet: str = ""
     source_tool: str = ""
     explanation: str = ""
+    threat_model_context: str = ""
 
 
 class ReachabilityTriageRunner:
@@ -156,16 +157,26 @@ class ReachabilityTriageRunner:
         max_tool_rounds: int | None,
         label: str,
     ) -> TriageDecisionModel | None:
+        system_prompt = _SYSTEM_PROMPT
+        if finding.threat_model_context:
+            system_prompt += _THREAT_MODEL_GUIDANCE
+        threat_model_section = ""
+        if finding.threat_model_context:
+            threat_model_section = (
+                "\n\nAuthoritative threat-model context:\n"
+                + finding.threat_model_context
+            )
         return self._runner.invoke(
             JsonPromptRequest(
                 model=self._model,
                 max_tokens=5000,
                 temperature=0.1,
-                system_prompt=_SYSTEM_PROMPT,
+                system_prompt=system_prompt,
                 user_prompt=_USER_PROMPT,
                 variables={
                     "finding": _finding_section(finding),
                     "reachability_context": context,
+                    "threat_model_section": threat_model_section,
                 },
                 parse=_parse_triage_decision,
                 logger=logger,
@@ -629,4 +640,11 @@ Reported finding:
 
 Reachability context:
 {reachability_context}
+{threat_model_section}
 """
+
+_THREAT_MODEL_GUIDANCE = """
+
+When authoritative threat-model context is supplied, treat its applicable
+project scope and caller contracts as binding. Do not apply a contract whose
+scope does not match the reported file or call path."""

--- a/src/metis/engine/review_aggregation.py
+++ b/src/metis/engine/review_aggregation.py
@@ -16,6 +16,7 @@ from .review_validation import (
     review_validation_final_keep,
     review_validation_payload,
 )
+from .threat_context_retrieval import get_threat_model_context
 
 logger = logging.getLogger("metis")
 
@@ -102,12 +103,16 @@ class ReviewResultAggregator:
 
         candidates = []
         candidate_refs = []
+        threat_model_context = get_threat_model_context(self._config.memory_service)
         for group_index, item_index, item in _iter_review_items(review_groups):
             if needs_reachability_validation(item):
                 candidate_refs.append((group_index, item_index))
                 candidates.append(
                     review_validation_payload(
-                        len(candidates), item, codebase_path=self._config.codebase_path
+                        len(candidates),
+                        item,
+                        codebase_path=self._config.codebase_path,
+                        threat_model_context=threat_model_context,
                     )
                 )
 
@@ -148,6 +153,9 @@ class ReviewResultAggregator:
             drop_reason = review_validation_drop_reason(decision)
             if drop_reason:
                 item_copy["review_validation_drop_reason"] = drop_reason
+            scope_policy = decision.get("threat_model_scope_policy")
+            if isinstance(scope_policy, dict):
+                item_copy["threat_model_scope_policy"] = dict(scope_policy)
             model_keep = bool(decision.get("keep", True))
             keep = review_validation_final_keep(candidates[candidate_index], decision)
             item_copy["review_validation_keep"] = keep

--- a/src/metis/engine/review_service.py
+++ b/src/metis/engine/review_service.py
@@ -21,6 +21,7 @@ from .repository import EngineRepository
 from .review_reachability import ReachabilityReviewBackend
 from .review_validation import ReviewFindingValidator
 from .runtime import EngineConfig
+from .threat_context_retrieval import get_threat_model_context
 
 logger = logging.getLogger("metis")
 
@@ -168,6 +169,7 @@ class ReviewService:
 
         language_prompts = plugin.get_prompts()
         relative_path = os.path.relpath(file_path, base_path)
+        threat_model_context = get_threat_model_context(self._config.memory_service)
 
         try:
             req: ReviewRequest = {
@@ -177,6 +179,7 @@ class ReviewService:
                 "default_prompt_key": "security_review_file",
                 "relative_file": relative_path,
                 "mode": "file",
+                "threat_model_context": threat_model_context,
             }
             return self._review_graph_factory().review(req)
         except Exception as e:
@@ -326,6 +329,7 @@ class ReviewService:
             if not snippet:
                 continue
             language_prompts = plugin.get_prompts()
+            threat_model_context = get_threat_model_context(self._config.memory_service)
             try:
                 original_content = read_file_content(abs_path)
                 req: ReviewRequest = {
@@ -336,6 +340,7 @@ class ReviewService:
                     "relative_file": relative_path,
                     "mode": "patch",
                     "original_file": original_content or "",
+                    "threat_model_context": threat_model_context,
                 }
                 review_dict = self._review_graph_factory().review(req)
             except Exception as e:

--- a/src/metis/engine/review_validation.py
+++ b/src/metis/engine/review_validation.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from metis.engine.threat_context_retrieval import threat_model_scope_policy
 from metis.engine.review_finding_adapter import (
     safe_float as _safe_float,
     split_reachability_reasoning as _split_reachability_reasoning,
@@ -61,6 +62,18 @@ Return JSON only:
   ]
 }"""
 
+_THREAT_MODEL_VALIDATION_GUIDANCE = """
+
+Authoritative threat-model context is supplied with these candidates:
+- Treat it as binding. When a caller contract directly assigns input,
+  operation, buffer, or pointer validity to callers or integrators, keep=false
+  when the candidate depends on violating that prerequisite, regardless of the
+  resulting internal failure mode. Use
+  drop_reason=authoritative_threat_model_integration_risk.
+- Do not apply an unrelated caller contract. Keep an implementation defect only
+  when the evidence shows it remains reachable with contract-compliant inputs.
+"""
+
 
 class _ReviewValidationDecisionModel(BaseModel):
     index: int = Field(description="Candidate index from the input.")
@@ -97,7 +110,16 @@ class ReviewFindingValidator:
             or self._config.llama_query_model
         )
         reasoning_effort = self._reachability_settings.get("reasoning_effort")
-        batches = list(enumerate(_validation_batches(candidates)))
+        deterministic_decisions = []
+        remaining_candidates = []
+        for candidate in candidates:
+            decision = _review_validation_scope_decision(candidate)
+            if decision is not None:
+                deterministic_decisions.append(decision)
+            else:
+                remaining_candidates.append(candidate)
+
+        batches = list(enumerate(_validation_batches(remaining_candidates)))
         batch_results = run_reachability_jobs(
             batches,
             lambda item: (
@@ -115,7 +137,7 @@ class ReviewFindingValidator:
             result_key=lambda item: item[0],
             swallow_exceptions=False,
         )
-        decisions = []
+        decisions = deterministic_decisions
         for _index, parsed in sorted(batch_results, key=lambda item: item[0]):
             if not parsed:
                 continue
@@ -125,19 +147,46 @@ class ReviewFindingValidator:
         return _rescue_filtered_duplicate_cluster_representatives(candidates, decisions)
 
     def invoke_batch(self, batch, *, model, reasoning_effort=None):
+        system_prompt = _REVIEW_VALIDATION_SYSTEM_PROMPT
+        threat_model_context = next(
+            (
+                candidate["threat_model_context"]
+                for candidate in batch
+                if candidate.get("threat_model_context")
+            ),
+            [],
+        )
+        if threat_model_context:
+            system_prompt += _THREAT_MODEL_VALIDATION_GUIDANCE
+        validation_input: dict[str, Any] = {
+            "candidate_findings": [
+                {
+                    key: value
+                    for key, value in candidate.items()
+                    if key != "threat_model_context"
+                }
+                for candidate in batch
+            ]
+        }
+        if threat_model_context:
+            validation_input["threat_model_context"] = threat_model_context
+
         return self._runner.invoke(
             JsonPromptRequest(
                 model=model,
                 max_tokens=6000,
                 temperature=0.0,
-                system_prompt=_REVIEW_VALIDATION_SYSTEM_PROMPT,
+                system_prompt=system_prompt,
                 user_prompt=(
-                    "Candidate findings JSON:\n{candidate_findings}\n\n"
+                    "Review validation input JSON:\n{validation_input}\n\n"
                     "Return exactly one JSON object with a top-level "
                     '"decisions" array. Do not return markdown or prose.'
                 ),
                 variables={
-                    "candidate_findings": json.dumps(batch, separators=(",", ":"))
+                    "validation_input": json.dumps(
+                        validation_input,
+                        separators=(",", ":"),
+                    )
                 },
                 parse=_parse_review_validation_response,
                 logger=logger,
@@ -187,7 +236,13 @@ def _review_validation_structured_payload(raw):
     return {"decisions": [dict(decision) for decision in decisions]}
 
 
-def _review_validation_payload(index, item, *, codebase_path=""):
+def _review_validation_payload(
+    index,
+    item,
+    *,
+    codebase_path="",
+    threat_model_context=None,
+):
     root_cause, evidence = _split_reachability_reasoning(item.get("reasoning"))
     payload = {
         "index": index,
@@ -207,7 +262,29 @@ def _review_validation_payload(index, item, *, codebase_path=""):
     code_context = _review_validation_code_context(codebase_path, item)
     if code_context:
         payload["code_context"] = code_context
+    if threat_model_context:
+        payload["threat_model_context"] = threat_model_context
     return payload
+
+
+def _review_validation_scope_decision(candidate):
+    policy = threat_model_scope_policy(
+        candidate.get("threat_model_context", []),
+        path=str(candidate.get("primary_file") or ""),
+    )
+    if policy is None:
+        return None
+    return {
+        "index": _safe_int(candidate.get("index"), -1),
+        "keep": False,
+        "confidence": 0.0,
+        "drop_reason": "authoritative_threat_model_out_of_scope",
+        "reason": (
+            "Dropped because authoritative project security scope marks this "
+            "finding as out of scope rather than a project vulnerability."
+        ),
+        "threat_model_scope_policy": policy,
+    }
 
 
 def _review_validation_code_context(codebase_path, item):

--- a/src/metis/engine/threat_context.py
+++ b/src/metis/engine/threat_context.py
@@ -31,17 +31,6 @@ logger = logging.getLogger("metis")
 
 THREAT_MODEL_NAMESPACE = ("repo", "threat_model")
 
-_COMMON_THREAT_MODEL_FILE_PATTERNS = (
-    "SECURITY.*",
-    "THREAT_MODEL.*",
-    "THREATMODEL.*",
-    "threat_model.*",
-    ".github/SECURITY.*",
-    "docs/SECURITY.*",
-    "docs/THREAT_MODEL.*",
-    "docs/threat_model.*",
-)
-
 
 @dataclass(frozen=True)
 class ThreatSource:
@@ -78,7 +67,10 @@ class _ThreatSourceClaimRecordModel(BaseModel):
     )
     applies_to: list[str] = Field(
         default_factory=list,
-        description="Short scopes or path globs.",
+        description=(
+            "Use repository for repository-wide claims, otherwise repository-relative "
+            "path globs."
+        ),
     )
     disposition: Literal["out_of_scope", "integration_risk", "advisory", "review"]
 
@@ -380,10 +372,8 @@ def _write_authoritative_contract_record(
     body = {
         "authority": "authoritative",
         "binding": True,
-        "repository_wide": True,
         "scope_clauses": clauses,
         "source_refs": source_refs,
-        "claim_summaries": claim_summaries,
     }
     summary = f"Authoritative threat-model contract: {'; '.join(claim_summaries)}"
     service.create_record(
@@ -401,7 +391,6 @@ def _write_authoritative_contract_record(
             "authority": "authoritative",
             "binding": True,
             "role": "compiled_contract",
-            "repository_wide": True,
             "scope_clauses": clauses,
             "sources": source_refs,
         },
@@ -467,12 +456,14 @@ def _model_distilled_source_claims(
                     "caller_contract|asset|attacker_capability|mitigation|"
                     'architecture_assumption|analysis_policy",'
                     '"statement":"one concise reusable statement",'
-                    '"applies_to":["short scopes or path globs"],'
+                    '"applies_to":["repository"],'
                     '"disposition":"out_of_scope|integration_risk|advisory|review"'
                     "}}]}}\n"
                     "Return one record for every distinct security-relevant claim "
                     "supported by this evidence batch. Merge equivalent claims and "
-                    "do not repeat them. Each statement must be plain text without "
+                    'do not repeat them. Use exactly "repository" for repository-wide '
+                    "claims; otherwise use repository-relative path globs. Each "
+                    "statement must be plain text without "
                     "Markdown, bullets, prefixes, or line breaks, and under 240 chars."
                 ),
                 variables={
@@ -541,15 +532,17 @@ def _model_reduce_source_claim_group(
                 "caller_contract|asset|attacker_capability|mitigation|"
                 'architecture_assumption|analysis_policy",'
                 '"statement":"one concise reusable statement",'
-                '"applies_to":["short scopes or path globs"],'
+                '"applies_to":["repository"],'
                 '"disposition":"out_of_scope|integration_risk|advisory|review",'
                 '"source_claim_indexes":[0,1]}}]}}\n'
                 "Return an empty records array if no candidate is useful. "
                 "Each statement must preserve the security or triage-scope meaning. "
                 "Return one consolidated record for every distinct claim supported "
                 "by the candidates. Merge equivalent claims and do not omit unique "
-                "claims. Each statement must be plain text without Markdown, bullets, "
-                "prefixes, or line breaks, and under 240 chars."
+                'claims. Use exactly "repository" for repository-wide claims; '
+                "otherwise use repository-relative path globs. Each statement must "
+                "be plain text without Markdown, bullets, prefixes, or line breaks, "
+                "and under 240 chars."
             ),
             variables={"evidence": evidence},
             parse=lambda raw: _parse_distilled_records(
@@ -625,21 +618,8 @@ def _find_threat_sources(
     supported_extensions: set[str],
     is_metisignored: Callable[[str], bool],
 ) -> list[ThreatSource]:
-    configured_paths: list[Path] = []
-    configured_glob_paths: list[Path] = []
-    well_known_paths: list[Path] = []
-    configured_source_requested = False
-
-    for raw_path in string_list(threat_config.get("source_paths")):
-        candidate = Path(raw_path)
-        if candidate.suffix.lower() not in supported_extensions:
-            continue
-        configured_source_requested = True
-        if not candidate.is_absolute():
-            candidate = repo_root / candidate
-        configured_paths.append(candidate)
-
-    for pattern in string_list(threat_config.get("source_globs")):
+    resolved_paths: set[Path] = set()
+    for pattern in string_list(threat_config.get("source_patterns")):
         pattern_path = Path(pattern)
         suffix = pattern_path.suffix.lower()
         if suffix and not has_magic(suffix) and suffix not in supported_extensions:
@@ -651,23 +631,7 @@ def _find_threat_sources(
                 continue
         if ".." in pattern_path.parts:
             continue
-        configured_source_requested = True
-        configured_glob_paths.extend(repo_root.glob(pattern_path.as_posix()))
-
-    if bool(threat_config.get("include_well_known", True)):
-        for pattern in _COMMON_THREAT_MODEL_FILE_PATTERNS:
-            well_known_paths.extend(repo_root.glob(pattern))
-
-    source_groups = (
-        ("configured_path", configured_paths),
-        ("configured_glob", configured_glob_paths),
-        ("well_known", well_known_paths),
-    )
-    sources: list[ThreatSource] = []
-    seen_paths: set[Path] = set()
-    for source, paths in source_groups:
-        resolved_paths: set[Path] = set()
-        for path in paths:
+        for path in repo_root.glob(pattern_path.as_posix()):
             resolved = _safe_repo_path(repo_root, path)
             if (
                 resolved is None
@@ -676,20 +640,14 @@ def _find_threat_sources(
             ):
                 continue
             resolved_paths.add(resolved)
-        for resolved in sorted(
-            resolved_paths - seen_paths,
-            key=lambda path: path.relative_to(repo_root).as_posix(),
-        ):
-            seen_paths.add(resolved)
-            sources.append(ThreatSource(path=resolved, source=source))
 
-    if configured_source_requested and not any(
-        source.source in {"configured_path", "configured_glob"} for source in sources
-    ):
-        raise ValueError(
-            "Configured threat-model sources did not match any supported files"
+    return [
+        ThreatSource(path=resolved, source="configured_pattern")
+        for resolved in sorted(
+            resolved_paths,
+            key=lambda path: path.relative_to(repo_root).as_posix(),
         )
-    return sources
+    ]
 
 
 def _claim_source_refs(claim: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/metis/engine/threat_context_retrieval.py
+++ b/src/metis/engine/threat_context_retrieval.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+from typing import Any
+
+from metis.memory import MemoryService
+
+from .threat_context import THREAT_MODEL_NAMESPACE
+
+
+def get_threat_model_context(
+    service: MemoryService | None,
+) -> list[dict[str, Any]]:
+    if service is None:
+        return []
+
+    contract = service.get_record(
+        (*THREAT_MODEL_NAMESPACE, "contracts"),
+        "authoritative",
+    )
+    if contract is None:
+        return []
+    return [
+        {
+            "summary": contract.summary_text,
+            "metadata": {
+                "authority": contract.authority,
+                "scope_clauses": contract.metadata["scope_clauses"],
+            },
+        }
+    ]
+
+
+def format_threat_model_context(records: list[dict[str, Any]]) -> str:
+    sections = []
+    for record in records:
+        metadata = record["metadata"]
+        sections.append(f"- [{metadata['authority']}] {record['summary']}")
+        clauses = metadata["scope_clauses"]
+        if clauses:
+            sections.append(
+                "  Binding scope clauses: " + json.dumps(clauses, separators=(",", ":"))
+            )
+    return "\n".join(sections)
+
+
+def threat_model_review_scope_guidance(records: list[dict[str, Any]]) -> str:
+    if not records:
+        return ""
+    return (
+        "Treat applicable authoritative threat-model scope as binding. Apply "
+        "path-scoped clauses only when their applies_to pattern matches the FILE."
+    )
+
+
+def threat_model_scope_policy(
+    records: list[dict[str, Any]],
+    *,
+    path: str,
+) -> dict[str, Any] | None:
+    for clause in _scope_clauses(records):
+        if _clause_authorizes_automatic_filter(clause, path):
+            return dict(clause)
+    return None
+
+
+def threat_model_triage_override(
+    policy: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if policy is None:
+        return None
+
+    source_path = policy["source_path"]
+    return {
+        "status": "invalid",
+        "reason": (
+            "Invalid under authoritative threat-model scope "
+            f"({source_path}). {policy['reason']} "
+            "This is out of scope for project security."
+        ),
+        "evidence": [source_path],
+        "resolution_chain": ["authoritative_threat_model_scope"],
+        "unresolved_hops": [],
+        "evidence_obligations": ["authoritative_threat_model_scope"],
+        "evidence_coverage": {"authoritative_threat_model_scope": 1},
+        "missing_evidence": [],
+        "threat_model_policy": policy,
+    }
+
+
+def _scope_clauses(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        clause for record in records for clause in record["metadata"]["scope_clauses"]
+    ]
+
+
+def _clause_authorizes_automatic_filter(
+    clause: dict[str, Any],
+    path: str,
+) -> bool:
+    if _is_global_exclusion(clause):
+        return True
+
+    if (
+        not _is_binding(clause)
+        or clause["claim_type"] not in {"analysis_policy", "scope_rule"}
+        or clause["disposition"] != "out_of_scope"
+    ):
+        return False
+
+    scopes = clause["applies_to"]
+    if "repository" in scopes:
+        return False
+
+    normalized_path = path.replace("\\", "/")
+    if not normalized_path:
+        return False
+    return any(PurePosixPath(normalized_path).match(scope) for scope in scopes)
+
+
+def _is_binding(clause: dict[str, Any]) -> bool:
+    return clause["source_authority"] == "authoritative" and clause["binding"]
+
+
+def _is_global_exclusion(clause: dict[str, Any]) -> bool:
+    return (
+        _is_binding(clause)
+        and clause["claim_type"] == "analysis_policy"
+        and clause["disposition"] == "out_of_scope"
+        and "repository" in clause["applies_to"]
+    )

--- a/src/metis/engine/triage_service.py
+++ b/src/metis/engine/triage_service.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import threading
 from typing import Any, Callable
 
+from metis.memory import MemoryService
 from metis.usage import UsageHooks
 
 from .triage_service_exec import TriageServiceExecutionMixin
@@ -34,6 +35,7 @@ class TriageService(TriageServiceRuntimeMixin, TriageServiceExecutionMixin):
         model_tool_max_rounds: int | None = None,
         reachability_service: Any = None,
         reachability_settings: dict[str, Any] | None = None,
+        memory_service: MemoryService | None = None,
     ):
         self.codebase_path = codebase_path
         self.llm_provider = llm_provider
@@ -50,5 +52,6 @@ class TriageService(TriageServiceRuntimeMixin, TriageServiceExecutionMixin):
         self.model_tool_max_rounds = model_tool_max_rounds
         self.reachability_service = reachability_service
         self.reachability_settings = dict(reachability_settings or {})
+        self.memory_service = memory_service
 
         self._triage_graph_local = threading.local()

--- a/src/metis/engine/triage_service_exec.py
+++ b/src/metis/engine/triage_service_exec.py
@@ -8,6 +8,14 @@ import logging
 
 from metis.engine.options import TriageOptions
 from metis.engine.graphs.types import TriageRequest
+from metis.memory import MemoryService
+
+from .threat_context_retrieval import (
+    format_threat_model_context,
+    get_threat_model_context,
+    threat_model_scope_policy,
+    threat_model_triage_override,
+)
 from metis.sarif.triage import (
     apply_triage_result,
     extract_findings,
@@ -20,6 +28,8 @@ logger = logging.getLogger("metis")
 
 
 class TriageServiceExecutionMixin:
+    memory_service: MemoryService | None
+
     def _invoke_callback(self, callback, *args, **kwargs) -> None:
         if not callable(callback):
             return
@@ -72,10 +82,23 @@ class TriageServiceExecutionMixin:
         *,
         debug_callback,
     ) -> dict:
+        threat_model_context = get_threat_model_context(self.memory_service)
+        policy = threat_model_scope_policy(
+            threat_model_context,
+            path=finding.file_path,
+        )
+        override = threat_model_triage_override(policy)
+        if override is not None:
+            return override
         if self._supports_reachability_triage(finding.file_path):
             del debug_callback
             return self.reachability_service.triage_finding(
-                self._reachability_triage_request(finding),
+                self._reachability_triage_request(
+                    finding,
+                    threat_model_context=format_threat_model_context(
+                        threat_model_context
+                    ),
+                ),
                 options=self._reachability_triage_options(),
                 model_tools=self.model_tools,
                 model_tool_max_rounds=self.model_tool_max_rounds,
@@ -85,6 +108,7 @@ class TriageServiceExecutionMixin:
             finding=finding,
             debug_callback=debug_callback,
         )
+        req["threat_model_context"] = threat_model_context
         return self._get_thread_triage_graph().triage(req)
 
     def _record_triage_success(self, triaged_payload: dict, finding, decision: dict):
@@ -98,6 +122,7 @@ class TriageServiceExecutionMixin:
                 "evidence_requirements": decision.get("evidence_obligations"),
                 "evidence_coverage": decision.get("evidence_coverage"),
                 "missing_evidence": decision.get("missing_evidence"),
+                "threat_model_policy": decision.get("threat_model_policy"),
             },
         )
 

--- a/src/metis/engine/triage_service_runtime.py
+++ b/src/metis/engine/triage_service_runtime.py
@@ -77,7 +77,12 @@ class TriageServiceRuntimeMixin:
             default_workers=self.max_workers,
         )
 
-    def _reachability_triage_request(self, finding) -> ReachabilityTriageRequest:
+    def _reachability_triage_request(
+        self,
+        finding,
+        *,
+        threat_model_context: str = "",
+    ) -> ReachabilityTriageRequest:
         return ReachabilityTriageRequest(
             message=finding.message,
             file_path=finding.file_path,
@@ -86,6 +91,7 @@ class TriageServiceRuntimeMixin:
             snippet=finding.snippet,
             source_tool=getattr(finding, "source_tool", ""),
             explanation=getattr(finding, "explanation", ""),
+            threat_model_context=threat_model_context,
         )
 
     def close(self):

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -33,6 +33,17 @@ metis_engine:
   reachability_domain_hints: []
   model_tools:
     max_rounds: 6
+  threat_model:
+    source_patterns:
+      - "SECURITY.*"
+      - "THREAT_MODEL.*"
+      - "THREATMODEL.*"
+      - "threat_model.*"
+      - ".github/SECURITY.*"
+      - "docs/SECURITY.*"
+      - "docs/THREAT_MODEL.*"
+      - "docs/threat_model.*"
+      - "docs/**/*threat*model*.*"
 
 memory:
   enabled: false

--- a/src/metis/sarif/triage.py
+++ b/src/metis/sarif/triage.py
@@ -18,6 +18,7 @@ METIS_TRIAGE_TIMESTAMP_KEY = "metisTriageTimestamp"
 METIS_EVIDENCE_REQUIREMENTS_KEY = "metisEvidenceRequirements"
 METIS_EVIDENCE_COVERAGE_KEY = "metisEvidenceCoverage"
 METIS_MISSING_EVIDENCE_KEY = "metisMissingEvidence"
+METIS_THREAT_MODEL_POLICY_KEY = "metisThreatModelPolicy"
 
 
 @dataclass(frozen=True)
@@ -230,13 +231,25 @@ def _apply_triage_metadata(
         properties[METIS_EVIDENCE_REQUIREMENTS_KEY] = [
             str(item) for item in evidence_requirements if str(item or "").strip()
         ]
+    else:
+        properties.pop(METIS_EVIDENCE_REQUIREMENTS_KEY, None)
 
     evidence_coverage = metadata.get("evidence_coverage")
     if isinstance(evidence_coverage, dict):
         properties[METIS_EVIDENCE_COVERAGE_KEY] = dict(evidence_coverage)
+    else:
+        properties.pop(METIS_EVIDENCE_COVERAGE_KEY, None)
 
     missing_evidence = metadata.get("missing_evidence")
     if isinstance(missing_evidence, list):
         properties[METIS_MISSING_EVIDENCE_KEY] = [
             str(item) for item in missing_evidence if str(item or "").strip()
         ]
+    else:
+        properties.pop(METIS_MISSING_EVIDENCE_KEY, None)
+
+    threat_model_policy = metadata.get("threat_model_policy")
+    if isinstance(threat_model_policy, dict):
+        properties[METIS_THREAT_MODEL_POLICY_KEY] = dict(threat_model_policy)
+    else:
+        properties.pop(METIS_THREAT_MODEL_POLICY_KEY, None)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -139,10 +139,8 @@ def test_load_runtime_config_accepts_threat_model_sources(tmp_path, monkeypatch)
         """
 metis_engine:
   threat_model:
-    include_well_known: false
-    source_paths:
+    source_patterns:
       - THREAT_MODEL.md
-    source_globs:
       - docs/threat-model/*.md
 llm_provider:
   name: openai
@@ -154,9 +152,10 @@ llm_provider:
     runtime = load_runtime_config(config_path)
 
     threat_model = runtime["threat_model_config"]
-    assert threat_model["include_well_known"] is False
-    assert threat_model["source_paths"] == ["THREAT_MODEL.md"]
-    assert threat_model["source_globs"] == ["docs/threat-model/*.md"]
+    assert threat_model["source_patterns"] == [
+        "THREAT_MODEL.md",
+        "docs/threat-model/*.md",
+    ]
 
 
 def test_load_runtime_config_accepts_pgvector_halfvec_flag(tmp_path, monkeypatch):

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -285,6 +285,9 @@ def test_init_codebase_populates_memory(tmp_path, dummy_backend):
             "backend": "sqlite",
             "location": "memory.sqlite3",
         },
+        threat_model_config={
+            "source_patterns": ["SECURITY.*"],
+        },
     )
 
     result = engine.init_codebase(include_index=False)

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -84,3 +84,27 @@ def test_review_nodes_pipeline_parses():
 
     s3 = review_node_parse(s2)
     assert s3.get("parsed_reviews") and isinstance(s3["parsed_reviews"], list)
+
+
+def test_review_body_includes_threat_model_context():
+    from metis.engine.graphs.review import _build_body_text
+
+    body = _build_body_text(
+        {
+            "file_path": "src/main.c",
+            "snippet": "int main(void) { return 0; }",
+            "threat_model_context": [
+                {
+                    "summary": "Authoritative policy says images are untrusted.",
+                    "metadata": {
+                        "authority": "authoritative",
+                        "scope_clauses": [],
+                    },
+                }
+            ],
+        }
+    )
+
+    assert "THREAT_MODEL_CONTEXT:" in body
+    assert "Authoritative policy says images are untrusted." in body
+    assert body.index("THREAT_MODEL_CONTEXT:") < body.index("SNIPPET:")

--- a/tests/test_sarif_triage.py
+++ b/tests/test_sarif_triage.py
@@ -174,6 +174,10 @@ def test_triage_payload_writes_evidence_metadata(engine, monkeypatch):
                 "evidence_obligations": ["local_context", "use_site"],
                 "evidence_coverage": {"local_context": 1, "use_site": 0},
                 "missing_evidence": ["use_site"],
+                "threat_model_policy": {
+                    "claim_type": "caller_contract",
+                    "disposition": "integration_risk",
+                },
             }
 
     monkeypatch.setattr(
@@ -188,6 +192,10 @@ def test_triage_payload_writes_evidence_metadata(engine, monkeypatch):
     assert props["metisEvidenceRequirements"] == ["local_context", "use_site"]
     assert props["metisEvidenceCoverage"] == {"local_context": 1, "use_site": 0}
     assert props["metisMissingEvidence"] == ["use_site"]
+    assert props["metisThreatModelPolicy"] == {
+        "claim_type": "caller_contract",
+        "disposition": "integration_risk",
+    }
 
 
 def test_triage_file_writes_checkpoints(engine, monkeypatch, tmp_path):

--- a/tests/test_threat_context.py
+++ b/tests/test_threat_context.py
@@ -22,9 +22,7 @@ def _config(tmp_path):
     return SimpleNamespace(
         codebase_path=str(repo),
         threat_model_config={
-            "include_well_known": True,
-            "source_paths": [],
-            "source_globs": [],
+            "source_patterns": ["SECURITY.*"],
         },
         plugin_config={
             "docs": {"supported_extensions": [".md", ".html", ".txt", ".pdf", ".rst"]}
@@ -130,9 +128,10 @@ def test_initialize_threat_model_memory_preserves_snapshot_on_model_failure(
 def test_initialize_threat_model_memory_uses_configured_sources_only(tmp_path):
     config = _config(tmp_path)
     config.threat_model_config = {
-        "include_well_known": False,
-        "source_paths": ["docs/platform-risk-register.html"],
-        "source_globs": ["design/*.md"],
+        "source_patterns": [
+            "docs/platform-risk-register.html",
+            "design/*.md",
+        ],
     }
     repo = tmp_path / "repo"
     (repo / "SECURITY.md").write_text(
@@ -154,8 +153,8 @@ def test_initialize_threat_model_memory_uses_configured_sources_only(tmp_path):
     result = initialize_threat_model_memory(config)
 
     assert result["authoritative_sources"] == [
-        "docs/platform-risk-register.html",
         "design/boot-flow.md",
+        "docs/platform-risk-register.html",
     ]
     methods = {
         record.metadata["path"]: record.metadata["source"]["source_method"]
@@ -164,17 +163,15 @@ def test_initialize_threat_model_memory_uses_configured_sources_only(tmp_path):
         )
     }
     assert methods == {
-        "docs/platform-risk-register.html": "configured_path",
-        "design/boot-flow.md": "configured_glob",
+        "docs/platform-risk-register.html": "configured_pattern",
+        "design/boot-flow.md": "configured_pattern",
     }
 
 
 def test_initialize_threat_model_memory_ignores_unsupported_sources(tmp_path):
     config = _config(tmp_path)
     config.threat_model_config = {
-        "include_well_known": False,
-        "source_paths": ["docs/security.pdf"],
-        "source_globs": [],
+        "source_patterns": ["docs/security.pdf"],
     }
     repo = tmp_path / "repo"
     (repo / "docs").mkdir()

--- a/tests/test_threat_context_retrieval.py
+++ b/tests/test_threat_context_retrieval.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from langgraph.store.memory import InMemoryStore
+
+from metis.engine.threat_context import THREAT_MODEL_NAMESPACE
+from metis.engine.threat_context_retrieval import format_threat_model_context
+from metis.engine.threat_context_retrieval import get_threat_model_context
+from metis.engine.threat_context_retrieval import threat_model_scope_policy
+from metis.engine.threat_context_retrieval import threat_model_triage_override
+from metis.memory import MemoryService
+
+
+def _memory_with_contract(tmp_path, clauses):
+    service = MemoryService(InMemoryStore(), repo_root=str(tmp_path))
+    service.create_record(
+        namespace=(*THREAT_MODEL_NAMESPACE, "contracts"),
+        key="authoritative",
+        artifact_type="threat_model_contract",
+        memory_type="procedural",
+        authority="authoritative",
+        repo_fingerprint="repo",
+        input_fingerprint="input",
+        body_json={},
+        summary_text="Authoritative project security contract.",
+        search_text="authoritative security contract",
+        metadata={
+            "authority": "authoritative",
+            "binding": True,
+            "scope_clauses": clauses,
+        },
+        source_kind="compiled_contract",
+    )
+    return service
+
+
+def test_authoritative_contract_drives_global_triage_override(tmp_path):
+    memory = _memory_with_contract(
+        tmp_path,
+        [
+            {
+                "claim_type": "caller_contract",
+                "disposition": "integration_risk",
+                "reason": "Integrators own input validation.",
+                "applies_to": ["repository"],
+                "source_authority": "authoritative",
+                "binding": True,
+                "source_path": "SECURITY.md",
+            },
+            {
+                "claim_type": "analysis_policy",
+                "disposition": "out_of_scope",
+                "reason": "Security findings are outside project scope.",
+                "applies_to": ["repository"],
+                "source_authority": "authoritative",
+                "binding": True,
+                "source_path": "SECURITY.md",
+            },
+        ],
+    )
+    context = get_threat_model_context(memory)
+
+    assert len(context) == 1
+    assert "Authoritative project security contract" in format_threat_model_context(
+        context
+    )
+
+    override = threat_model_triage_override(
+        threat_model_scope_policy(context, path="src/example.c")
+    )
+
+    assert override is not None
+    assert override["status"] == "invalid"
+    assert override["threat_model_policy"]["claim_type"] == "analysis_policy"
+    assert override["threat_model_policy"]["source_path"] == "SECURITY.md"
+
+
+def test_path_scoped_policy_does_not_apply_to_other_files(tmp_path):
+    memory = _memory_with_contract(
+        tmp_path,
+        [
+            {
+                "claim_type": "caller_contract",
+                "disposition": "integration_risk",
+                "reason": "Callers own validation for this interface.",
+                "applies_to": ["src/public_api/*.c"],
+                "source_authority": "authoritative",
+                "binding": True,
+                "source_path": "THREAT_MODEL.md",
+            },
+            {
+                "claim_type": "scope_rule",
+                "disposition": "out_of_scope",
+                "reason": "This interface is outside project security scope.",
+                "applies_to": ["src/public_api/*.c"],
+                "source_authority": "authoritative",
+                "binding": True,
+                "source_path": "THREAT_MODEL.md",
+            },
+        ],
+    )
+    context = get_threat_model_context(memory)
+
+    matching = threat_model_scope_policy(
+        context,
+        path="src/public_api/call.c",
+    )
+    unrelated = threat_model_scope_policy(
+        context,
+        path="src/internal/call.c",
+    )
+    nested = threat_model_scope_policy(
+        context,
+        path="src/public_api/nested/call.c",
+    )
+
+    assert matching is not None
+    assert matching["claim_type"] == "scope_rule"
+    assert matching["disposition"] == "out_of_scope"
+    assert unrelated is None
+    assert nested is None

--- a/tests/test_triage_graph.py
+++ b/tests/test_triage_graph.py
@@ -133,12 +133,23 @@ def test_triage_user_prompt_includes_language_navigation_guidance():
             "finding_snippet": "danger(x)",
             "triage_language": "python",
             "triage_language_guidance": "Inspect decorators and validators first.",
+            "threat_model_context": [
+                {
+                    "summary": "Callers validate input.",
+                    "metadata": {
+                        "authority": "authoritative",
+                        "scope_clauses": [],
+                    },
+                }
+            ],
         }
     )
 
     assert "Language Context:" in prompt
     assert "- language: python" in prompt
     assert "Inspect decorators and validators first." in prompt
+    assert "Authoritative Threat-Model Context:" in prompt
+    assert "Callers validate input." in prompt
 
 
 def test_triage_schema_rejects_inconclusive_without_unresolved_hops():


### PR DESCRIPTION
  - Apply authoritative threat-model context during review validation and SARIF triage.
  - Enforce explicit binding out-of-scope policies for repository-wide and matching path scopes.
  - Use caller contracts and integration-risk clauses as semantic guidance rather than automatic exclusions.
  - Apply threat-model context to both generic and C/C++ reachability triage.
  - Send the contract once per validation batch and keep it outside the triage evidence budget.
  - Preserve applied policy provenance in SARIF and clear stale metadata during retriage.
  - Configure threat-model sources solely through `metis_engine.threat_model.source_patterns`.