### PR TITLE
feat: Qdrant Vector Search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: uv venv --python ${{ matrix.python-version }}
 
       - name: Install test dependencies
-        run: uv pip install '.[test]'
+        run: uv pip install '.[test,qdrant]'
 
       - name: Run pre-commit checks
         run: |

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ For the current Reachability and simple LLM triage paths, see
 
 Metis uses a plugin-based language system, making it easy to extend support to additional languages.
 
-It also supports multiple vector store backends, including PostgreSQL with pgvector and ChromaDB.
+It supports ChromaDB, PostgreSQL with pgvector, and Qdrant vector-store backends.
 
 ## Getting Started
 
-By default, Metis uses **ChromaDB** for local, no-setup usage. You can also use **PostgreSQL (with pgvector)** for scalable indexing and multi-project support.
+By default, Metis uses **ChromaDB** for local, no-setup usage. PostgreSQL with pgvector and Qdrant are available as optional backends.
 
 ### 1. **Installation**
 
@@ -90,6 +90,12 @@ To install with **PostgreSQL (pgvector)** backend support:
 
 ```bash
 uv pip install '.[postgres]'
+```
+
+To install with Qdrant backend support:
+
+```bash
+uv pip install '.[qdrant]'
 ```
 
 ### 1.1 **Docker**
@@ -205,8 +211,9 @@ Metis also provides an interactive CLI with several built-in commands:
 - `--custom-prompt PATH` – optional `.md` or `.txt` file containing additional
   security-review guidance. If omitted, Metis uses `.metis.md` from the project
   root when that file exists.
-- `--backend chroma|postgres` – choose vector-store backend (default `chroma`).
-- `--project-schema` / `--chroma-dir` – backend-specific knobs.
+- `--backend chroma|postgres|qdrant` – choose a vector-store backend (default `chroma`).
+- `--project-schema` namespaces PostgreSQL schemas and Qdrant collections.
+- `--chroma-dir` and `--qdrant-url` configure backend storage.
 - `--triage` – after `review_code`, `review_dir`, `review_file`, or `review_patch`, triage findings and annotate SARIF output.
 - `--include-triaged` – include findings already triaged by Metis when running triage.
 - `--verbose` – show the stages and nodes executed by the selected graph.
@@ -314,7 +321,23 @@ metis_engine:
   pgvector_use_halfvec: auto  # auto, true, or false
 ```
 
-#### Example 3: Usage and output
+#### Example 3: Qdrant
+
+Qdrant must be running as a server. See the [Qdrant quickstart](https://qdrant.tech/documentation/quickstart/) for setup details, or start a local server with Docker:
+
+```bash
+docker run -p 6333:6333 qdrant/qdrant
+```
+
+Metis connects to localhost by default:
+
+```bash
+metis --backend qdrant --project-schema myproject
+```
+
+For another Qdrant Server or Qdrant Cloud endpoint, pass `--qdrant-url` or set `QDRANT_URL`. Set `QDRANT_API_KEY` when authentication is required. Metis creates `<project-schema>_code` and `<project-schema>_docs` collections.
+
+#### Example 4: Usage and output
 
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ optional-dependencies.bedrock-mantle = [
 optional-dependencies.dev = [
   "metis[all-providers]",
   "metis[lint]",
+  "metis[qdrant]",
   "metis[test]",
 ]
 optional-dependencies.gemini = [
@@ -68,6 +69,10 @@ optional-dependencies.lint = [
 ]
 optional-dependencies.postgres = [
   "llama-index-vector-stores-postgres>=0.8.1",
+]
+optional-dependencies.qdrant = [
+  "llama-index-vector-stores-qdrant>=0.10.2",
+  "qdrant-client<1.19",
 ]
 optional-dependencies.test = [
   "pytest>=9.0.3",

--- a/src/metis/cli/commands.py
+++ b/src/metis/cli/commands.py
@@ -57,13 +57,14 @@ Type one of the following commands (with arguments):
 - [magenta]help[/magenta]   (show this message)
 
 Options:
-    --backend chroma|postgres  Vector backend to use (default: chroma).
+    --backend chroma|postgres|qdrant  Vector backend to use (default: chroma).
     --output-file PATH         Save analysis results to this file.
     --custom-prompt PATH       Custom prompt file (.md or .txt) to guide analysis.
     --triage                   Triage findings and annotate SARIF output for review commands.
     --include-triaged          Include findings already triaged by Metis.
     --project-schema SCHEMA    (Optional) Project identifier if postgresql is used.
     --chroma-dir DIR           (Optional) Directory to store ChromaDB data (default: ./chromadb).
+    --qdrant-url URL           (Optional) Qdrant server URL (default: http://localhost:6333).
     --verbose                  (Optional) Shows detailed output in the terminal window.
     --version                  (Optional) Show program version
 """

--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -34,6 +34,7 @@ from .utils import (
     PG_SUPPORTED,
     build_pg_backend,
     build_chroma_backend,
+    build_qdrant_backend,
     print_console,
     print_usage_summary,
     print_final_usage_summary,
@@ -217,6 +218,8 @@ def build_engine(args, runtime):
 
     if args.backend == "postgres":
         vector_backend = build_pg_backend(args, runtime, None, None)
+    elif args.backend == "qdrant":
+        vector_backend = build_qdrant_backend(args, runtime, None, None)
     else:
         vector_backend = build_chroma_backend(args, runtime, None, None)
 
@@ -398,9 +401,17 @@ def main():
         help="Path to a custom Metis config file.",
     )
     parser.add_argument("--chroma-dir", type=str, default="./chromadb")
+    parser.add_argument(
+        "--qdrant-url",
+        type=str,
+        help="Qdrant server URL (default: http://localhost:6333).",
+    )
     parser.add_argument("--codebase-path", type=str, default=".")
     parser.add_argument(
-        "--backend", type=str, default="chroma", choices=["chroma", "postgres"]
+        "--backend",
+        type=str,
+        default="chroma",
+        choices=["chroma", "postgres", "qdrant"],
     )
     parser.add_argument("--log-file", type=str)
     parser.add_argument("--log-level", type=str, default="ERROR")

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -710,3 +710,27 @@ def build_chroma_backend(args, runtime, embed_model_code, embed_model_docs):
         embed_model_docs=embed_model_docs,
         query_config=retriever_query_config(runtime),
     )
+
+
+def build_qdrant_backend(
+    args, runtime, embed_model_code, embed_model_docs, quiet=False
+):
+    try:
+        from metis.vector_store.qdrant_store import QdrantStore
+    except ImportError as exc:
+        print_console(
+            "[bold red]Qdrant backend requested but not installed. Install it with:[/bold red]",
+            quiet,
+        )
+        print_console("  uv pip install '.[qdrant]'", quiet, markup=False)
+        raise SystemExit(1) from exc
+
+    return QdrantStore(
+        url=args.qdrant_url or os.environ.get("QDRANT_URL") or "http://localhost:6333",
+        api_key=os.environ.get("QDRANT_API_KEY"),
+        collection_prefix=args.project_schema,
+        embed_dim=runtime["embed_dim"],
+        embed_model_code=embed_model_code,
+        embed_model_docs=embed_model_docs,
+        query_config=retriever_query_config(runtime),
+    )

--- a/src/metis/engine/capabilities/indexing.py
+++ b/src/metis/engine/capabilities/indexing.py
@@ -3,22 +3,22 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import unidiff
 from llama_index.core import SimpleDirectoryReader
 from llama_index.core.schema import Document
 
-from metis.exceptions import ParsingError
-from metis.utils import read_file_content
-
 from metis.engine.diff_utils import extract_content_from_diff
 from metis.engine.helpers import prepare_nodes_iter
 from metis.engine.repository import EngineRepository
-from metis.engine.runtime import EngineConfig, EngineState
+from metis.engine.runtime import EngineConfig
+from metis.engine.runtime import EngineState
+from metis.exceptions import ParsingError
+from metis.utils import read_file_content
 
 logger = logging.getLogger("metis")
 
@@ -134,7 +134,6 @@ class IndexingService:
         )
 
         self._state.pending_nodes = (nodes_code, nodes_docs)
-        return
 
     def index_prepare_nodes(self):
         for _ in self.index_prepare_nodes_iter():

--- a/src/metis/engine/capabilities/indexing.py
+++ b/src/metis/engine/capabilities/indexing.py
@@ -155,6 +155,24 @@ class IndexingService:
         )
         self._state.pending_nodes = None
 
+    def _split_updated_document(self, doc, language_name, doc_splitter):
+        if language_name is None:
+            return doc_splitter.get_nodes_from_documents([doc])
+        plugin = self._repository.get_plugin_for_path(doc.id_)
+        if not plugin:
+            return None
+        splitter = self._repository.get_splitter_cached(plugin)
+        try:
+            return splitter.get_nodes_from_documents([doc])
+        except Exception as exc:
+            logger.warning(
+                "Could not parse code with language %s for file %s: %s",
+                plugin.get_name(),
+                doc.id_,
+                exc,
+            )
+            return None
+
     def update_index(self, patch_text):
         embed_model_code, embed_model_docs = self._get_embedding_models()
         try:
@@ -198,26 +216,26 @@ class IndexingService:
                     id_=doc_id,
                 )
 
+                nodes = self._split_updated_document(
+                    doc,
+                    language_name,
+                    doc_splitter,
+                )
+                if nodes is None:
+                    continue
                 if diff_file.is_added_file:
-                    if language_name is not None:
-                        plugin = self._repository.get_plugin_for_path(doc_id)
-                        if not plugin:
-                            continue
-                        splitter = self._repository.get_splitter_cached(plugin)
-                        try:
-                            nodes = splitter.get_nodes_from_documents([doc])
-                        except Exception as e:
-                            logger.warning(
-                                "Could not parse code with language %s for file %s: %s",
-                                plugin.get_name(),
-                                doc.id_,
-                                e,
-                            )
-                            continue
-                    else:
-                        nodes = doc_splitter.get_nodes_from_documents([doc])
                     target_index.insert_nodes(nodes)
                 else:
-                    target_index.refresh_ref_docs([doc])
+                    embed_model = (
+                        embed_model_code
+                        if language_name is not None
+                        else embed_model_docs
+                    )
+                    self._config.vector_backend.replace_ref_doc(
+                        target_index,
+                        doc_id,
+                        nodes,
+                        embed_model=embed_model,
+                    )
                 target_index.docstore.set_document_hash(doc.id_, doc.hash)
         logger.info("Index update complete based on the provided patch diff.")

--- a/src/metis/vector_store/base.py
+++ b/src/metis/vector_store/base.py
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 
 
 class BaseVectorStore(ABC):
     @abstractmethod
     def init(self):
         """Initialize vector storage components (e.g., vector store and storage context)."""
-        pass
 
     @abstractmethod
     def get_retrievers(
@@ -19,7 +19,6 @@ class BaseVectorStore(ABC):
         callbacks=None,
     ):
         """Return tuple of LangChain-style retrievers (code, docs)."""
-        pass
 
     @abstractmethod
     def index_nodes(
@@ -32,7 +31,6 @@ class BaseVectorStore(ABC):
         **embed_model_kwargs,
     ):
         """Write prepared code and docs nodes to the vector backend."""
-        pass
 
     @abstractmethod
     def get_index_handles(
@@ -43,8 +41,7 @@ class BaseVectorStore(ABC):
         **embed_model_kwargs,
     ):
         """Return mutable index handles (code, docs) for patch updates."""
-        pass
 
     def close(self):
         """Best-effort resource cleanup hook for vector backends."""
-        return None
+        return

--- a/src/metis/vector_store/base.py
+++ b/src/metis/vector_store/base.py
@@ -1,14 +1,24 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
+
+from llama_index.core import VectorStoreIndex
+from llama_index.core.indices.utils import embed_nodes
+from llama_index.core.vector_stores import MetadataFilter
+from llama_index.core.vector_stores import MetadataFilters
+
+from metis.exceptions import RetrieverInitError
+from metis.vector_store.retrievers import LlamaIndexNodeRetriever
+from metis.vector_store.retrievers import QueryAnswerRetriever
+from metis.vector_store.retrievers import query_chat_model_kwargs
 
 
 class BaseVectorStore(ABC):
     @abstractmethod
     def init(self):
         """Initialize vector storage components (e.g., vector store and storage context)."""
-        pass
 
     @abstractmethod
     def get_retrievers(
@@ -19,7 +29,6 @@ class BaseVectorStore(ABC):
         callbacks=None,
     ):
         """Return tuple of LangChain-style retrievers (code, docs)."""
-        pass
 
     @abstractmethod
     def index_nodes(
@@ -32,7 +41,6 @@ class BaseVectorStore(ABC):
         **embed_model_kwargs,
     ):
         """Write prepared code and docs nodes to the vector backend."""
-        pass
 
     @abstractmethod
     def get_index_handles(
@@ -43,8 +51,124 @@ class BaseVectorStore(ABC):
         **embed_model_kwargs,
     ):
         """Return mutable index handles (code, docs) for patch updates."""
-        pass
+
+    def replace_ref_doc(self, index, ref_doc_id, nodes, *, embed_model):
+        """Replace one document without deleting its existing nodes first."""
+
+        filters = MetadataFilters(
+            filters=[MetadataFilter(key="ref_doc_id", value=ref_doc_id)]
+        )
+        old_nodes = index.vector_store.get_nodes(None, filters=filters)
+
+        embeddings = embed_nodes(nodes, embed_model)
+        embedded_nodes = []
+        for node in nodes:
+            embedded_node = node.model_copy()
+            embedded_node.embedding = embeddings[node.node_id]
+            embedded_nodes.append(embedded_node)
+
+        index.insert_nodes(embedded_nodes)
+
+        new_node_ids = {node.node_id for node in embedded_nodes}
+        stale_node_ids = [
+            node.node_id for node in old_nodes if node.node_id not in new_node_ids
+        ]
+        if stale_node_ids:
+            index.vector_store.delete_nodes(node_ids=stale_node_ids)
 
     def close(self):
         """Best-effort resource cleanup hook for vector backends."""
-        return None
+
+
+class LlamaIndexVectorBackend(BaseVectorStore):
+    """Shared behavior for backends exposed through LlamaIndex vector stores."""
+
+    def get_retrievers(
+        self,
+        llm_provider,
+        similarity_top_k,
+        callback_manager=None,
+        callbacks=None,
+    ):
+        try:
+            indexes = self._index_handles(callback_manager=callback_manager)
+            chat_model_kwargs = query_chat_model_kwargs(
+                self.query_config,
+                callbacks=callbacks,
+            )
+            return tuple(
+                QueryAnswerRetriever(
+                    LlamaIndexNodeRetriever(
+                        index.as_retriever(similarity_top_k=similarity_top_k)
+                    ),
+                    llm_provider,
+                    chat_model_kwargs=chat_model_kwargs,
+                )
+                for index in indexes
+            )
+        except Exception as exc:
+            raise RetrieverInitError() from exc
+
+    def index_nodes(
+        self,
+        nodes_code,
+        nodes_docs,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        for nodes, storage_context, embed_model in zip(
+            (nodes_code, nodes_docs),
+            self.get_storage_contexts(),
+            (embed_model_code, embed_model_docs),
+            strict=True,
+        ):
+            VectorStoreIndex(
+                nodes,
+                storage_context=storage_context,
+                embed_model=embed_model,
+                **embed_model_kwargs,
+            )
+
+    def get_index_handles(
+        self,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        return self._index_handles(
+            embed_models=(embed_model_code, embed_model_docs),
+            **embed_model_kwargs,
+        )
+
+    def _index_handles(
+        self,
+        *,
+        embed_models=None,
+        callback_manager=None,
+        **embed_model_kwargs,
+    ):
+        embed_models = embed_models or (
+            self.embed_model_code,
+            self.embed_model_docs,
+        )
+        return tuple(
+            VectorStoreIndex.from_vector_store(
+                vector_store,
+                storage_context=storage_context,
+                embed_model=embed_model,
+                callback_manager=callback_manager,
+                **embed_model_kwargs,
+            )
+            for vector_store, storage_context, embed_model in zip(
+                (self.vector_store_code, self.vector_store_docs),
+                self.get_storage_contexts(),
+                embed_models,
+                strict=True,
+            )
+        )
+
+    def get_storage_contexts(self):
+        return self.storage_context_code, self.storage_context_docs

--- a/src/metis/vector_store/chroma_store.py
+++ b/src/metis/vector_store/chroma_store.py
@@ -6,16 +6,16 @@ from threading import RLock
 
 from chromadb import PersistentClient
 from chromadb.config import Settings
-from llama_index.core import StorageContext, VectorStoreIndex
+from llama_index.core import StorageContext
+from llama_index.core import VectorStoreIndex
 from llama_index.vector_stores.chroma import ChromaVectorStore
 
-from metis.exceptions import RetrieverInitError, VectorStoreInitError
+from metis.exceptions import RetrieverInitError
+from metis.exceptions import VectorStoreInitError
 from metis.vector_store.base import BaseVectorStore
-from metis.vector_store.retrievers import (
-    ChromaCollectionRetriever,
-    QueryAnswerRetriever,
-    query_chat_model_kwargs,
-)
+from metis.vector_store.retrievers import ChromaCollectionRetriever
+from metis.vector_store.retrievers import QueryAnswerRetriever
+from metis.vector_store.retrievers import query_chat_model_kwargs
 
 logger = logging.getLogger(__name__)
 

--- a/src/metis/vector_store/llama_index_backend.py
+++ b/src/metis/vector_store/llama_index_backend.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from llama_index.core import VectorStoreIndex
+
+from metis.exceptions import RetrieverInitError
+from metis.vector_store.base import BaseVectorStore
+from metis.vector_store.retrievers import LlamaIndexNodeRetriever
+from metis.vector_store.retrievers import QueryAnswerRetriever
+from metis.vector_store.retrievers import query_chat_model_kwargs
+
+
+class LlamaIndexVectorBackend(BaseVectorStore):
+    """Shared behavior for backends exposed through LlamaIndex vector stores."""
+
+    index_class = VectorStoreIndex
+
+    def get_retrievers(
+        self,
+        llm_provider,
+        similarity_top_k,
+        callback_manager=None,
+        callbacks=None,
+    ):
+        try:
+            indexes = self._index_handles(callback_manager=callback_manager)
+            chat_model_kwargs = query_chat_model_kwargs(
+                self.query_config,
+                callbacks=callbacks,
+            )
+            return tuple(
+                QueryAnswerRetriever(
+                    LlamaIndexNodeRetriever(
+                        index.as_retriever(similarity_top_k=similarity_top_k)
+                    ),
+                    llm_provider,
+                    chat_model_kwargs=chat_model_kwargs,
+                )
+                for index in indexes
+            )
+        except Exception as exc:
+            raise RetrieverInitError() from exc
+
+    def index_nodes(
+        self,
+        nodes_code,
+        nodes_docs,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        for nodes, storage_context, embed_model in zip(
+            (nodes_code, nodes_docs),
+            self.get_storage_contexts(),
+            (embed_model_code, embed_model_docs),
+            strict=True,
+        ):
+            self.index_class(
+                nodes,
+                storage_context=storage_context,
+                embed_model=embed_model,
+                **embed_model_kwargs,
+            )
+
+    def get_index_handles(
+        self,
+        *,
+        embed_model_code,
+        embed_model_docs,
+        **embed_model_kwargs,
+    ):
+        return self._index_handles(
+            embed_models=(embed_model_code, embed_model_docs),
+            **embed_model_kwargs,
+        )
+
+    def _index_handles(
+        self,
+        *,
+        embed_models=None,
+        callback_manager=None,
+        **embed_model_kwargs,
+    ):
+        embed_models = embed_models or (
+            self.embed_model_code,
+            self.embed_model_docs,
+        )
+        return tuple(
+            self.index_class.from_vector_store(
+                vector_store,
+                storage_context=storage_context,
+                embed_model=embed_model,
+                callback_manager=callback_manager,
+                **embed_model_kwargs,
+            )
+            for vector_store, storage_context, embed_model in zip(
+                (self.vector_store_code, self.vector_store_docs),
+                self.get_storage_contexts(),
+                embed_models,
+                strict=True,
+            )
+        )
+
+    def get_storage_contexts(self):
+        return self.storage_context_code, self.storage_context_docs

--- a/src/metis/vector_store/pgvector_store.py
+++ b/src/metis/vector_store/pgvector_store.py
@@ -1,21 +1,17 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from llama_index.core import StorageContext, VectorStoreIndex
-from sqlalchemy import create_engine, text
-from metis.exceptions import (
-    VectorStoreInitError,
-    RetrieverInitError,
-    VectorSchemaError,
-)
-from metis.vector_store.base import BaseVectorStore
-from metis.vector_store.retrievers import LlamaIndexNodeRetriever, QueryAnswerRetriever
-from metis.vector_store.retrievers import query_chat_model_kwargs
+import logging
+
+from llama_index.core import StorageContext
 from llama_index.vector_stores.postgres import PGVectorStore
+from sqlalchemy import create_engine
+from sqlalchemy import text
 from sqlalchemy.engine.url import make_url
 
-
-import logging
+from metis.exceptions import VectorSchemaError
+from metis.exceptions import VectorStoreInitError
+from metis.vector_store.llama_index_backend import LlamaIndexVectorBackend
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +40,7 @@ def copy_hnsw_kwargs(hnsw_kwargs):
     return hnsw_kwargs.copy()
 
 
-class PGVectorStoreImpl(BaseVectorStore):
+class PGVectorStoreImpl(LlamaIndexVectorBackend):
     def __init__(
         self,
         connection_string,
@@ -114,95 +110,6 @@ class PGVectorStoreImpl(BaseVectorStore):
         except Exception as e:
             logger.error(f"Error initializing PGVectorStore: {e}")
             raise VectorStoreInitError()
-
-    def get_retrievers(
-        self,
-        llm_provider,
-        similarity_top_k,
-        callback_manager=None,
-        callbacks=None,
-    ):
-        try:
-            index_code = VectorStoreIndex.from_vector_store(
-                self.vector_store_code,
-                storage_context=self.storage_context_code,
-                embed_model=self.embed_model_code,
-                callback_manager=callback_manager,
-            )
-            index_docs = VectorStoreIndex.from_vector_store(
-                self.vector_store_docs,
-                storage_context=self.storage_context_docs,
-                embed_model=self.embed_model_docs,
-                callback_manager=callback_manager,
-            )
-            chat_model_kwargs = query_chat_model_kwargs(
-                self.query_config,
-                callbacks=callbacks,
-            )
-            retriever_code = QueryAnswerRetriever(
-                LlamaIndexNodeRetriever(
-                    index_code.as_retriever(similarity_top_k=similarity_top_k)
-                ),
-                llm_provider,
-                chat_model_kwargs=chat_model_kwargs,
-            )
-            retriever_docs = QueryAnswerRetriever(
-                LlamaIndexNodeRetriever(
-                    index_docs.as_retriever(similarity_top_k=similarity_top_k)
-                ),
-                llm_provider,
-                chat_model_kwargs=chat_model_kwargs,
-            )
-            return (retriever_code, retriever_docs)
-        except Exception as e:
-            logger.error(f"Error creating PG retrievers: {e}")
-            raise RetrieverInitError()
-
-    def index_nodes(
-        self,
-        nodes_code,
-        nodes_docs,
-        *,
-        embed_model_code,
-        embed_model_docs,
-        **embed_model_kwargs,
-    ):
-        VectorStoreIndex(
-            nodes_code,
-            storage_context=self.storage_context_code,
-            embed_model=embed_model_code,
-            **embed_model_kwargs,
-        )
-        VectorStoreIndex(
-            nodes_docs,
-            storage_context=self.storage_context_docs,
-            embed_model=embed_model_docs,
-            **embed_model_kwargs,
-        )
-
-    def get_index_handles(
-        self,
-        *,
-        embed_model_code,
-        embed_model_docs,
-        **embed_model_kwargs,
-    ):
-        index_code = VectorStoreIndex.from_vector_store(
-            self.vector_store_code,
-            storage_context=self.storage_context_code,
-            embed_model=embed_model_code,
-            **embed_model_kwargs,
-        )
-        index_docs = VectorStoreIndex.from_vector_store(
-            self.vector_store_docs,
-            storage_context=self.storage_context_docs,
-            embed_model=embed_model_docs,
-            **embed_model_kwargs,
-        )
-        return index_code, index_docs
-
-    def get_storage_contexts(self):
-        return self.storage_context_code, self.storage_context_docs
 
     def check_project_schema_exists(self):
         engine = None

--- a/src/metis/vector_store/pgvector_store.py
+++ b/src/metis/vector_store/pgvector_store.py
@@ -1,21 +1,17 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from llama_index.core import StorageContext, VectorStoreIndex
-from sqlalchemy import create_engine, text
-from metis.exceptions import (
-    VectorStoreInitError,
-    RetrieverInitError,
-    VectorSchemaError,
-)
-from metis.vector_store.base import BaseVectorStore
-from metis.vector_store.retrievers import LlamaIndexNodeRetriever, QueryAnswerRetriever
-from metis.vector_store.retrievers import query_chat_model_kwargs
+import logging
+
+from llama_index.core import StorageContext
 from llama_index.vector_stores.postgres import PGVectorStore
+from sqlalchemy import create_engine
+from sqlalchemy import text
 from sqlalchemy.engine.url import make_url
 
-
-import logging
+from metis.exceptions import VectorSchemaError
+from metis.exceptions import VectorStoreInitError
+from metis.vector_store.base import LlamaIndexVectorBackend
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +40,7 @@ def copy_hnsw_kwargs(hnsw_kwargs):
     return hnsw_kwargs.copy()
 
 
-class PGVectorStoreImpl(BaseVectorStore):
+class PGVectorStoreImpl(LlamaIndexVectorBackend):
     def __init__(
         self,
         connection_string,
@@ -114,95 +110,6 @@ class PGVectorStoreImpl(BaseVectorStore):
         except Exception as e:
             logger.error(f"Error initializing PGVectorStore: {e}")
             raise VectorStoreInitError()
-
-    def get_retrievers(
-        self,
-        llm_provider,
-        similarity_top_k,
-        callback_manager=None,
-        callbacks=None,
-    ):
-        try:
-            index_code = VectorStoreIndex.from_vector_store(
-                self.vector_store_code,
-                storage_context=self.storage_context_code,
-                embed_model=self.embed_model_code,
-                callback_manager=callback_manager,
-            )
-            index_docs = VectorStoreIndex.from_vector_store(
-                self.vector_store_docs,
-                storage_context=self.storage_context_docs,
-                embed_model=self.embed_model_docs,
-                callback_manager=callback_manager,
-            )
-            chat_model_kwargs = query_chat_model_kwargs(
-                self.query_config,
-                callbacks=callbacks,
-            )
-            retriever_code = QueryAnswerRetriever(
-                LlamaIndexNodeRetriever(
-                    index_code.as_retriever(similarity_top_k=similarity_top_k)
-                ),
-                llm_provider,
-                chat_model_kwargs=chat_model_kwargs,
-            )
-            retriever_docs = QueryAnswerRetriever(
-                LlamaIndexNodeRetriever(
-                    index_docs.as_retriever(similarity_top_k=similarity_top_k)
-                ),
-                llm_provider,
-                chat_model_kwargs=chat_model_kwargs,
-            )
-            return (retriever_code, retriever_docs)
-        except Exception as e:
-            logger.error(f"Error creating PG retrievers: {e}")
-            raise RetrieverInitError()
-
-    def index_nodes(
-        self,
-        nodes_code,
-        nodes_docs,
-        *,
-        embed_model_code,
-        embed_model_docs,
-        **embed_model_kwargs,
-    ):
-        VectorStoreIndex(
-            nodes_code,
-            storage_context=self.storage_context_code,
-            embed_model=embed_model_code,
-            **embed_model_kwargs,
-        )
-        VectorStoreIndex(
-            nodes_docs,
-            storage_context=self.storage_context_docs,
-            embed_model=embed_model_docs,
-            **embed_model_kwargs,
-        )
-
-    def get_index_handles(
-        self,
-        *,
-        embed_model_code,
-        embed_model_docs,
-        **embed_model_kwargs,
-    ):
-        index_code = VectorStoreIndex.from_vector_store(
-            self.vector_store_code,
-            storage_context=self.storage_context_code,
-            embed_model=embed_model_code,
-            **embed_model_kwargs,
-        )
-        index_docs = VectorStoreIndex.from_vector_store(
-            self.vector_store_docs,
-            storage_context=self.storage_context_docs,
-            embed_model=embed_model_docs,
-            **embed_model_kwargs,
-        )
-        return index_code, index_docs
-
-    def get_storage_contexts(self):
-        return self.storage_context_code, self.storage_context_docs
 
     def check_project_schema_exists(self):
         engine = None

--- a/src/metis/vector_store/qdrant_store.py
+++ b/src/metis/vector_store/qdrant_store.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from contextlib import suppress
+
+from llama_index.core import StorageContext
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance
+from qdrant_client.models import VectorParams
+
+from metis.exceptions import VectorStoreInitError
+from metis.vector_store.base import LlamaIndexVectorBackend
+
+
+class QdrantStore(LlamaIndexVectorBackend):
+    def __init__(
+        self,
+        *,
+        url: str,
+        api_key: str | None,
+        collection_prefix: str,
+        embed_dim: int,
+        embed_model_code,
+        embed_model_docs,
+        query_config=None,
+    ) -> None:
+        self.url = url
+        self.api_key = api_key
+        self.collection_prefix = collection_prefix
+        self.embed_dim = embed_dim
+        self.embed_model_code = embed_model_code
+        self.embed_model_docs = embed_model_docs
+        self.query_config = query_config or {}
+        self._client: QdrantClient | None = None
+
+    def init(self) -> None:
+        if self._client is not None:
+            return
+        try:
+            self._client = QdrantClient(url=self.url, api_key=self.api_key)
+            self._configure_stores()
+        except Exception as exc:
+            self.close()
+            raise VectorStoreInitError() from exc
+
+    def _configure_stores(self) -> None:
+        assert self._client is not None
+        for kind in ("code", "docs"):
+            name = f"{self.collection_prefix}_{kind}"
+            if self._client.collection_exists(name):
+                continue
+            self._client.create_collection(
+                collection_name=name,
+                vectors_config=VectorParams(
+                    size=self.embed_dim,
+                    distance=Distance.COSINE,
+                ),
+            )
+
+        stores = tuple(
+            QdrantVectorStore(
+                client=self._client,
+                collection_name=f"{self.collection_prefix}_{kind}",
+            )
+            for kind in ("code", "docs")
+        )
+        self.vector_store_code, self.vector_store_docs = stores
+        self.storage_context_code, self.storage_context_docs = tuple(
+            StorageContext.from_defaults(vector_store=store) for store in stores
+        )
+
+    def reset_index(self) -> None:
+        self.init()
+        assert self._client is not None
+        for kind in ("code", "docs"):
+            name = f"{self.collection_prefix}_{kind}"
+            if self._client.collection_exists(name):
+                self._client.delete_collection(name)
+        self._configure_stores()
+
+    def close(self) -> None:
+        if self._client is not None:
+            with suppress(Exception):
+                self._client.close()
+        self._client = None

--- a/src/metis/vector_store/qdrant_store.py
+++ b/src/metis/vector_store/qdrant_store.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from contextlib import suppress
+
+from llama_index.core import StorageContext
+from llama_index.core import VectorStoreIndex
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance
+from qdrant_client.models import VectorParams
+
+from metis.vector_store.llama_index_backend import LlamaIndexVectorBackend
+
+
+class QdrantVectorStoreIndex(VectorStoreIndex):
+    """Vector index that updates documents stored in Qdrant."""
+
+    def refresh_ref_docs(self, documents, **update_kwargs):
+        for document in documents:
+            self.update_ref_doc(
+                document,
+                **update_kwargs.get("update_kwargs", {}),
+            )
+        return [True] * len(documents)
+
+
+class QdrantStore(LlamaIndexVectorBackend):
+    index_class = QdrantVectorStoreIndex
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        api_key: str | None,
+        collection_prefix: str,
+        embed_dim: int,
+        embed_model_code,
+        embed_model_docs,
+        query_config=None,
+    ) -> None:
+        self.url = url
+        self.api_key = api_key
+        self.collection_prefix = collection_prefix
+        self.embed_dim = embed_dim
+        self.embed_model_code = embed_model_code
+        self.embed_model_docs = embed_model_docs
+        self.query_config = query_config or {}
+        self._client: QdrantClient | None = None
+
+    def init(self) -> None:
+        if self._client is not None:
+            return
+        client = QdrantClient(url=self.url, api_key=self.api_key)
+        components = self._build_store_components(client)
+
+        (
+            self.vector_store_code,
+            self.vector_store_docs,
+            self.storage_context_code,
+            self.storage_context_docs,
+        ) = components
+        self._client = client
+
+    def _build_store_components(self, client: QdrantClient):
+        for kind in ("code", "docs"):
+            name = f"{self.collection_prefix}_{kind}"
+            if client.collection_exists(name):
+                continue
+
+            client.create_collection(
+                collection_name=name,
+                vectors_config=VectorParams(
+                    size=self.embed_dim,
+                    distance=Distance.COSINE,
+                ),
+            )
+
+        stores = tuple(
+            QdrantVectorStore(
+                client=client,
+                collection_name=f"{self.collection_prefix}_{kind}",
+            )
+            for kind in ("code", "docs")
+        )
+        contexts = tuple(
+            StorageContext.from_defaults(vector_store=store) for store in stores
+        )
+        return *stores, *contexts
+
+    def reset_index(self) -> None:
+        self.init()
+        assert self._client is not None
+        for kind in ("code", "docs"):
+            name = f"{self.collection_prefix}_{kind}"
+            if self._client.collection_exists(name):
+                self._client.delete_collection(name)
+        (
+            self.vector_store_code,
+            self.vector_store_docs,
+            self.storage_context_code,
+            self.storage_context_docs,
+        ) = self._build_store_components(self._client)
+
+    def close(self) -> None:
+        if self._client is not None:
+            with suppress(Exception):
+                self._client.close()
+        self._client = None

--- a/tests/test_engine_chroma.py
+++ b/tests/test_engine_chroma.py
@@ -1,14 +1,16 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 import os
 from unittest.mock import patch
-from metis.engine import MetisEngine
-from metis.cli.utils import build_chroma_backend
-from metis.vector_store.chroma_store import ChromaStore
-from llama_index.core.settings import Settings
+
+import pytest
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.settings import Settings
+
+from metis.cli.utils import build_chroma_backend
+from metis.engine import MetisEngine
+from metis.vector_store.chroma_store import ChromaStore
 
 
 @pytest.mark.chroma

--- a/tests/test_qdrant_store.py
+++ b/tests/test_qdrant_store.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+from unittest.mock import call
+
+import pytest
+from qdrant_client.models import Distance
+
+from metis.vector_store import qdrant_store
+from metis.vector_store.qdrant_store import QdrantStore
+from metis.vector_store.qdrant_store import QdrantVectorStoreIndex
+
+
+@pytest.fixture
+def qdrant(monkeypatch):
+    client = Mock()
+    client.collection_exists.return_value = True
+    client_constructor = Mock(return_value=client)
+    stores = (object(), object())
+    contexts = (object(), object())
+    store_constructor = Mock(side_effect=stores)
+    context_constructor = Mock(side_effect=contexts)
+
+    monkeypatch.setattr(qdrant_store, "QdrantClient", client_constructor)
+    monkeypatch.setattr(qdrant_store, "QdrantVectorStore", store_constructor)
+    monkeypatch.setattr(
+        qdrant_store.StorageContext,
+        "from_defaults",
+        context_constructor,
+    )
+
+    backend = QdrantStore(
+        url="http://localhost:6333",
+        api_key="secret",
+        collection_prefix="project",
+        embed_dim=8,
+        embed_model_code=Mock(),
+        embed_model_docs=Mock(),
+    )
+    return SimpleNamespace(
+        backend=backend,
+        client=client,
+        client_constructor=client_constructor,
+        stores=stores,
+        contexts=contexts,
+        context_constructor=context_constructor,
+    )
+
+
+def test_init_creates_collections_once(qdrant):
+    qdrant.client.collection_exists.side_effect = [False, True]
+
+    qdrant.backend.init()
+    qdrant.backend.init()
+
+    qdrant.client_constructor.assert_called_once_with(
+        url="http://localhost:6333",
+        api_key="secret",
+    )
+    create_kwargs = qdrant.client.create_collection.call_args.kwargs
+    assert create_kwargs["collection_name"] == "project_code"
+    assert create_kwargs["vectors_config"].size == 8
+    assert create_kwargs["vectors_config"].distance == Distance.COSINE
+    assert (
+        qdrant.backend.vector_store_code,
+        qdrant.backend.vector_store_docs,
+    ) == qdrant.stores
+    assert qdrant.backend.get_storage_contexts() == qdrant.contexts
+
+
+def test_failed_init_does_not_publish_partial_state(qdrant):
+    qdrant.context_constructor.side_effect = RuntimeError("context failure")
+
+    with pytest.raises(RuntimeError, match="context failure"):
+        qdrant.backend.init()
+
+    assert qdrant.backend._client is None
+    assert not hasattr(qdrant.backend, "vector_store_code")
+    assert not hasattr(qdrant.backend, "storage_context_code")
+
+
+def test_refresh_replaces_qdrant_documents():
+    index = Mock()
+    documents = [Mock(), Mock()]
+
+    refreshed = QdrantVectorStoreIndex.refresh_ref_docs(index, documents)
+
+    assert index.update_ref_doc.call_args_list == [
+        call(documents[0]),
+        call(documents[1]),
+    ]
+    assert refreshed == [True, True]


### PR DESCRIPTION
## Description

This PR adds support for using Qdrant as an optional vector search provider in Metis.

[Qdrant](https://qdrant.tech) is an open-source vector search engine built for high-peformance and massive scale.

### Testing

I've unit tested this integration against a local Qdrant instance.

### Setup

You can run Qdrant with 

```bash
docker run -p 6333:6333 qdrant/qdrant
```

The dashboard is accessible at http://localhost:6333/dashboard.

You can then configure Metis with:

```bash
uv pip install '.[qdrant]'
```

```bash
metis --backend qdrant --project-schema myproject
```

Metis will connect to http://localhost:6333 by default. Also supports custom Qdrant URLs and API keys if needed.