### PR TITLE
feat(runlog): add explainable workflow tracing for CLI and engine runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 .python-version
 uv.lock
 results/
+/metis-runlog/
 /local-tests/
 /metis*.yaml
 /metis*.yml

--- a/README.md
+++ b/README.md
@@ -219,9 +219,14 @@ Metis also provides an interactive CLI with several built-in commands:
 - `--verbose` – show the stages and nodes executed by the selected graph.
 - `--log-level` – configure Python logging independently of graph progress.
 - `--quiet`, `--output-file`, `--output-files` – control console and export output.
+- `--log-workflow-debug` – write a full local workflow trace containing prompts,
+  model responses, tool calls, decisions, usage, and execution lifecycle data.
+- `--log-workflow-debug-path PATH` – choose the trace directory or a new exact
+  `.ndjson` path; this also enables workflow tracing.
 
 See the [execution graph guide](docs/execution-graph.md) for stage, node, and
-output configuration. See
+output configuration, the [workflow run-log format](docs/workflow-log-format.md)
+for local trace capture, and
 [adding a capability](docs/capabilities/adding-capability.md) for shared runtime
 services and model-tool adapters.
 

--- a/docs/workflow-log-format.md
+++ b/docs/workflow-log-format.md
@@ -1,0 +1,268 @@
+# Workflow run-log format v1
+
+Metis can write a local, append-only trace of a CLI session or programmatic
+engine run. The trace records execution topology, stages, nodes, parallel tasks,
+inner workflows, prompts, physical model calls, tool calls, decisions, usage,
+and produced artifacts.
+
+Run logging is opt-in because full traces can contain source code, prompts,
+model responses, tool output, file paths, and findings.
+
+## CLI
+
+```bash
+metis --log-workflow-debug [--log-workflow-debug-path PATH] ...
+```
+
+`--log-workflow-debug-path` implies `--log-workflow-debug`. `PATH` may be:
+
+- a directory, under which Metis creates a timestamped run directory; or
+- a new path ending in `.ndjson`, which Metis uses exactly.
+
+Metis never appends a new run to an existing NDJSON file. An existing exact
+path is an error.
+
+Without a path override, bundles are written below `./metis-runlog/`.
+
+## Programmatic API
+
+```python
+from metis.engine import MetisEngine
+from metis.runlog import RunLogConfig, build_run_metadata, open_runlog
+
+config = RunLogConfig(path="traces", content="full")
+metadata = build_run_metadata(
+    metis_version="1.5.0",
+    codebase_path="/path/to/repository",
+)
+
+with open_runlog(config, metadata=metadata) as session:
+    engine = MetisEngine(
+        codebase_path="/path/to/repository",
+        runlog=session,
+        # normal engine configuration follows
+    )
+    result = engine.execute_graph()
+```
+
+A session can contain multiple command or execution spans. Context is
+propagated into Metis worker pools through the existing context-copying worker
+helper.
+
+Complete bundles can be checked before consumption:
+
+```python
+from metis.runlog import validate_runlog
+
+summary = validate_runlog(session.ndjson_path)
+```
+
+Validation checks required envelope fields, ordering and identity, root and child
+span lifecycle, event containment, metadata completion/status, and the byte
+count and SHA-256 digest of every referenced blob.
+
+## Bundle layout
+
+Directory output uses:
+
+```text
+<run-directory>/
+  run.ndjson
+  meta.json
+  blobs/
+```
+
+For an exact `trace.ndjson` path, metadata is stored in
+`trace.ndjson.meta.json` and blobs in `trace.blobs/`.
+
+`meta.json` is initially written with `complete: false` and is atomically
+updated when the session closes. A process crash can leave it incomplete while
+`run.ndjson` remains readable through its last complete line.
+
+Trace directories use private directory permissions and trace/blob files use
+private file permissions.
+
+## Record envelope
+
+Every NDJSON line is one JSON object with these fields:
+
+| Field | Meaning |
+| --- | --- |
+| `v` | Schema version, currently `1` |
+| `record` | `span.start`, `span.end`, or `event` |
+| `record_id` | Unique identity for this line |
+| `ts` | UTC wall-clock timestamp |
+| `mono_ns` | Process monotonic timestamp |
+| `seq` | Contiguous, authoritative line ordering within the run |
+| `run_id` | Identity shared by every record in the bundle |
+| `span_id` | Span being started/ended, or containing span for an event |
+| `name` | Stable operation or event name |
+| `explanation` | Stable human-readable description of what the span or event does |
+| `thread`, `thread_id` | Emitting thread identity |
+| `attributes` | Type-specific JSON payload |
+
+Span records additionally contain `kind` and `parent_span_id`. Span end records
+contain `status` and `duration_ms`, and may contain `error`.
+
+Point events are not spans. They have their own `record_id`, refer to their
+containing `span_id`, and do not contain `parent_span_id`. This prevents cycles
+in the visualized span tree.
+
+Sequence allocation and line writing happen under one lock. Therefore line
+number and `seq` order agree even when worker threads emit concurrently.
+
+### Explanations
+
+Every record has a non-empty top-level `explanation`. It is written from the
+perspective of someone reading the completed trace: what the record represents
+or what was done. The visualizer can display it directly without translating
+implementation-oriented recorder language. Span start and end records carry
+the same explanation.
+
+Metis resolves default explanations from the span `kind` and `name`, or from the
+event name. Progress events additionally use `attributes.event`, so a generic
+`progress` record can explain a specific marker such as
+`global_lifecycle_start`. Unknown extension names receive a generic explanation
+instead of omitting the field.
+
+Instrumentation may override the catalogue text when a call site needs more
+specific help:
+
+```python
+with runlog.span(
+    "task",
+    "custom_policy_check",
+    explanation="One finding checked against the installed policy rules.",
+):
+    ...
+```
+
+`explanation` describes the operation or observed action. Dynamic state,
+counts, inputs, and outputs remain under `attributes`.
+
+## Span hierarchy
+
+A complete configured run normally has this shape:
+
+```text
+run
+└─ command
+   └─ execution
+      └─ stage
+         └─ node
+            └─ task
+               └─ workflow
+                  └─ step
+                     └─ prompt
+                        └─ attempt
+                           ├─ llm.call
+                           └─ model_loop
+                              └─ tool
+```
+
+Not every operation requires every level. For example, a deterministic node
+may have no tasks or prompts.
+
+### Stable span kinds
+
+- `run`: one bundle lifecycle
+- `command`: one interactive, non-interactive, or default graph command
+- `execution`: a configured graph, standalone stage, or ask execution
+- `stage`: initialize, review, or triage
+- `node`: one selected `NodeRegistration`
+- `task`: one parallel file, finding, or reachability job
+- `workflow`: an inner LangGraph invocation
+- `step`: one inner-workflow node
+- `prompt`: one logical prompt and parsing contract
+- `attempt`: one retry-policy attempt
+- `llm.call`: one physical provider invocation
+- `model_loop`: a model/tool interaction loop
+- `tool`: one model-requested tool invocation
+- `retrieval`: one vector retrieval operation
+- `memory`: one semantic repository-memory operation
+- `threat_context`: threat-model policy retrieval and application
+
+Logical prompts and physical model calls are deliberately separate. Structured
+output fallback, retries, and model/tool rounds may cause more than one
+`llm.call` under one `prompt`.
+
+## Point events
+
+Metis currently emits these stable event names:
+
+- `execution.topology`: configured stage and node graph
+- `progress`: engine/node progress callback payload
+- `debug`: node debug callback payload
+- `checkpoint`: triage checkpoint metadata
+- `diagnostic`: execution or node diagnostic
+- `retry`: retry reason and backoff
+- `model.round`: one response in a model/tool loop
+- `usage`: token usage for one physical model call
+- `decision`: deterministic or policy-driven decision
+- `artifact`: in-memory review, triage, or threat-model result
+- `artifact.written`: output path, format, byte count, and SHA-256 digest
+
+Consumers must ignore unknown event names, span kinds, and attributes.
+
+## Content and blobs
+
+The default explicit debug mode is `full`. Large strings and JSON values are
+replaced with a content-addressed reference:
+
+```json
+{
+  "$ref": "blobs/<sha256>.json",
+  "bytes": 12345,
+  "sha256": "<sha256>",
+  "media_type": "application/json",
+  "preview": "..."
+}
+```
+
+Blob writes use a temporary file and atomic replacement. Identical content is
+stored once per bundle.
+
+`RunLogConfig(content="metadata")` records hashes and previews but omits blob
+content. It is available to programmatic callers even though the CLI debug flag
+selects full content.
+
+Serialization is bounded by configured recursion and collection limits. Cycles
+and truncated values are represented explicitly instead of failing the run.
+
+## Redaction and security
+
+Known configuration keys such as API keys, tokens, passwords, authorization,
+credentials, and secrets are replaced with:
+
+```json
+{"$redacted": true, "sha256": "<sha256>"}
+```
+
+Sensitive command-line flag values are also redacted. Redaction cannot infer
+secrets embedded in source code, prompts, responses, or tool output. Treat full
+bundles as sensitive project data and apply the same retention and access policy
+as the reviewed source repository.
+
+## Failure behavior
+
+Failure to create an explicitly requested trace is fatal before analysis starts.
+After the run starts, a trace serialization or write failure disables further
+telemetry and emits one warning; it does not change execution results. The
+metadata file remains incomplete when possible.
+
+Span context managers record uncaught exceptions with type, message, and
+traceback. Keyboard interruption records a cancelled outcome. Caught execution
+failures are recorded from their returned status or diagnostic before the run
+closes.
+
+## External execution nodes
+
+The Execution Node API remains version 1. Separately distributed nodes appear
+as opaque `node` spans. Metis automatically records:
+
+- the node boundary and validated inputs/outputs;
+- calls made through `invocation.context.prompts`;
+- progress, debug, checkpoint, and diagnostic callbacks.
+
+External nodes do not receive the internal span authoring API. A future public
+trace sink would require a versioned Execution Node API change.

--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -20,6 +20,7 @@ from metis.usage import UsageRuntime
 from metis.utils import read_file_content
 from metis.providers.registry import get_chat_provider
 from metis.providers.registry import get_embedding_provider
+from metis import runlog
 
 try:
     from metis.vector_store.pgvector_store import PGVectorStoreImpl
@@ -42,6 +43,7 @@ from .utils import (
     save_output,
     output_format,
     output_files_for_formats,
+    workflow_debug_context,
 )
 
 logging.captureWarnings(True)
@@ -230,6 +232,7 @@ def build_engine(args, runtime):
         vector_backend=vector_backend,
         custom_prompt_text=resolve_custom_prompt(args),
         usage_runtime=usage_runtime,
+        runlog=getattr(args, "_metis_runlog", None),
         **engine_runtime,
     )
     return engine, vector_backend
@@ -287,6 +290,18 @@ def _prepare_command_runtime(cmd, cmd_args, args):
 
 
 def execute_command(engine, cmd, cmd_args, args):
+    with runlog.span(
+        "command",
+        cmd,
+        lambda: {
+            "arguments": list(cmd_args),
+            "interactive": not bool(getattr(args, "non_interactive", False)),
+        },
+    ):
+        return _execute_command(engine, cmd, cmd_args, args)
+
+
+def _execute_command(engine, cmd, cmd_args, args):
     if cmd not in COMMANDS:
         print_console(f"[red]Unknown command:[/red] {escape(cmd)}", args.quiet)
         return
@@ -416,6 +431,16 @@ def main():
     parser.add_argument("--log-file", type=str)
     parser.add_argument("--log-level", type=str, default="ERROR")
     parser.add_argument(
+        "--log-workflow-debug",
+        action="store_true",
+        help="Emit a full local NDJSON workflow trace.",
+    )
+    parser.add_argument(
+        "--log-workflow-debug-path",
+        type=str,
+        help="Directory or new .ndjson path for the workflow trace.",
+    )
+    parser.add_argument(
         "--custom-prompt",
         type=str,
         help="Path to a custom prompt file (.md or .txt) used to guide analysis",
@@ -491,53 +516,73 @@ def main():
         raise SystemExit(1)
 
     configure_logger(logger, args)
-    runtime = load_runtime_config(
-        config_path=args.config,
-        enable_psql=(args.backend == "postgres"),
-    )
-    engine, vector_backend = build_engine(args, runtime)
-    exit_code = 0
-    farewell = None
-    try:
-        if graph_requested:
-            try:
-                determine_output_file("graph", args, [])
-                callbacks: dict[str, object] = {
-                    "diagnostic_callback": (
-                        lambda diagnostic: _print_graph_diagnostic(
-                            diagnostic, args.quiet
+    with workflow_debug_context(args) as runlog_session:
+        if runlog_session is not None:
+            args._metis_runlog = runlog_session
+            print_console(
+                f"[blue]Workflow debug log:[/blue] {runlog_session.ndjson_path}",
+                args.quiet,
+            )
+        engine = None
+        vector_backend = None
+        exit_code = 0
+        farewell = None
+        try:
+            runtime = load_runtime_config(
+                config_path=args.config,
+                enable_psql=(args.backend == "postgres"),
+            )
+            engine, vector_backend = build_engine(args, runtime)
+            if graph_requested:
+                with runlog.span(
+                    "command",
+                    "execution_graph",
+                    {"include_triaged": bool(args.include_triaged)},
+                ) as command_span:
+                    try:
+                        determine_output_file("graph", args, [])
+                        callbacks: dict[str, object] = {
+                            "diagnostic_callback": (
+                                lambda diagnostic: _print_graph_diagnostic(
+                                    diagnostic, args.quiet
+                                )
+                            )
+                        }
+                        if args.verbose:
+                            callbacks["progress_callback"] = lambda event: (
+                                _print_graph_progress(event, args.quiet)
+                            )
+                        result = engine.execute_graph(
+                            include_triaged=True if args.include_triaged else None,
+                            callbacks=callbacks,
                         )
-                    )
-                }
-                if args.verbose:
-                    callbacks["progress_callback"] = lambda event: (
-                        _print_graph_progress(event, args.quiet)
-                    )
-                result = engine.execute_graph(
-                    include_triaged=True if args.include_triaged else None,
-                    callbacks=callbacks,
-                )
-                _save_graph_outputs(
-                    args.output_file,
-                    result,
-                    args.quiet,
-                    generated_output=bool(
-                        getattr(args, "_metis_generated_output", False)
-                    ),
-                )
-            except Exception as exc:
-                print_console(
-                    f"[bold red]Error:[/bold red] {escape(str(exc))}",
-                    args.quiet,
-                )
-                exit_code = 1
+                        _save_graph_outputs(
+                            args.output_file,
+                            result,
+                            args.quiet,
+                            generated_output=bool(
+                                getattr(args, "_metis_generated_output", False)
+                            ),
+                        )
+                    except Exception as exc:
+                        command_span.end(status="error", exc=exc)
+                        print_console(
+                            f"[bold red]Error:[/bold red] {escape(str(exc))}",
+                            args.quiet,
+                        )
+                        exit_code = 1
+                    else:
+                        print_console(
+                            "[green]Execution graph complete.[/green]", args.quiet
+                        )
+            elif args.non_interactive:
+                exit_code, farewell = run_non_interactive(engine, args)
             else:
-                print_console("[green]Execution graph complete.[/green]", args.quiet)
-        elif args.non_interactive:
-            exit_code, farewell = run_non_interactive(engine, args)
-        else:
-            farewell = run_interactive_loop(engine, args, vector_backend)
-    finally:
-        finalize_cli_session_and_close(engine, args, farewell)
-    if exit_code:
-        raise SystemExit(exit_code)
+                farewell = run_interactive_loop(engine, args, vector_backend)
+        finally:
+            if engine is not None:
+                finalize_cli_session_and_close(engine, args, farewell)
+        if exit_code:
+            if runlog_session is not None:
+                runlog_session.set_outcome("error")
+            raise SystemExit(exit_code)

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
+import hashlib
 import importlib.metadata
 import json
 import logging
@@ -10,10 +12,15 @@ import tempfile
 import warnings
 from datetime import datetime
 from pathlib import Path
+import sys
 from importlib.resources import files
 
 from rich.console import Console
 from rich.errors import MarkupError
+from metis.runlog import RunLogConfig
+from metis.runlog import build_run_metadata
+from metis.runlog import open_runlog
+from metis import runlog
 from rich.markup import escape
 from rich.progress import (
     Progress,
@@ -97,6 +104,28 @@ def configure_logger(logger, args):
     warnings_logger = logging.getLogger("py.warnings")
     warnings_logger.setLevel(level)
     warnings_logger.propagate = True
+
+
+def workflow_debug_context(args):
+    path_override = getattr(args, "log_workflow_debug_path", None)
+    if not getattr(args, "log_workflow_debug", False) and not path_override:
+        return contextlib.nullcontext(None)
+    metadata = build_run_metadata(
+        argv=list(sys.argv),
+        metis_version=METIS_VERSION,
+        codebase_path=getattr(args, "codebase_path", None),
+        config={
+            "backend": getattr(args, "backend", None),
+            "config_path": getattr(args, "config", None),
+            "log_level": getattr(args, "log_level", None),
+            "non_interactive": getattr(args, "non_interactive", None),
+            "command": getattr(args, "command", None),
+        },
+    )
+    return open_runlog(
+        RunLogConfig(path=path_override, content="full"),
+        metadata=metadata,
+    )
 
 
 def print_console(message, quiet=False, **kwargs):
@@ -324,6 +353,22 @@ def output_files_for_formats(
     return selected
 
 
+def _record_output_artifact(path: str | Path, format_name: str) -> None:
+    output_path = Path(path).resolve()
+    with output_path.open("rb") as handle:
+        digest = hashlib.file_digest(handle, "sha256").hexdigest()
+    runlog.event(
+        "artifact.written",
+        {
+            "kind": "output_file",
+            "format": format_name,
+            "path": str(output_path),
+            "bytes": output_path.stat().st_size,
+            "sha256": digest,
+        },
+    )
+
+
 def save_output(output_files, data, quiet=False, sarif_payload=None):
     if not output_files:
         return
@@ -361,6 +406,7 @@ def save_output(output_files, data, quiet=False, sarif_payload=None):
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
             raise
+        _record_output_artifact(path, output_format(path))
         print_console(
             f"[blue]{label} saved to {escape(str(path))}[/blue]",
             quiet,
@@ -378,6 +424,7 @@ def save_output(output_files, data, quiet=False, sarif_payload=None):
                 f"[blue]HTML report saved to {escape(str(html_path))}[/blue]",
                 quiet,
             )
+            _record_output_artifact(html_path, "html")
             continue
 
         if suffix == ".sarif":
@@ -388,6 +435,7 @@ def save_output(output_files, data, quiet=False, sarif_payload=None):
                 f"[blue]SARIF report saved to {escape(str(sarif_path))}[/blue]",
                 quiet,
             )
+            _record_output_artifact(sarif_path, "sarif")
             continue
 
         if suffix == ".csv":
@@ -396,6 +444,7 @@ def save_output(output_files, data, quiet=False, sarif_payload=None):
                 f"[blue]CSV report saved to {escape(str(csv_path))}[/blue]",
                 quiet,
             )
+            _record_output_artifact(csv_path, "csv")
             continue
 
         # default to JSON

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -16,6 +16,9 @@ from metis.plugins.c_family.codegraph import CFamilyCodeGraphProvider
 from metis.plugins.c_family.semantics import CFamilyCodeGraphSemantics
 from metis.plugins.registry import LanguagePluginRegistry
 from metis.usage import UsageRuntime
+from metis.runlog import RunLogSession
+from metis.runlog import bind_runlog
+from metis import runlog
 from metis.vector_store.base import BaseVectorStore
 
 from .ask import AskGraph
@@ -53,9 +56,11 @@ class MetisEngine:
         vector_backend: Any = BaseVectorStore,
         llm_provider: Any = None,
         embedding_provider: Any = None,
+        runlog: RunLogSession | None = None,
         **kwargs: Any,
     ) -> None:
         self.codebase_path = codebase_path
+        self._runlog = runlog
 
         required_keys = [
             "max_workers",
@@ -195,9 +200,20 @@ class MetisEngine:
         self._config.memory_service = self.capabilities.get("memory")
 
     def init_codebase(self) -> dict[str, object]:
-        result = self.execution.execute_initialize()
-        initialization = _require_execution_outputs(result)["initialize"]
-        return _execution_value(initialization)
+        with (
+            bind_runlog(self._runlog),
+            runlog.span("execution", "initialize") as execution_span,
+        ):
+            result = self.execution.execute_initialize()
+            initialization = _require_execution_outputs(result)["initialize"]
+            execution_span.end(
+                status=result.status.value,
+                attributes={
+                    "outputs": initialization,
+                    "diagnostics": result.diagnostics,
+                },
+            )
+            return _execution_value(initialization)
 
     def execute_review(
         self,
@@ -206,12 +222,24 @@ class MetisEngine:
         target: str | None = None,
         callbacks: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        result = self.execution.execute_review(
-            ReviewCommand(mode=mode, target=target),
-            callbacks=callbacks,
-        )
-        review = _require_execution_outputs(result)["review"]
-        return _execution_value(review)
+        with (
+            bind_runlog(self._runlog),
+            runlog.span(
+                "execution",
+                "review",
+                {"mode": mode, "target": target},
+            ) as execution_span,
+        ):
+            result = self.execution.execute_review(
+                ReviewCommand(mode=mode, target=target),
+                callbacks=callbacks,
+            )
+            review = _require_execution_outputs(result)["review"]
+            execution_span.end(
+                status=result.status.value,
+                attributes={"outputs": review, "diagnostics": result.diagnostics},
+            )
+            return _execution_value(review)
 
     def execute_graph(
         self,
@@ -219,16 +247,30 @@ class MetisEngine:
         include_triaged: bool | None = None,
         callbacks: dict[str, object] | None = None,
     ) -> ExecutionResult:
-        result = self.execution.execute_graph(
-            include_triaged=include_triaged,
-            callbacks=callbacks,
-        )
-        outputs = _require_execution_outputs(result)
-        return ExecutionResult(
-            status=result.status,
-            outputs={name: _execution_value(value) for name, value in outputs.items()},
-            diagnostics=result.diagnostics,
-        )
+        with (
+            bind_runlog(self._runlog),
+            runlog.span(
+                "execution",
+                "configured_graph",
+                {"include_triaged": include_triaged},
+            ) as execution_span,
+        ):
+            result = self.execution.execute_graph(
+                include_triaged=include_triaged,
+                callbacks=callbacks,
+            )
+            outputs = _require_execution_outputs(result)
+            execution_span.end(
+                status=result.status.value,
+                attributes={"outputs": outputs, "diagnostics": result.diagnostics},
+            )
+            return ExecutionResult(
+                status=result.status,
+                outputs={
+                    name: _execution_value(value) for name, value in outputs.items()
+                },
+                diagnostics=result.diagnostics,
+            )
 
     def usage_command(
         self,
@@ -307,14 +349,20 @@ class MetisEngine:
         return self._state.ask_graph
 
     def ask_question(self, question):
-        retriever_code, retriever_docs = self._index_capability().get_retrievers()
-        logger.info("Querying codebase for your question...")
-        req = {
-            "question": question,
-            "retriever_code": retriever_code,
-            "retriever_docs": retriever_docs,
-        }
-        return self._get_ask_graph().ask(req)
+        with (
+            bind_runlog(self._runlog),
+            runlog.span("execution", "ask", {"question": question}) as execution_span,
+        ):
+            retriever_code, retriever_docs = self._index_capability().get_retrievers()
+            logger.info("Querying codebase for your question...")
+            req = {
+                "question": question,
+                "retriever_code": retriever_code,
+                "retriever_docs": retriever_docs,
+            }
+            result = self._get_ask_graph().ask(req)
+            execution_span.end(attributes={"outputs": result})
+            return result
 
     def execute_triage(
         self,
@@ -326,25 +374,37 @@ class MetisEngine:
         checkpoint_path: str | None = None,
         options: TriageOptions | None = None,
     ) -> dict:
-        options = options or self._triage_options
-        if checkpoint_callback is None and checkpoint_path is not None:
-            if self._triage_service is None:
-                raise RuntimeError("Triage stage is not configured")
-            checkpoint_callback = self._triage_service.checkpoint_callback(
-                checkpoint_path
+        with (
+            bind_runlog(self._runlog),
+            runlog.span(
+                "execution",
+                "triage",
+                {"include_triaged": bool(options and options.include_triaged)},
+            ) as execution_span,
+        ):
+            options = options or self._triage_options
+            if checkpoint_callback is None and checkpoint_path is not None:
+                if self._triage_service is None:
+                    raise RuntimeError("Triage stage is not configured")
+                checkpoint_callback = self._triage_service.checkpoint_callback(
+                    checkpoint_path
+                )
+            result = self.execution.execute_triage(
+                payload,
+                codegraph=codegraph,
+                include_triaged=options.include_triaged,
+                callbacks={
+                    "progress_callback": progress_callback,
+                    "debug_callback": debug_callback,
+                    "checkpoint_callback": checkpoint_callback,
+                },
             )
-        result = self.execution.execute_triage(
-            payload,
-            codegraph=codegraph,
-            include_triaged=options.include_triaged,
-            callbacks={
-                "progress_callback": progress_callback,
-                "debug_callback": debug_callback,
-                "checkpoint_callback": checkpoint_callback,
-            },
-        )
-        triage = _require_execution_outputs(result)["triage"]
-        return _execution_value(triage)
+            triage = _require_execution_outputs(result)["triage"]
+            execution_span.end(
+                status=result.status.value,
+                attributes={"outputs": triage, "diagnostics": result.diagnostics},
+            )
+            return _execution_value(triage)
 
     def close(self):
         if self._simple_llm_triage is not None:

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from pathlib import Path
 from typing import Any
@@ -199,14 +200,19 @@ class MetisEngine:
         self._simple_llm_triage = builtin_execution.simple_llm_triage
         self._config.memory_service = self.capabilities.get("memory")
 
-    def init_codebase(self) -> dict[str, object]:
+    @contextlib.contextmanager
+    def _execution_span(self, name: str, attributes: dict[str, object] | None = None):
         with (
             bind_runlog(self._runlog),
-            runlog.span("execution", "initialize") as execution_span,
+            runlog.span("execution", name, attributes) as span,
         ):
+            yield span
+
+    def init_codebase(self) -> dict[str, object]:
+        with self._execution_span("initialize") as span:
             result = self.execution.execute_initialize()
             initialization = _require_execution_outputs(result)["initialize"]
-            execution_span.end(
+            span.end(
                 status=result.status.value,
                 attributes={
                     "outputs": initialization,
@@ -222,20 +228,13 @@ class MetisEngine:
         target: str | None = None,
         callbacks: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        with (
-            bind_runlog(self._runlog),
-            runlog.span(
-                "execution",
-                "review",
-                {"mode": mode, "target": target},
-            ) as execution_span,
-        ):
+        with self._execution_span("review", {"mode": mode, "target": target}) as span:
             result = self.execution.execute_review(
                 ReviewCommand(mode=mode, target=target),
                 callbacks=callbacks,
             )
             review = _require_execution_outputs(result)["review"]
-            execution_span.end(
+            span.end(
                 status=result.status.value,
                 attributes={"outputs": review, "diagnostics": result.diagnostics},
             )
@@ -247,20 +246,15 @@ class MetisEngine:
         include_triaged: bool | None = None,
         callbacks: dict[str, object] | None = None,
     ) -> ExecutionResult:
-        with (
-            bind_runlog(self._runlog),
-            runlog.span(
-                "execution",
-                "configured_graph",
-                {"include_triaged": include_triaged},
-            ) as execution_span,
-        ):
+        with self._execution_span(
+            "configured_graph", {"include_triaged": include_triaged}
+        ) as span:
             result = self.execution.execute_graph(
                 include_triaged=include_triaged,
                 callbacks=callbacks,
             )
             outputs = _require_execution_outputs(result)
-            execution_span.end(
+            span.end(
                 status=result.status.value,
                 attributes={"outputs": outputs, "diagnostics": result.diagnostics},
             )
@@ -349,10 +343,7 @@ class MetisEngine:
         return self._state.ask_graph
 
     def ask_question(self, question):
-        with (
-            bind_runlog(self._runlog),
-            runlog.span("execution", "ask", {"question": question}) as execution_span,
-        ):
+        with self._execution_span("ask", {"question": question}) as span:
             retriever_code, retriever_docs = self._index_capability().get_retrievers()
             logger.info("Querying codebase for your question...")
             req = {
@@ -361,7 +352,7 @@ class MetisEngine:
                 "retriever_docs": retriever_docs,
             }
             result = self._get_ask_graph().ask(req)
-            execution_span.end(attributes={"outputs": result})
+            span.end(attributes={"outputs": result})
             return result
 
     def execute_triage(
@@ -374,14 +365,9 @@ class MetisEngine:
         checkpoint_path: str | None = None,
         options: TriageOptions | None = None,
     ) -> dict:
-        with (
-            bind_runlog(self._runlog),
-            runlog.span(
-                "execution",
-                "triage",
-                {"include_triaged": bool(options and options.include_triaged)},
-            ) as execution_span,
-        ):
+        with self._execution_span(
+            "triage", {"include_triaged": bool(options and options.include_triaged)}
+        ) as span:
             options = options or self._triage_options
             if checkpoint_callback is None and checkpoint_path is not None:
                 if self._triage_service is None:
@@ -400,7 +386,7 @@ class MetisEngine:
                 },
             )
             triage = _require_execution_outputs(result)["triage"]
-            execution_span.end(
+            span.end(
                 status=result.status.value,
                 attributes={"outputs": triage, "diagnostics": result.diagnostics},
             )

--- a/src/metis/engine/execution/runner.py
+++ b/src/metis/engine/execution/runner.py
@@ -13,6 +13,8 @@ from typing import get_origin
 from pydantic import TypeAdapter
 from pydantic import ValidationError
 
+from metis import runlog
+
 from .compiler import StagePlan
 from .compiler import _PlannedNode
 from .contracts import ExecutionDiagnostic
@@ -37,105 +39,169 @@ def run_stage(
     context: NodeContext,
     initial_inputs: Mapping[str, object],
 ) -> StageRun:
-    outputs: dict[str, Mapping[str, object]] = {}
-    diagnostics: list[ExecutionDiagnostic] = []
-    status = ExecutionStatus.OK
-    failed: set[str] = set()
-    stage_started = perf_counter()
-    _progress(context, {"event": "execution_stage_start", "stage": stage_name})
-    for node in planned.nodes:
-        if node.required_dependencies & failed:
-            failed.add(node.name)
-            _progress(
-                context,
+    with runlog.span(
+        "stage",
+        stage_name,
+        lambda: {
+            "nodes": [
                 {
-                    "event": "execution_node_skipped",
+                    "name": node.name,
+                    "dependencies": sorted(node.dependencies),
+                    "required_dependencies": sorted(node.required_dependencies),
+                    "capabilities": sorted(node.capabilities),
+                }
+                for node in planned.nodes
+            ],
+            "output_bindings": dict(planned.output_bindings),
+            "initial_inputs": initial_inputs,
+        },
+    ) as stage_span:
+        outputs: dict[str, Mapping[str, object]] = {}
+        diagnostics: list[ExecutionDiagnostic] = []
+        status = ExecutionStatus.OK
+        failed: set[str] = set()
+        stage_started = perf_counter()
+        _progress(context, {"event": "execution_stage_start", "stage": stage_name})
+        for node in planned.nodes:
+            if node.required_dependencies & failed:
+                failed.add(node.name)
+                with runlog.span(
+                    "node",
+                    f"{stage_name}.{node.name}",
+                    {
+                        "stage": stage_name,
+                        "node": node.name,
+                        "dependencies": sorted(node.dependencies),
+                    },
+                ) as skipped_span:
+                    skipped_span.end(
+                        status="cancelled",
+                        attributes={"reason": "dependency_failed"},
+                    )
+                _progress(
+                    context,
+                    {
+                        "event": "execution_node_skipped",
+                        "stage": stage_name,
+                        "node": node.name,
+                        "reason": "dependency_failed",
+                    },
+                )
+                continue
+            with runlog.span(
+                "node",
+                f"{stage_name}.{node.name}",
+                lambda: {
                     "stage": stage_name,
                     "node": node.name,
-                    "reason": "dependency_failed",
+                    "configuration": node.configuration,
+                    "input_bindings": dict(node.input_bindings),
+                    "capabilities": sorted(node.capabilities),
+                    "formats": node.definition.formats,
+                    "filename": node.definition.filename,
                 },
-            )
-            continue
+            ) as node_span:
+                _progress(
+                    context,
+                    {
+                        "event": "execution_node_start",
+                        "stage": stage_name,
+                        "node": node.name,
+                    },
+                )
+                node_started = perf_counter()
+                node_status = ExecutionStatus.ERROR
+                inputs: dict[str, object] = {}
+                result = None
+                node_error: Exception | None = None
+                try:
+                    inputs = _resolve_inputs(node, outputs, initial_inputs)
+                    node_context = replace(
+                        context,
+                        capabilities=node.capabilities,
+                    )
+                    result = node.registration.execute(
+                        NodeInvocation(
+                            configuration=node.configuration,
+                            inputs=inputs,
+                            context=node_context,
+                            formats=node.definition.formats,
+                            filename=node.definition.filename,
+                        )
+                    )
+                    diagnostics.extend(result.diagnostics)
+                    node_status = result.status
+                    if result.status is ExecutionStatus.ERROR:
+                        failed.add(node.name)
+                        status = ExecutionStatus.ERROR
+                    else:
+                        outputs[node.name] = _validate_outputs(
+                            node.registration,
+                            result.outputs,
+                        )
+                        if (
+                            result.status is ExecutionStatus.INCONCLUSIVE
+                            and status is ExecutionStatus.OK
+                        ):
+                            status = ExecutionStatus.INCONCLUSIVE
+                except Exception as exc:
+                    node_error = exc
+                    node_status = ExecutionStatus.ERROR
+                    diagnostics.append(
+                        ExecutionDiagnostic(
+                            code="execution.node_failed",
+                            message=(
+                                f"Execution node {stage_name}.{node.name} failed: {exc}"
+                            ),
+                        )
+                    )
+                    failed.add(node.name)
+                    status = ExecutionStatus.ERROR
+                _progress(
+                    context,
+                    {
+                        "event": "execution_node_end",
+                        "stage": stage_name,
+                        "node": node.name,
+                        "status": node_status.value,
+                        "duration_seconds": perf_counter() - node_started,
+                    },
+                )
+                node_span.end(
+                    status=node_status.value,
+                    attributes={
+                        "inputs": inputs,
+                        "outputs": result.outputs if result is not None else {},
+                        "diagnostics": (
+                            result.diagnostics if result is not None else ()
+                        ),
+                    },
+                    exc=node_error,
+                )
+        if not planned.output_bindings:
+            stage_outputs: dict[str, object] = {
+                name: _single_or_mapping(values) for name, values in outputs.items()
+            }
+        else:
+            stage_outputs = {
+                name: _resolve_source(source, outputs, {})
+                for name, source in planned.output_bindings.items()
+                if _source_is_available(source, outputs)
+            }
         _progress(
             context,
             {
-                "event": "execution_node_start",
+                "event": "execution_stage_end",
                 "stage": stage_name,
-                "node": node.name,
+                "status": status.value,
+                "duration_seconds": perf_counter() - stage_started,
             },
         )
-        node_started = perf_counter()
-        node_status = ExecutionStatus.ERROR
-        try:
-            inputs = _resolve_inputs(node, outputs, initial_inputs)
-            node_context = replace(
-                context,
-                capabilities=node.capabilities,
-            )
-            result = node.registration.execute(
-                NodeInvocation(
-                    configuration=node.configuration,
-                    inputs=inputs,
-                    context=node_context,
-                    formats=node.definition.formats,
-                    filename=node.definition.filename,
-                )
-            )
-            diagnostics.extend(result.diagnostics)
-            node_status = result.status
-            if result.status is ExecutionStatus.ERROR:
-                failed.add(node.name)
-                status = ExecutionStatus.ERROR
-            else:
-                outputs[node.name] = _validate_outputs(
-                    node.registration,
-                    result.outputs,
-                )
-                if (
-                    result.status is ExecutionStatus.INCONCLUSIVE
-                    and status is ExecutionStatus.OK
-                ):
-                    status = ExecutionStatus.INCONCLUSIVE
-        except Exception as exc:
-            node_status = ExecutionStatus.ERROR
-            diagnostics.append(
-                ExecutionDiagnostic(
-                    code="execution.node_failed",
-                    message=f"Execution node {stage_name}.{node.name} failed: {exc}",
-                )
-            )
-            failed.add(node.name)
-            status = ExecutionStatus.ERROR
-        _progress(
-            context,
-            {
-                "event": "execution_node_end",
-                "stage": stage_name,
-                "node": node.name,
-                "status": node_status.value,
-                "duration_seconds": perf_counter() - node_started,
-            },
+        stage_span.end(
+            status=status.value,
+            attributes={"outputs": stage_outputs, "diagnostics": diagnostics},
         )
-    if not planned.output_bindings:
-        stage_outputs: dict[str, object] = {
-            name: _single_or_mapping(values) for name, values in outputs.items()
-        }
-    else:
-        stage_outputs = {
-            name: _resolve_source(source, outputs, {})
-            for name, source in planned.output_bindings.items()
-            if _source_is_available(source, outputs)
-        }
-    _progress(
-        context,
-        {
-            "event": "execution_stage_end",
-            "stage": stage_name,
-            "status": status.value,
-            "duration_seconds": perf_counter() - stage_started,
-        },
-    )
-    return StageRun(status, stage_outputs, tuple(diagnostics))
+        return StageRun(status, stage_outputs, tuple(diagnostics))
 
 
 def _progress(context: NodeContext, event: Mapping[str, object]) -> None:

--- a/src/metis/engine/llm_runner.py
+++ b/src/metis/engine/llm_runner.py
@@ -9,6 +9,8 @@ from langchain_core.messages import SystemMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
+from metis import runlog
+from metis.runlog.langchain import ensure_runlog_callback
 from metis.chat_model_options import merge_chat_model_kwargs
 from metis.engine.model_tool_runner import (
     ModelToolConfigurationError,
@@ -54,6 +56,36 @@ class JsonPromptRunner:
         self._retry_backoff_seconds = float(retry_backoff_seconds)
 
     def invoke(self, request: JsonPromptRequest):
+        with runlog.span(
+            "prompt",
+            request.label,
+            lambda: {
+                "model": request.model,
+                "system_prompt": request.system_prompt,
+                "user_prompt": request.user_prompt,
+                "variables": request.variables,
+                "batch_size": request.batch_size,
+                "response_model": (
+                    request.response_model.__name__
+                    if request.response_model is not None
+                    else None
+                ),
+                "reasoning_effort": request.reasoning_effort,
+                "tools": [
+                    getattr(tool, "name", type(tool).__name__)
+                    for tool in request.model_tools
+                ],
+                "max_tool_rounds": request.max_tool_rounds,
+            },
+        ) as prompt_span:
+            parsed = self._invoke_attempts(request)
+            prompt_span.end(
+                status="ok" if parsed is not None else "inconclusive",
+                attributes={"parsed": parsed},
+            )
+            return parsed
+
+    def _invoke_attempts(self, request: JsonPromptRequest):
         last_failure = "unknown failure"
         max_tool_rounds = (
             require_max_tool_rounds(request.max_tool_rounds)
@@ -61,74 +93,118 @@ class JsonPromptRunner:
             else None
         )
         for attempt in range(self._max_attempts):
-            try:
-                usage_chat_kwargs = (
-                    self._usage_runtime.hooks.chat_model_kwargs()
-                    if self._usage_runtime is not None
-                    else None
-                )
-                params = merge_chat_model_kwargs(
-                    request.chat_model_kwargs,
-                    usage_chat_kwargs,
-                    model=request.model,
-                    reasoning_effort=request.reasoning_effort,
-                )
-                if request.max_tokens is not None:
-                    params["max_tokens"] = request.max_tokens
-                if request.temperature is not None:
-                    params["temperature"] = request.temperature
-                chat = self._llm_provider.get_chat_model(**params)
-                system_prompt = model_tool_system_prompt(
-                    request.system_prompt,
-                    request.model_tools,
-                )
-                prompt = ChatPromptTemplate.from_messages(
-                    [
-                        SystemMessage(content=system_prompt),
-                        ("user", request.user_prompt),
-                    ]
-                )
-                parsed = None
-                structured_output = getattr(chat, "with_structured_output", None)
-                if (
-                    not request.model_tools
-                    and request.response_model is not None
-                    and callable(structured_output)
-                ):
-                    try:
-                        parsed = request.parse(
-                            (
-                                prompt
-                                | structured_output(
-                                    request.response_model,
-                                    method="function_calling",
-                                )
-                            ).invoke(request.variables)
+            response_text: Any = None
+            parsed: Any = None
+            attempt_error: Exception | None = None
+            with runlog.span(
+                "attempt",
+                f"{request.label}:{attempt + 1}",
+                {
+                    "attempt": attempt + 1,
+                    "max_attempts": self._max_attempts,
+                },
+            ) as attempt_span:
+                try:
+                    usage_chat_kwargs = (
+                        self._usage_runtime.hooks.chat_model_kwargs()
+                        if self._usage_runtime is not None
+                        else None
+                    )
+                    params = merge_chat_model_kwargs(
+                        request.chat_model_kwargs,
+                        usage_chat_kwargs,
+                        model=request.model,
+                        reasoning_effort=request.reasoning_effort,
+                    )
+                    params["callbacks"] = ensure_runlog_callback(
+                        params.get("callbacks")
+                    )
+                    if request.max_tokens is not None:
+                        params["max_tokens"] = request.max_tokens
+                    if request.temperature is not None:
+                        params["temperature"] = request.temperature
+                    chat = self._llm_provider.get_chat_model(**params)
+                    system_prompt = model_tool_system_prompt(
+                        request.system_prompt,
+                        request.model_tools,
+                    )
+                    prompt = ChatPromptTemplate.from_messages(
+                        [
+                            SystemMessage(content=system_prompt),
+                            ("user", request.user_prompt),
+                        ]
+                    )
+                    structured_output = getattr(chat, "with_structured_output", None)
+                    if (
+                        not request.model_tools
+                        and request.response_model is not None
+                        and callable(structured_output)
+                    ):
+                        try:
+                            parsed = request.parse(
+                                (
+                                    prompt
+                                    | structured_output(
+                                        request.response_model,
+                                        method="function_calling",
+                                    )
+                                ).invoke(request.variables)
+                            )
+                        except Exception as exc:
+                            last_failure = f"structured validation failed: {exc}"
+                    if parsed is None:
+                        if request.model_tools:
+                            response_text = invoke_model_with_tools(
+                                chat,
+                                prompt,
+                                request.variables,
+                                request.model_tools,
+                                max_tool_rounds=max_tool_rounds,
+                            )
+                        else:
+                            response_text = (prompt | chat | StrOutputParser()).invoke(
+                                request.variables
+                            )
+                        parsed = request.parse(response_text)
+                    if parsed is not None:
+                        attempt_span.end(
+                            attributes={
+                                "response_text": response_text,
+                                "parsed": parsed,
+                            }
                         )
-                    except Exception as exc:
-                        last_failure = f"structured validation failed: {exc}"
-                if parsed is None:
-                    if request.model_tools:
-                        response_text = invoke_model_with_tools(
-                            chat,
-                            prompt,
-                            request.variables,
-                            request.model_tools,
-                            max_tool_rounds=max_tool_rounds,
-                        )
-                    else:
-                        response_text = (prompt | chat | StrOutputParser()).invoke(
-                            request.variables
-                        )
-                    parsed = request.parse(response_text)
-                if parsed is not None:
-                    return parsed
-                last_failure = request.invalid_message
-            except Exception as exc:
-                if isinstance(exc, ModelToolConfigurationError):
-                    raise
-                last_failure = str(exc)
+                        return parsed
+                    last_failure = request.invalid_message
+                except Exception as exc:
+                    if isinstance(exc, ModelToolConfigurationError):
+                        raise
+                    attempt_error = exc
+                    last_failure = str(exc)
+                attempt_span.end(
+                    status="error" if attempt_error is not None else "inconclusive",
+                    attributes={
+                        "response_text": response_text,
+                        "failure": last_failure,
+                    },
+                    exc=attempt_error,
+                )
             if attempt < self._max_attempts - 1:
+                backoff_seconds = (
+                    min(self._retry_backoff_seconds * (2**attempt), 30.0)
+                    if self._retry_backoff_seconds > 0
+                    else 0.0
+                )
+                runlog.event(
+                    "retry",
+                    {
+                        "operation": "llm",
+                        "label": request.label,
+                        "attempt": attempt + 2,
+                        "max_attempts": self._max_attempts,
+                        "backoff_ms": backoff_seconds * 1000.0,
+                        "reason": last_failure,
+                    },
+                )
                 request.logger.warning(
                     "%s failed for %d candidates; retrying (attempt %d/%d): %s",
                     request.label,
@@ -137,8 +213,8 @@ class JsonPromptRunner:
                     self._max_attempts,
                     last_failure,
                 )
-                if self._retry_backoff_seconds > 0:
-                    time.sleep(min(self._retry_backoff_seconds * (2**attempt), 30.0))
+                if backoff_seconds > 0:
+                    time.sleep(backoff_seconds)
         request.logger.warning(
             "%s failed for %d candidates; %s: %s",
             request.label,

--- a/src/metis/engine/model_tool_runner.py
+++ b/src/metis/engine/model_tool_runner.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from langchain_core.messages import ToolMessage
 from langchain_core.prompts import ChatPromptTemplate
+from metis import runlog
+
 
 logger = logging.getLogger("metis")
 
@@ -61,56 +63,106 @@ def invoke_model_with_tools(
     *,
     max_tool_rounds: int,
 ) -> str:
-    bind_tools = getattr(chat, "bind_tools", None)
-    if not callable(bind_tools):
-        raise ModelToolConfigurationError(
-            "model_tools require a LangChain chat model with bind_tools support"
-        )
-
-    tool_chat = bind_tools(list(tools))
-    tool_by_name = {getattr(tool, "name", ""): tool for tool in tools}
-    messages = prompt.invoke(variables).to_messages()
-    last_response = None
-    for _ in range(max_tool_rounds):
-        last_response = tool_chat.invoke(messages)
-        tool_calls = list(getattr(last_response, "tool_calls", None) or [])
-        if not tool_calls:
-            return _message_content_text(last_response)
-        messages.append(last_response)
-        for index, tool_call in enumerate(tool_calls):
-            name = str(tool_call.get("name") or "")
-            args = tool_call.get("args") or {}
-            tool_call_id = str(tool_call.get("id") or f"{name}-{index}")
-            status = "success"
-            try:
-                tool = tool_by_name[name]
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(
-                        "Invoking model tool %s with args=%s",
-                        name,
-                        _debug_tool_args(args),
-                    )
-                content = tool.invoke(args)
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(
-                        "Model tool %s completed with %d output chars",
-                        name,
-                        len(str(content)),
-                    )
-            except Exception as exc:
-                status = "error"
-                content = f"Tool {name!r} failed: {exc}"
-                logger.debug("Model tool %s failed: %s", name, exc)
-            messages.append(
-                ToolMessage(
-                    content=str(content),
-                    name=name,
-                    tool_call_id=tool_call_id,
-                    status=status,
-                )
+    with runlog.span(
+        "model_loop",
+        "tool_loop",
+        {
+            "tools": [getattr(tool, "name", type(tool).__name__) for tool in tools],
+            "max_tool_rounds": max_tool_rounds,
+        },
+    ) as loop_span:
+        bind_tools = getattr(chat, "bind_tools", None)
+        if not callable(bind_tools):
+            raise ModelToolConfigurationError(
+                "model_tools require a LangChain chat model with bind_tools support"
             )
-    last_response = tool_chat.invoke(messages)
-    return _message_content_text(last_response)
+
+        tool_chat = bind_tools(list(tools))
+        tool_by_name = {getattr(tool, "name", ""): tool for tool in tools}
+        messages = prompt.invoke(variables).to_messages()
+        last_response = None
+        for round_index in range(1, max_tool_rounds + 1):
+            last_response = tool_chat.invoke(messages)
+            tool_calls = list(getattr(last_response, "tool_calls", None) or [])
+            loop_span.event(
+                "model.round",
+                {
+                    "round": round_index,
+                    "response": last_response,
+                    "tool_calls": tool_calls,
+                },
+            )
+            if not tool_calls:
+                content = _message_content_text(last_response)
+                loop_span.end(attributes={"response": content, "rounds": round_index})
+                return content
+            messages.append(last_response)
+            for index, tool_call in enumerate(tool_calls):
+                name = str(tool_call.get("name") or "")
+                args = tool_call.get("args") or {}
+                tool_call_id = str(tool_call.get("id") or f"{name}-{index}")
+                status = "success"
+                with runlog.span(
+                    "tool",
+                    name or "unknown",
+                    {
+                        "round": round_index,
+                        "tool_call_id": tool_call_id,
+                        "arguments": args,
+                    },
+                ) as tool_span:
+                    try:
+                        tool = tool_by_name[name]
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "Invoking model tool %s with args=%s",
+                                name,
+                                _debug_tool_args(args),
+                            )
+                        content = tool.invoke(args)
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "Model tool %s completed with %d output chars",
+                                name,
+                                len(str(content)),
+                            )
+                        tool_span.end(
+                            attributes={
+                                "output": str(content),
+                                "output_bytes": len(str(content).encode("utf-8")),
+                            }
+                        )
+                    except Exception as exc:
+                        status = "error"
+                        content = f"Tool {name!r} failed: {exc}"
+                        logger.debug("Model tool %s failed: %s", name, exc)
+                        tool_span.end(
+                            status="error",
+                            attributes={"output": content},
+                            exc=exc,
+                        )
+                runlog.bump("tool_calls")
+                messages.append(
+                    ToolMessage(
+                        content=str(content),
+                        name=name,
+                        tool_call_id=tool_call_id,
+                        status=status,
+                    )
+                )
+        last_response = tool_chat.invoke(messages)
+        content = _message_content_text(last_response)
+        loop_span.event(
+            "model.round",
+            {
+                "round": max_tool_rounds + 1,
+                "response": last_response,
+                "tool_calls": [],
+                "final": True,
+            },
+        )
+        loop_span.end(attributes={"response": content, "rounds": max_tool_rounds + 1})
+        return content
 
 
 def _tool_contract_sections(tools: tuple[Any, ...]) -> list[str]:

--- a/src/metis/engine/nodes/reachability/workers.py
+++ b/src/metis/engine/nodes/reachability/workers.py
@@ -11,6 +11,7 @@ import threading
 from typing import Any, TypeVar
 
 from metis.usage import submit_with_current_context
+from metis import runlog
 
 logger = logging.getLogger("metis")
 
@@ -98,6 +99,18 @@ def run_reachability_jobs(
     def key_for(job):
         return result_key(job) if result_key else job
 
+    def invoke_worker(job):
+        key = key_for(job)
+        with runlog.span(
+            "task",
+            label,
+            {"kind": "reachability_job", "label": label, "key": key},
+        ) as task_span:
+            runlog.bump("tasks")
+            result = worker(job)
+            task_span.end(attributes={"result": result})
+            return result
+
     def collect(job, completed, result_func):
         key = key_for(job)
         try:
@@ -117,12 +130,13 @@ def run_reachability_jobs(
 
     if worker_count == 1:
         for completed, job in enumerate(job_list, start=1):
-            collect(job, completed, lambda job=job: worker(job))
+            collect(job, completed, lambda job=job: invoke_worker(job))
         return results
 
     with ThreadPoolExecutor(max_workers=worker_count) as executor:
         futures = {
-            submit_with_current_context(executor, worker, job): job for job in job_list
+            submit_with_current_context(executor, invoke_worker, job): job
+            for job in job_list
         }
         for completed, future in enumerate(as_completed(futures), start=1):
             collect(futures[future], completed, future.result)

--- a/src/metis/engine/nodes/result/review.py
+++ b/src/metis/engine/nodes/result/review.py
@@ -16,6 +16,7 @@ from metis.engine.stages.review.models import ReviewRun
 from metis.engine.stages.review.models import ReviewStatus
 from metis.sarif.models import SarifPayload
 from metis.sarif.writer import generate_sarif
+from metis import runlog
 
 
 def execute(invocation: NodeInvocation) -> NodeResult:
@@ -28,7 +29,7 @@ def execute(invocation: NodeInvocation) -> NodeResult:
     sarif = SarifPayload.model_validate(
         generate_sarif(findings.model_dump(mode="python"))
     )
-    return NodeResult(
+    result = NodeResult(
         {
             "formats": invocation.formats or (),
             "filename": invocation.filename,
@@ -38,6 +39,15 @@ def execute(invocation: NodeInvocation) -> NodeResult:
         },
         status=_execution_status(combined.status),
     )
+    runlog.event(
+        "artifact",
+        {
+            "kind": "review_result",
+            "formats": invocation.formats or (),
+            "payload": result.outputs,
+        },
+    )
+    return result
 
 
 registration = NodeRegistration(

--- a/src/metis/engine/nodes/result/triage.py
+++ b/src/metis/engine/nodes/result/triage.py
@@ -13,6 +13,7 @@ from metis.engine.execution.contracts import ResultFormat
 from metis.engine.stages.triage.models import TriageRun
 from metis.sarif.models import SarifPayload
 from metis.sarif.triage import METIS_TRIAGE_STATUS_KEY
+from metis import runlog
 
 
 def execute(invocation: NodeInvocation) -> NodeResult:
@@ -46,7 +47,7 @@ def execute(invocation: NodeInvocation) -> NodeResult:
                 "warning",
             ),
         )
-    return NodeResult(
+    output = NodeResult(
         {
             "formats": invocation.formats or (),
             "filename": invocation.filename,
@@ -55,6 +56,15 @@ def execute(invocation: NodeInvocation) -> NodeResult:
         status=status,
         diagnostics=diagnostics,
     )
+    runlog.event(
+        "artifact",
+        {
+            "kind": "triage_result",
+            "formats": invocation.formats or (),
+            "payload": output.outputs,
+        },
+    )
+    return output
 
 
 registration = NodeRegistration(

--- a/src/metis/engine/nodes/simple_llm_review/graph.py
+++ b/src/metis/engine/nodes/simple_llm_review/graph.py
@@ -11,6 +11,8 @@ from langgraph.cache.memory import InMemoryCache
 
 from metis.engine.llm_runner import JsonPromptRequest, JsonPromptRunner
 from metis.engine.source import SourceMap
+from metis import runlog
+from metis.runlog.workflow import traced_step
 from metis.engine.threat_context_retrieval import (
     format_threat_model_context,
     threat_model_review_scope_guidance,
@@ -242,9 +244,12 @@ class ReviewGraph:
         )
         parse = review_node_parse
 
-        graph.add_node("build_prompt", build_prompt)
-        graph.add_node("review", review)
-        graph.add_node("parse", parse)
+        graph.add_node(
+            "build_prompt",
+            traced_step("simple_llm_review", "build_prompt", build_prompt),
+        )
+        graph.add_node("review", traced_step("simple_llm_review", "review", review))
+        graph.add_node("parse", traced_step("simple_llm_review", "parse", parse))
 
         graph.set_entry_point("build_prompt")
         graph.add_edge("build_prompt", "review")
@@ -290,25 +295,44 @@ class ReviewGraph:
                 "original_file": original_file,
                 "threat_model_context": threat_model_context,
             }
-            out = app.invoke(state)
+            with runlog.span(
+                "workflow",
+                "simple_llm_review",
+                {
+                    "nodes": ["build_prompt", "review", "parse"],
+                    "edges": [
+                        ["__start__", "build_prompt"],
+                        ["build_prompt", "review"],
+                        ["review", "parse"],
+                        ["parse", "__end__"],
+                    ],
+                    "chunk": {
+                        "file_path": file_path,
+                        "start_line": chunk_start,
+                        "end_line": chunk_end,
+                    },
+                    "initial_state": state,
+                },
+            ) as workflow_span:
+                runlog.bump("workflow_runs")
+                out = app.invoke(state)
+                workflow_span.end(attributes={"final_state": out})
             chunk_reviews = out.get("parsed_reviews", []) or []
             if chunk_reviews:
                 accumulated.extend(chunk_reviews)
 
-        if not accumulated:
-            file_display = relative_file if relative_file else file_path
-            result: dict[str, Any] = {
-                "file": file_display,
-                "file_path": file_path,
-                "reviews": [],
-            }
-            return result
-
         file_display = relative_file if relative_file else file_path
-        result = {
+        result: dict[str, Any] = {
             "file": file_display,
             "file_path": file_path,
             "reviews": accumulated,
         }
-
+        runlog.event(
+            "artifact",
+            {
+                "kind": "review_findings",
+                "file_path": file_display,
+                "payload": result,
+            },
+        )
         return result

--- a/src/metis/engine/nodes/simple_llm_review/service.py
+++ b/src/metis/engine/nodes/simple_llm_review/service.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import unidiff
 
 from metis.usage import submit_with_current_context
+from metis import runlog
 from metis.utils import read_file_content
 
 from metis.engine.diff_utils import process_diff_file
@@ -212,6 +213,17 @@ class SimpleLlmReviewService:
         }
         return (review_graph or self._review_graph_factory(None)).review(req)
 
+    def _review_file_task(self, review_fn, path):
+        with runlog.span(
+            "task",
+            "review_file",
+            {"kind": "review_file", "file_path": str(path)},
+        ) as task_span:
+            runlog.bump("tasks")
+            result = review_fn(path)
+            task_span.end(attributes={"result": result})
+            return result
+
     def _review_files(
         self,
         files,
@@ -219,7 +231,9 @@ class SimpleLlmReviewService:
     ):
         with ThreadPoolExecutor(max_workers=self._config.max_workers) as executor:
             future_to_path = {
-                submit_with_current_context(executor, review_fn, path): path
+                submit_with_current_context(
+                    executor, self._review_file_task, review_fn, path
+                ): path
                 for path in files
             }
             for future in as_completed(future_to_path):

--- a/src/metis/engine/nodes/simple_llm_triage/workflow/workflow.py
+++ b/src/metis/engine/nodes/simple_llm_triage/workflow/workflow.py
@@ -11,6 +11,8 @@ from langgraph.graph import END, StateGraph
 
 from metis.engine.llm_runner import JsonPromptRequest, JsonPromptRunner
 from metis.utils import parse_json_output
+from metis import runlog
+from metis.runlog.workflow import traced_step
 
 from metis.engine.stages.triage.models import TriageDecisionModel
 from metis.engine.stages.triage.models import TriageRequest
@@ -113,13 +115,21 @@ class TriageWorkflow:
         graph = StateGraph(cast(Any, TriageState))
         graph.add_node(
             "collect_evidence",
-            partial(triage_node_collect_evidence, toolbox=self.toolbox),
+            traced_step(
+                "simple_llm_triage",
+                "collect_evidence",
+                partial(triage_node_collect_evidence, toolbox=self.toolbox),
+            ),
         )
         graph.add_node(
             "triage",
-            partial(
-                triage_node_llm,
-                invoke_decision=self._invoke_triage_model,
+            traced_step(
+                "simple_llm_triage",
+                "triage",
+                partial(
+                    triage_node_llm,
+                    invoke_decision=self._invoke_triage_model,
+                ),
             ),
         )
         graph.set_entry_point("collect_evidence")
@@ -129,24 +139,50 @@ class TriageWorkflow:
         return self._app
 
     def triage(self, request: TriageRequest) -> dict:
-        out = self._get_app().invoke(
+        state = {
+            "finding_message": request["finding_message"],
+            "finding_file_path": request["finding_file_path"],
+            "finding_line": request["finding_line"],
+            "finding_rule_id": request["finding_rule_id"],
+            "finding_snippet": request["finding_snippet"],
+            "finding_source_tool": request.get("finding_source_tool", ""),
+            "finding_is_metis": bool(request.get("finding_is_metis", False)),
+            "finding_explanation": request.get("finding_explanation", ""),
+            "triage_language": request.get("triage_language", ""),
+            "triage_language_guidance": request.get("triage_language_guidance", ""),
+            "threat_model_context": request.get("threat_model_context", []),
+            "debug_callback": request.get("debug_callback"),
+            "triage_system_prompt": self.triage_system_prompt,
+            "triage_decision_prompt": self.triage_decision_prompt,
+        }
+        with runlog.span(
+            "workflow",
+            "simple_llm_triage",
             {
-                "finding_message": request["finding_message"],
-                "finding_file_path": request["finding_file_path"],
-                "finding_line": request["finding_line"],
-                "finding_rule_id": request["finding_rule_id"],
-                "finding_snippet": request["finding_snippet"],
-                "finding_source_tool": request.get("finding_source_tool", ""),
-                "finding_is_metis": bool(request.get("finding_is_metis", False)),
-                "finding_explanation": request.get("finding_explanation", ""),
-                "triage_language": request.get("triage_language", ""),
-                "triage_language_guidance": request.get("triage_language_guidance", ""),
-                "threat_model_context": request.get("threat_model_context", []),
-                "debug_callback": request.get("debug_callback"),
-                "triage_system_prompt": self.triage_system_prompt,
-                "triage_decision_prompt": self.triage_decision_prompt,
-            }
-        )
+                "nodes": ["collect_evidence", "triage"],
+                "edges": [
+                    ["__start__", "collect_evidence"],
+                    ["collect_evidence", "triage"],
+                    ["triage", "__end__"],
+                ],
+                "initial_state": {
+                    key: value
+                    for key, value in state.items()
+                    if key != "debug_callback"
+                },
+            },
+        ) as workflow_span:
+            runlog.bump("workflow_runs")
+            out = self._get_app().invoke(state)
+            workflow_span.end(
+                attributes={
+                    "final_state": {
+                        key: value
+                        for key, value in out.items()
+                        if key != "debug_callback"
+                    }
+                }
+            )
         try:
             validated = TriageDecisionModel(
                 status=out.get("decision_status", ""),
@@ -188,6 +224,15 @@ class TriageWorkflow:
                 "deterministic adjudicator marked evidence as insufficiently stable"
             ]
         reason = compose_final_reason(status, model_status, reason, reason_codes)
+        runlog.event(
+            "decision",
+            {
+                "kind": "triage_adjudication",
+                "model_status": model_status,
+                "final_status": status,
+                "reason_codes": reason_codes,
+            },
+        )
         return {
             "status": status,
             "reason": reason,

--- a/src/metis/engine/nodes/threat_model/registration.py
+++ b/src/metis/engine/nodes/threat_model/registration.py
@@ -17,6 +17,8 @@ from metis.engine.execution.contracts import CapabilityRequirement
 from metis.engine.execution.contracts import NodeInvocation
 from metis.engine.execution.contracts import NodeRegistration
 from metis.engine.execution.contracts import NodeResult
+from metis import runlog
+
 
 if TYPE_CHECKING:
     from metis.engine.repository import EngineRepository
@@ -47,6 +49,10 @@ def create_node(
                 repository,
                 memory_service,
             )
+        )
+        runlog.event(
+            "artifact",
+            {"kind": "threat_model_snapshot", "payload": result},
         )
         return NodeResult({"threat_model": result})
 

--- a/src/metis/engine/nodes/threat_model/service.py
+++ b/src/metis/engine/nodes/threat_model/service.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from metis import runlog
 from metis.engine.llm_runner import invoke_langchain_json_prompt_with_retry
 from metis.engine.prompt_catalog import get_engine_prompts
 from metis.engine.repository import EngineRepository
@@ -191,22 +192,39 @@ def _build_threat_model_snapshot(
     )
     prepared_sources: list[PreparedThreatSource] = []
     for source in threat_sources:
-        prepared = _prepare_threat_source(
-            config,
-            repo_root,
-            source,
-        )
-        if prepared is None:
-            raise RuntimeError(
-                f"Threat-model source could not be read: "
-                f"{source.path.relative_to(repo_root).as_posix()}"
+        relative_path = source.path.relative_to(repo_root).as_posix()
+        with runlog.span(
+            "task",
+            "threat_source",
+            {
+                "kind": "threat_source",
+                "path": relative_path,
+                "source_method": source.source,
+            },
+        ) as task_span:
+            runlog.bump("tasks")
+            prepared = _prepare_threat_source(
+                config,
+                repo_root,
+                source,
             )
-        prepared_sources.append(prepared)
-        _write_threat_source_record(
-            candidate_service,
-            repo_fp,
-            prepared,
-        )
+            if prepared is None:
+                raise RuntimeError(
+                    f"Threat-model source could not be read: {relative_path}"
+                )
+            prepared_sources.append(prepared)
+            _write_threat_source_record(
+                candidate_service,
+                repo_fp,
+                prepared,
+            )
+            task_span.end(
+                attributes={
+                    "source_fingerprint": prepared.source_fp,
+                    "claims": prepared.distilled_claims,
+                    "summary": prepared.summary,
+                }
+            )
 
     claims: list[dict[str, Any]] = []
     for prepared in prepared_sources:

--- a/src/metis/engine/stages/service.py
+++ b/src/metis/engine/stages/service.py
@@ -14,6 +14,8 @@ from metis.engine.llm_runner import JsonPromptRunner
 from metis.engine.codegraph import CodeGraphReference
 from metis.sarif.models import SarifPayload
 
+from metis import runlog
+
 from ..execution.catalog import NodeCatalog
 from ..execution.compiler import StagePlan
 from ..execution.compiler import _annotations_compatible
@@ -149,6 +151,13 @@ class ExecutionGraphService:
         include_triaged: bool | None = None,
         callbacks: Mapping[str, object] | None = None,
     ) -> ExecutionResult:
+        runlog.event(
+            "execution.topology",
+            {
+                "stage_order": self.configuration.stage_order(),
+                "configuration": self.configuration,
+            },
+        )
         outputs: dict[str, Any] = {}
         diagnostics: list[ExecutionDiagnostic] = []
         status = ExecutionStatus.OK
@@ -307,11 +316,54 @@ def _resolve_stage_input(
 def _node_callbacks(callbacks: Mapping[str, object] | None) -> NodeCallbacks:
     values = callbacks or {}
     return NodeCallbacks(
-        progress=cast(Any, values.get("progress_callback")),
-        debug=cast(Any, values.get("debug_callback")),
-        checkpoint=cast(Any, values.get("checkpoint_callback")),
-        diagnostic=cast(Any, values.get("diagnostic_callback")),
+        progress=_mapping_callback(
+            "progress", cast(Any, values.get("progress_callback"))
+        ),
+        debug=_mapping_callback("debug", cast(Any, values.get("debug_callback"))),
+        checkpoint=_checkpoint_callback(cast(Any, values.get("checkpoint_callback"))),
+        diagnostic=_diagnostic_callback(cast(Any, values.get("diagnostic_callback"))),
     )
+
+
+def _mapping_callback(name: str, callback):
+    if not runlog.is_enabled():
+        return callback
+
+    def invoke(payload):
+        runlog.event(
+            name, payload if isinstance(payload, Mapping) else {"value": payload}
+        )
+        if callable(callback):
+            callback(payload)
+
+    return invoke
+
+
+def _checkpoint_callback(callback):
+    if not runlog.is_enabled():
+        return callback
+
+    def invoke(payload, processed, total):
+        runlog.event(
+            "checkpoint",
+            {"processed": processed, "total": total, "payload": payload},
+        )
+        if callable(callback):
+            callback(payload, processed, total)
+
+    return invoke
+
+
+def _diagnostic_callback(callback):
+    if not runlog.is_enabled():
+        return callback
+
+    def invoke(diagnostic):
+        runlog.event("diagnostic", {"diagnostic": diagnostic})
+        if callable(callback):
+            callback(diagnostic)
+
+    return invoke
 
 
 def _unavailable_stage(stage: str) -> ExecutionResult:
@@ -332,7 +384,7 @@ def _notify_diagnostics(
     diagnostics: tuple[ExecutionDiagnostic, ...],
 ) -> None:
     callback = (callbacks or {}).get("diagnostic_callback")
-    if not callable(callback):
-        return
     for diagnostic in diagnostics:
-        callback(diagnostic)
+        runlog.event("diagnostic", {"diagnostic": diagnostic})
+        if callable(callback):
+            callback(diagnostic)

--- a/src/metis/engine/stages/triage/service.py
+++ b/src/metis/engine/stages/triage/service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import hashlib
 import logging
 from typing import cast
 
@@ -19,6 +18,7 @@ from metis.sarif.triage import (
     apply_triage_result,
     save_sarif_file,
 )
+from metis.sarif.utils import create_fingerprint
 from metis.usage import submit_with_current_context
 from metis import runlog
 
@@ -71,17 +71,9 @@ class TriageService:
         debug_callback,
         memory_service: MemoryService | None,
     ) -> TriageDecision | None:
-        fingerprint = hashlib.sha256(
-            "\0".join(
-                (
-                    str(finding.rule_id),
-                    str(finding.file_path),
-                    str(finding.line),
-                    str(finding.message),
-                    str(finding.snippet),
-                )
-            ).encode("utf-8")
-        ).hexdigest()
+        fingerprint = create_fingerprint(
+            finding.file_path, finding.line, finding.rule_id
+        )
         finding_id = (
             f"sarif:{finding.run_index}:{finding.result_index}:{fingerprint[:12]}"
         )

--- a/src/metis/engine/stages/triage/service.py
+++ b/src/metis/engine/stages/triage/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import hashlib
 import logging
 from typing import cast
 
@@ -19,6 +20,8 @@ from metis.sarif.triage import (
     save_sarif_file,
 )
 from metis.usage import submit_with_current_context
+from metis import runlog
+
 
 from .contracts import TriageClassifier
 from .contracts import TriageDecision
@@ -68,18 +71,93 @@ class TriageService:
         debug_callback,
         memory_service: MemoryService | None,
     ) -> TriageDecision | None:
-        threat_model_context = get_threat_model_context(
-            memory_service,
-            path=finding.file_path,
+        fingerprint = hashlib.sha256(
+            "\0".join(
+                (
+                    str(finding.rule_id),
+                    str(finding.file_path),
+                    str(finding.line),
+                    str(finding.message),
+                    str(finding.snippet),
+                )
+            ).encode("utf-8")
+        ).hexdigest()
+        finding_id = (
+            f"sarif:{finding.run_index}:{finding.result_index}:{fingerprint[:12]}"
         )
-        policy = threat_model_scope_policy(
-            threat_model_context,
-            path=finding.file_path,
-        )
-        override = threat_model_triage_override(policy)
-        if override is not None:
-            return cast(TriageDecision, override)
-        return classifier(finding, threat_model_context, debug_callback)
+        with runlog.span(
+            "task",
+            "triage_finding",
+            {
+                "kind": "triage_finding",
+                "finding_id": finding_id,
+                "sarif": {
+                    "run_index": finding.run_index,
+                    "result_index": finding.result_index,
+                },
+                "fingerprint": fingerprint,
+                "file_path": finding.file_path,
+                "line": finding.line,
+                "rule_id": finding.rule_id,
+                "message": finding.message,
+            },
+        ) as task_span:
+            runlog.bump("tasks")
+            with runlog.span(
+                "threat_context",
+                "scope_policy",
+                {"path": finding.file_path},
+            ) as context_span:
+                threat_model_context = get_threat_model_context(
+                    memory_service,
+                    path=finding.file_path,
+                )
+                policy = threat_model_scope_policy(
+                    threat_model_context,
+                    path=finding.file_path,
+                )
+                override = threat_model_triage_override(policy)
+                context_span.end(
+                    attributes={
+                        "records": threat_model_context,
+                        "policy": policy,
+                        "override": override,
+                    }
+                )
+            if override is not None:
+                runlog.event(
+                    "decision",
+                    {
+                        "kind": "threat_model_override",
+                        "finding_id": finding_id,
+                        "decision": override,
+                    },
+                )
+                decision = cast(TriageDecision, override)
+            else:
+                decision = classifier(
+                    finding,
+                    threat_model_context,
+                    debug_callback,
+                )
+            if decision is not None:
+                runlog.event(
+                    "artifact",
+                    {
+                        "kind": "triage_decision",
+                        "finding_id": finding_id,
+                        "payload": decision,
+                    },
+                )
+            task_span.end(
+                status=(
+                    "inconclusive"
+                    if decision is None or decision.get("status") == "inconclusive"
+                    else "ok"
+                ),
+                attributes={"decision": decision},
+            )
+            return decision
 
     def _record_triage_success(self, triaged_payload: dict, finding, decision: dict):
         apply_triage_result(

--- a/src/metis/engine/threat_context_retrieval.py
+++ b/src/metis/engine/threat_context_retrieval.py
@@ -9,6 +9,8 @@ from pathlib import PurePosixPath
 from typing import Any
 
 from metis.memory import MemoryService
+from metis import runlog
+
 
 from .nodes.threat_model import THREAT_MODEL_NAMESPACE
 
@@ -17,6 +19,21 @@ def get_threat_model_context(
     service: MemoryService | None,
     *,
     path: str = "",
+) -> list[dict[str, Any]]:
+    with runlog.span(
+        "memory",
+        "threat_model_context",
+        {"operation": "retrieve", "path": path},
+    ) as memory_span:
+        records = _get_threat_model_context(service, path=path)
+        memory_span.end(attributes={"count": len(records), "records": records})
+        return records
+
+
+def _get_threat_model_context(
+    service: MemoryService | None,
+    *,
+    path: str,
 ) -> list[dict[str, Any]]:
     if service is None:
         return []

--- a/src/metis/runlog/__init__.py
+++ b/src/metis/runlog/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from .schema import RunLogConfig
+from .schema import SCHEMA_VERSION
+from .session import RunLogSession
+from .session import bind_runlog
+from .session import build_run_metadata
+from .session import bump
+from .session import current_runlog
+from .session import event
+from .session import is_enabled
+from .session import open_runlog
+from .validation import TraceSummary
+from .validation import TraceValidationError
+from .validation import validate_runlog
+from .session import span
+
+__all__ = [
+    "TraceSummary",
+    "TraceValidationError",
+    "RunLogConfig",
+    "RunLogSession",
+    "SCHEMA_VERSION",
+    "bind_runlog",
+    "build_run_metadata",
+    "bump",
+    "current_runlog",
+    "event",
+    "is_enabled",
+    "open_runlog",
+    "span",
+    "validate_runlog",
+]

--- a/src/metis/runlog/encoding.py
+++ b/src/metis/runlog/encoding.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import hashlib
+import json
+import math
+import os
+import tempfile
+from collections.abc import Mapping
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from .schema import PREVIEW_CHARS
+from .schema import RunLogConfig
+
+_SENSITIVE_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "client_secret",
+        "cookie",
+        "credentials",
+        "password",
+        "pg_password",
+        "private_key",
+        "proxy_authorization",
+        "refresh_token",
+        "secret",
+        "secret_access_key",
+        "session_token",
+        "set_cookie",
+        "token",
+        "x_api_key",
+    }
+)
+_SENSITIVE_SUFFIXES = (
+    "_access_key",
+    "_api_key",
+    "_authorization",
+    "_client_secret",
+    "_cookie",
+    "_credentials",
+    "_password",
+    "_private_key",
+    "_secret",
+    "_secret_access_key",
+    "_session_token",
+    "_token",
+)
+
+
+class PayloadEncoder:
+    """Converts trace payloads into bounded JSON values and blob references."""
+
+    def __init__(self, blobs_dir: Path, config: RunLogConfig) -> None:
+        self._blobs_dir = blobs_dir
+        self._config = config
+
+    def encode_mapping(self, value: Mapping[str, Any] | None) -> dict[str, Any]:
+        if not value:
+            return {}
+        seen: set[int] = set()
+        return {
+            str(key): self._encode(item, key=str(key), depth=0, seen=seen)
+            for key, item in value.items()
+        }
+
+    def _encode(
+        self,
+        value: Any,
+        *,
+        key: str | None,
+        depth: int,
+        seen: set[int],
+    ) -> Any:
+        if key is not None and _is_sensitive_key(key):
+            return _redacted(value)
+        if depth >= self._config.max_depth:
+            return {"$truncated": "max_depth", "type": type(value).__name__}
+        if value is None or isinstance(value, (bool, int)):
+            return value
+        if isinstance(value, float):
+            return value if math.isfinite(value) else repr(value)
+        if isinstance(value, str):
+            return self._encode_text(value)
+        if isinstance(value, bytes):
+            return self._encode_bytes(value)
+        if isinstance(value, (Path, datetime, date)):
+            return str(value)
+        if isinstance(value, Enum):
+            return self._encode(value.value, key=key, depth=depth + 1, seen=seen)
+
+        identity = id(value)
+        if identity in seen:
+            return {"$truncated": "cycle", "type": type(value).__name__}
+        seen.add(identity)
+        try:
+            normalized = self._normalize_object(value)
+            if normalized is not value:
+                return self._encode(
+                    normalized,
+                    key=key,
+                    depth=depth + 1,
+                    seen=seen,
+                )
+            if isinstance(value, Mapping):
+                encoded = {
+                    str(child_key): self._encode(
+                        child_value,
+                        key=str(child_key),
+                        depth=depth + 1,
+                        seen=seen,
+                    )
+                    for child_key, child_value in _limited_items(
+                        value.items(), self._config.max_collection_items
+                    )
+                }
+                if len(value) > self._config.max_collection_items:
+                    encoded["$truncated_items"] = (
+                        len(value) - self._config.max_collection_items
+                    )
+                return self._maybe_spill_json(encoded)
+            if isinstance(value, (list, tuple, set, frozenset)):
+                source = list(value)
+                encoded_items = [
+                    self._encode(item, key=None, depth=depth + 1, seen=seen)
+                    for item in source[: self._config.max_collection_items]
+                ]
+                if isinstance(value, (set, frozenset)):
+                    encoded_items.sort(key=_stable_sort_key)
+                if len(source) > self._config.max_collection_items:
+                    encoded_items.append(
+                        {
+                            "$truncated_items": len(source)
+                            - self._config.max_collection_items
+                        }
+                    )
+                return self._maybe_spill_json(encoded_items)
+            return self._encode_text(_safe_repr(value))
+        finally:
+            seen.discard(identity)
+
+    def _normalize_object(self, value: Any) -> Any:
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            return {
+                field.name: getattr(value, field.name)
+                for field in dataclasses.fields(value)
+            }
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            try:
+                return model_dump(mode="json", by_alias=True)
+            except TypeError:
+                try:
+                    return model_dump()
+                except Exception:
+                    return value
+            except Exception:
+                return value
+        return value
+
+    def _encode_text(self, text: str) -> Any:
+        raw = text.encode("utf-8")
+        if len(raw) <= self._config.blob_threshold:
+            return text
+        return self._blob_reference(
+            raw,
+            extension="txt",
+            media_type="text/plain; charset=utf-8",
+            preview=text[:PREVIEW_CHARS],
+        )
+
+    def _encode_bytes(self, raw: bytes) -> Any:
+        if len(raw) <= self._config.blob_threshold:
+            return {
+                "$bytes": base64.b64encode(raw).decode("ascii"),
+                "bytes": len(raw),
+                "encoding": "base64",
+            }
+        return self._blob_reference(
+            raw,
+            extension="bin",
+            media_type="application/octet-stream",
+            preview=base64.b64encode(raw[:48]).decode("ascii"),
+        )
+
+    def _maybe_spill_json(self, value: Any) -> Any:
+        raw = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if len(raw) <= self._config.blob_threshold:
+            return value
+        preview = raw[:PREVIEW_CHARS].decode("utf-8", errors="replace")
+        return self._blob_reference(
+            raw,
+            extension="json",
+            media_type="application/json",
+            preview=preview,
+        )
+
+    def _blob_reference(
+        self,
+        raw: bytes,
+        *,
+        extension: str,
+        media_type: str,
+        preview: str,
+    ) -> dict[str, Any]:
+        digest = hashlib.sha256(raw).hexdigest()
+        reference: dict[str, Any] = {
+            "bytes": len(raw),
+            "sha256": digest,
+            "media_type": media_type,
+            "preview": preview,
+        }
+        if self._config.content == "metadata":
+            reference["$omitted"] = True
+            return reference
+        self._blobs_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = self._blobs_dir / f"{digest}.{extension}"
+        if not path.exists():
+            fd, temporary = tempfile.mkstemp(
+                dir=self._blobs_dir,
+                prefix=f".{digest}.",
+                suffix=".tmp",
+            )
+            try:
+                os.fchmod(fd, 0o600)
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(raw)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temporary, path)
+                path.chmod(0o600)
+            except Exception:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                Path(temporary).unlink(missing_ok=True)
+                raise
+        reference["$ref"] = path.relative_to(self._blobs_dir.parent).as_posix()
+        return reference
+
+
+def _limited_items(items: Any, limit: int) -> list[tuple[Any, Any]]:
+    result: list[tuple[Any, Any]] = []
+    for index, item in enumerate(items):
+        if index >= limit:
+            break
+        result.append(item)
+    return result
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_")
+    return normalized in _SENSITIVE_KEYS or normalized.endswith(_SENSITIVE_SUFFIXES)
+
+
+def _redacted(value: Any) -> dict[str, Any]:
+    raw = _redaction_bytes(value)
+    return {"$redacted": True, "sha256": hashlib.sha256(raw).hexdigest()}
+
+
+def _redaction_bytes(value: Any) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    try:
+        return json.dumps(value, sort_keys=True, default=_safe_repr).encode("utf-8")
+    except Exception:
+        return _safe_repr(value).encode("utf-8")
+
+
+def _safe_repr(value: Any) -> str:
+    try:
+        return repr(value)
+    except Exception:
+        return f"<unrepresentable {type(value).__name__}>"
+
+
+def _stable_sort_key(value: Any) -> str:
+    try:
+        return json.dumps(value, sort_keys=True, ensure_ascii=False)
+    except Exception:
+        return _safe_repr(value)

--- a/src/metis/runlog/langchain.py
+++ b/src/metis/runlog/langchain.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from typing import Any
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.callbacks.base import BaseCallbackManager
+
+from .session import Span
+from .session import bump
+from .session import current_runlog
+
+
+class RunLogCallbackHandler(BaseCallbackHandler):
+    """Records physical LangChain model calls under the current logical prompt."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._spans: dict[str, Span] = {}
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[Any]],
+        *,
+        run_id: Any,
+        **kwargs: Any,
+    ) -> Any:
+        self._start(
+            run_id,
+            serialized,
+            {
+                "messages": messages,
+                "invocation": kwargs.get("invocation_params") or {},
+                "tags": kwargs.get("tags") or [],
+                "metadata": kwargs.get("metadata") or {},
+            },
+        )
+        return None
+
+    def on_llm_start(
+        self,
+        serialized: dict[str, Any],
+        prompts: list[str],
+        *,
+        run_id: Any,
+        **kwargs: Any,
+    ) -> Any:
+        self._start(
+            run_id,
+            serialized,
+            {
+                "prompts": prompts,
+                "invocation": kwargs.get("invocation_params") or {},
+                "tags": kwargs.get("tags") or [],
+                "metadata": kwargs.get("metadata") or {},
+            },
+        )
+        return None
+
+    def on_llm_end(self, response: Any, *, run_id: Any, **kwargs: Any) -> Any:
+        call = self._pop(run_id)
+        if call is None:
+            return None
+        usage = _usage(response)
+        model = _model_name(response)
+        if usage:
+            call.event("usage", {"model": model, **usage})
+            bump("input_tokens", usage["input_tokens"])
+            bump("output_tokens", usage["output_tokens"])
+            bump("total_tokens", usage["total_tokens"])
+        bump("llm_calls")
+        call.end(
+            attributes={
+                "response": _response_payload(response),
+                "model": model,
+                "usage": usage,
+            }
+        )
+        return None
+
+    def on_llm_error(self, error: BaseException, *, run_id: Any, **kwargs: Any) -> Any:
+        call = self._pop(run_id)
+        if call is None:
+            return None
+        bump("llm_calls")
+        call.end(status="error", exc=error)
+        return None
+
+    def _start(
+        self,
+        run_id: Any,
+        serialized: dict[str, Any],
+        attributes: dict[str, Any],
+    ) -> None:
+        session = current_runlog()
+        if session is None:
+            return
+        name = _serialized_name(serialized)
+        call = session.span(
+            "llm.call",
+            name,
+            {
+                "langchain_run_id": str(run_id),
+                "provider": serialized,
+                **attributes,
+            },
+        )
+        if not isinstance(call, Span):
+            return
+        with self._lock:
+            self._spans[str(run_id)] = call
+
+    def _pop(self, run_id: Any) -> Span | None:
+        with self._lock:
+            return self._spans.pop(str(run_id), None)
+
+
+RUNLOG_CALLBACK_HANDLER = RunLogCallbackHandler()
+
+
+def ensure_runlog_callback(callbacks: Any) -> Any:
+    """Returns callbacks with the singleton runlog handler included once."""
+
+    if callbacks is None:
+        return [RUNLOG_CALLBACK_HANDLER]
+    if isinstance(callbacks, list):
+        if any(callback is RUNLOG_CALLBACK_HANDLER for callback in callbacks):
+            return callbacks
+        return [*callbacks, RUNLOG_CALLBACK_HANDLER]
+    if isinstance(callbacks, tuple):
+        if any(callback is RUNLOG_CALLBACK_HANDLER for callback in callbacks):
+            return list(callbacks)
+        return [*callbacks, RUNLOG_CALLBACK_HANDLER]
+    if isinstance(callbacks, BaseCallbackManager):
+        callbacks.add_handler(RUNLOG_CALLBACK_HANDLER, inherit=True)
+        return callbacks
+    return callbacks
+
+
+def _serialized_name(serialized: dict[str, Any]) -> str:
+    name = serialized.get("name")
+    if name:
+        return str(name)
+    identifiers = serialized.get("id")
+    if isinstance(identifiers, list) and identifiers:
+        return str(identifiers[-1])
+    return "model"
+
+
+def _usage(response: Any) -> dict[str, int]:
+    llm_output = getattr(response, "llm_output", None) or {}
+    token_usage = llm_output.get("token_usage") if isinstance(llm_output, dict) else {}
+    if not isinstance(token_usage, dict):
+        token_usage = {}
+    input_tokens = _positive_int(
+        token_usage.get("prompt_tokens") or token_usage.get("input_tokens")
+    )
+    output_tokens = _positive_int(
+        token_usage.get("completion_tokens") or token_usage.get("output_tokens")
+    )
+    total_tokens = _positive_int(token_usage.get("total_tokens"))
+    if not any((input_tokens, output_tokens, total_tokens)):
+        for generation_list in getattr(response, "generations", None) or []:
+            if not isinstance(generation_list, Iterable):
+                continue
+            for generation in generation_list:
+                message = getattr(generation, "message", generation)
+                metadata = getattr(message, "usage_metadata", None) or {}
+                if not isinstance(metadata, dict):
+                    continue
+                input_tokens += _positive_int(metadata.get("input_tokens"))
+                output_tokens += _positive_int(metadata.get("output_tokens"))
+                total_tokens += _positive_int(metadata.get("total_tokens"))
+    if total_tokens <= 0:
+        total_tokens = input_tokens + output_tokens
+    if not any((input_tokens, output_tokens, total_tokens)):
+        return {}
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+def _model_name(response: Any) -> str:
+    llm_output = getattr(response, "llm_output", None) or {}
+    if isinstance(llm_output, dict) and llm_output.get("model_name"):
+        return str(llm_output["model_name"])
+    for generation_list in getattr(response, "generations", None) or []:
+        for generation in (
+            generation_list if isinstance(generation_list, Iterable) else ()
+        ):
+            message = getattr(generation, "message", generation)
+            metadata = getattr(message, "response_metadata", None) or {}
+            if isinstance(metadata, dict):
+                name = metadata.get("model_name") or metadata.get("model")
+                if name:
+                    return str(name)
+    return "unknown"
+
+
+def _response_payload(response: Any) -> dict[str, Any]:
+    generations = []
+    for generation_list in getattr(response, "generations", None) or []:
+        row = []
+        for generation in (
+            generation_list if isinstance(generation_list, Iterable) else ()
+        ):
+            message = getattr(generation, "message", None)
+            row.append(
+                {
+                    "text": getattr(generation, "text", None),
+                    "message": message,
+                    "generation_info": getattr(generation, "generation_info", None),
+                }
+            )
+        generations.append(row)
+    return {
+        "generations": generations,
+        "llm_output": getattr(response, "llm_output", None),
+    }
+
+
+def _positive_int(value: Any) -> int:
+    try:
+        parsed = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return parsed if parsed > 0 else 0

--- a/src/metis/runlog/schema.py
+++ b/src/metis/runlog/schema.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+SCHEMA_VERSION = 1
+DEFAULT_BLOB_THRESHOLD = 8 * 1024
+DEFAULT_MAX_DEPTH = 32
+DEFAULT_MAX_COLLECTION_ITEMS = 10_000
+PREVIEW_CHARS = 200
+
+ContentMode = Literal["full", "metadata"]
+SpanStatus = Literal["ok", "error", "cancelled", "inconclusive"]
+
+_SPAN_KIND_EXPLANATIONS = {
+    "run": "The complete Metis run, from startup through shutdown, including aggregate activity and totals.",
+    "command": "A CLI or programmatic command issued during this run and all work it triggered.",
+    "execution": "An engine workflow or standalone operation executed for the current command.",
+    "stage": "One configured initialize, review, or triage stage executed as part of the workflow.",
+    "node": "One selected execution node, with the validated inputs it received and outputs it produced.",
+    "task": "One bounded unit of work processed independently or in parallel.",
+    "workflow": "One inner workflow invocation, including its initial state, steps, and final state.",
+    "step": "One step executed inside an inner workflow and the state it returned.",
+    "prompt": "One logical model request, including its prompt inputs, response parsing, and retries.",
+    "attempt": "One attempt made to obtain and parse a valid response for the logical model request.",
+    "llm.call": "One request sent to the model provider, including the rendered messages, provider response, duration, and token usage.",
+    "model_loop": "A sequence of model responses and tool calls used to produce a final answer.",
+    "tool": "One tool call requested by the model, including its arguments, output, and outcome.",
+    "retrieval": "One search of the configured index for context relevant to a query, with the returned documents.",
+    "memory": "One repository-memory lookup or update used by the current operation.",
+    "threat_context": "The threat-model context and scope policy evaluated for the current source path or finding.",
+}
+
+_SPAN_NAME_EXPLANATIONS = {
+    (
+        "task",
+        "Supplementary lens",
+    ): "One supplementary security-analysis lens applied to the current CodeGraph.",
+    (
+        "task",
+        "Global lifecycle chunk",
+    ): "A size-bounded batch of functions checked for lifecycle asymmetry involving global callbacks, timers, work items, operation tables, or shared references.",
+    (
+        "task",
+        "review_file",
+    ): "The review of one source file and the model-derived findings it produced.",
+    (
+        "task",
+        "triage_finding",
+    ): "The triage of one SARIF finding using threat policy, code evidence, and the selected classifier.",
+    (
+        "task",
+        "threat_source",
+    ): "One configured threat-model source distilled into repository-memory claims.",
+    (
+        "workflow",
+        "simple_llm_review",
+    ): "A review workflow that built a prompt, requested model findings, and mapped them back to source.",
+    (
+        "workflow",
+        "simple_llm_triage",
+    ): "A triage workflow that collected evidence, requested a model decision, and applied deterministic adjudication.",
+    (
+        "model_loop",
+        "tool_loop",
+    ): "The sequence of model responses and tool calls used to reach a final answer or the round limit.",
+    (
+        "prompt",
+        "Supplementary reachability analysis",
+    ): "A model analysis of source context for the supplementary security checks selected by the active lens.",
+    (
+        "memory",
+        "threat_model_context",
+    ): "The authoritative and applicable history-derived threat-model records loaded for a source path.",
+    (
+        "threat_context",
+        "scope_policy",
+    ): "The authoritative threat-model scope policy evaluated for the current finding.",
+}
+
+_EVENT_EXPLANATIONS = {
+    "execution.topology": "The stage and node topology selected for this execution.",
+    "debug": "Structured diagnostic details emitted by the active node.",
+    "checkpoint": "A triage checkpoint written after the reported number of findings was processed.",
+    "diagnostic": "An execution warning or error raised during the current operation.",
+    "retry": "A retry scheduled after the previous attempt failed or returned an invalid result.",
+    "model.round": "One model response in the tool loop and the tool calls it requested.",
+    "usage": "The token usage reported for this model-provider request.",
+    "decision": "A policy, model, or deterministic adjudication decision made during the current operation.",
+    "artifact": "An in-memory review, triage, or threat-model result produced by Metis.",
+    "artifact.written": "An output file written by Metis, with its format, size, path, and digest.",
+}
+
+_PROGRESS_EXPLANATIONS = {
+    "start": "Processing began for one item; attributes identify the item and total workload.",
+    "done": "One item finished successfully; attributes include its result.",
+    "error": "One item failed; attributes identify the item and observed error.",
+    "execution_stage_start": "A configured stage began execution.",
+    "execution_stage_end": "The configured stage finished; attributes show its status and duration.",
+    "execution_node_start": "A selected node began execution within the current stage.",
+    "execution_node_end": "The selected node finished; attributes show its status and duration.",
+    "execution_node_skipped": "A node was skipped because a required dependency failed.",
+    "codegraph_start": "CodeGraph materialization began for the selected source files and language providers.",
+    "codegraph_progress": "File-level progress from one CodeGraph language provider.",
+    "codegraph_done": "CodeGraph materialization finished; attributes show graph and file-coverage totals.",
+    "combined_graph_lenses_start": "Combined supplementary graph analysis began for the selected functions and lens set.",
+    "combined_graph_lenses_done": "Combined supplementary graph analysis finished; the findings count is its raw candidate output.",
+    "reachability_file_paths_done": "File-focused path discovery finished; attributes show incoming, outgoing, and focus-node counts.",
+    "reachability_file_review_done": "File-focused reachability review finished; attributes show supplementary and path findings.",
+    "global_lifecycle_start": "Global-lifecycle analysis began after global constructs and related functions were selected; work was split into size-bounded chunks.",
+    "global_lifecycle_done": "Global-lifecycle analysis finished; the findings count is its raw candidate output before downstream validation and deduplication.",
+    "confirmation_start": "Model-backed confirmation began for the selected reachability path batches.",
+    "confirmation_progress": "One reachability confirmation batch finished.",
+    "confirmation_done": "Model-backed reachability confirmation finished; attributes show its candidate count.",
+    "findings_finalization_start": "Final validation and deduplication began for the collected candidate findings.",
+    "findings_finalization_progress": "Progress through candidate validation or representative adjudication.",
+    "findings_finalization_done": "Final validation and deduplication finished; attributes show kept and removed findings.",
+    "intra_audit_start": "Per-file intra-function auditing began for the selected functions.",
+    "intra_audit_progress": "One per-file intra-function audit batch finished.",
+    "lock_order_extraction_start": "Lock-order analysis began for the extracted conflicting acquisition candidates.",
+    "lock_order_extraction_done": "Lock-order analysis finished; attributes show its candidate findings.",
+    "supplementary_done": "All selected supplementary lenses finished; counts are grouped by analysis type before finalization.",
+    "reachability_paths_start": "Deterministic reachability path discovery began for the selected source nodes.",
+    "reachability_paths_progress": "Current progress through deterministic reachability path discovery.",
+    "reachability_paths_done": "Reachability path discovery and confirmation-path selection finished.",
+}
+
+
+def span_explanation(kind: str, name: str) -> str:
+    """Returns stable visualizer help text for a span."""
+
+    specific = _SPAN_NAME_EXPLANATIONS.get((kind, name))
+    if specific is not None:
+        return specific
+    generic = _SPAN_KIND_EXPLANATIONS.get(kind)
+    if generic is not None:
+        return generic
+    return f"The {name} {kind} operation, including its inputs, outcome, and duration."
+
+
+def event_explanation(name: str, attributes: object = None) -> str:
+    """Returns stable visualizer help text for a point event."""
+
+    if name == "progress" and isinstance(attributes, dict):
+        return progress_explanation(str(attributes.get("event") or "progress"))
+    specific = _EVENT_EXPLANATIONS.get(name)
+    if specific is not None:
+        return specific
+    return f"The {name} event emitted by the containing operation."
+
+
+def progress_explanation(event: str) -> str:
+    specific = _PROGRESS_EXPLANATIONS.get(event)
+    if specific is not None:
+        return specific
+    label = event.replace("_", " ").strip()
+    if event.endswith("_start"):
+        return f"Start of {label.removesuffix(' start')} processing; attributes summarize the selected workload."
+    if event.endswith("_progress"):
+        return f"Current progress through {label.removesuffix(' progress')} processing."
+    if event.endswith("_done"):
+        return f"Completion of {label.removesuffix(' done')} processing; attributes summarize its output before later stages."
+    if event.endswith("_error"):
+        return f"A failure during {label.removesuffix(' error')} processing, with the observed error in attributes."
+    return f"Progress information for {label} processing."
+
+
+@dataclass(frozen=True, slots=True)
+class RunLogConfig:
+    """Configuration for one run-log bundle."""
+
+    path: str | Path | None = None
+    content: ContentMode = "full"
+    blob_threshold: int = DEFAULT_BLOB_THRESHOLD
+    max_depth: int = DEFAULT_MAX_DEPTH
+    max_collection_items: int = DEFAULT_MAX_COLLECTION_ITEMS
+
+    def __post_init__(self) -> None:
+        if self.content not in {"full", "metadata"}:
+            raise ValueError("Run-log content must be 'full' or 'metadata'")
+        if self.blob_threshold < 1:
+            raise ValueError("Run-log blob threshold must be positive")
+        if self.max_depth < 1:
+            raise ValueError("Run-log maximum depth must be positive")
+        if self.max_collection_items < 1:
+            raise ValueError("Run-log maximum collection size must be positive")

--- a/src/metis/runlog/session.py
+++ b/src/metis/runlog/session.py
@@ -1,0 +1,771 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import platform
+import subprocess
+import sys
+import threading
+import time
+import traceback
+import uuid
+from collections.abc import Callable
+from collections.abc import Iterator
+from collections.abc import Mapping
+from contextvars import ContextVar
+from contextvars import Token
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+from typing import Any
+from typing import Literal
+
+from .encoding import PayloadEncoder
+from .schema import event_explanation
+from .schema import RunLogConfig
+from .schema import SCHEMA_VERSION
+from .schema import SpanStatus
+from .schema import span_explanation
+
+logger = logging.getLogger("metis")
+
+Attributes = Mapping[str, Any] | Callable[[], Mapping[str, Any]] | None
+
+_current_session: ContextVar[RunLogSession | None] = ContextVar(
+    "metis_runlog_session", default=None
+)
+_current_span: ContextVar[str | None] = ContextVar("metis_runlog_span", default=None)
+
+
+class Span:
+    __slots__ = (
+        "_ended",
+        "_session",
+        "_session_token",
+        "_span_token",
+        "_started",
+        "explanation",
+        "kind",
+        "name",
+        "parent_span_id",
+        "span_id",
+    )
+
+    def __init__(
+        self,
+        session: RunLogSession,
+        *,
+        span_id: str,
+        parent_span_id: str | None,
+        kind: str,
+        name: str,
+        explanation: str,
+        started: float,
+    ) -> None:
+        self._session = session
+        self.span_id = span_id
+        self.parent_span_id = parent_span_id
+        self.kind = kind
+        self.explanation = explanation
+        self.name = name
+        self._started = started
+        self._ended = False
+        self._session_token: Token[RunLogSession | None] | None = None
+        self._span_token: Token[str | None] | None = None
+
+    def __enter__(self) -> Span:
+        self._session_token = _current_session.set(self._session)
+        self._span_token = _current_span.set(self.span_id)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        try:
+            if not self._ended:
+                if exc is None:
+                    self.end()
+                elif isinstance(exc, KeyboardInterrupt):
+                    self.end(status="cancelled", exc=exc)
+                else:
+                    self.end(status="error", exc=exc)
+        finally:
+            if self._span_token is not None:
+                _current_span.reset(self._span_token)
+                self._span_token = None
+            if self._session_token is not None:
+                _current_session.reset(self._session_token)
+                self._session_token = None
+        return False
+
+    @contextlib.contextmanager
+    def activate(self) -> Iterator[Span]:
+        if self._ended:
+            raise RuntimeError("Cannot activate an ended run-log span")
+        session_token = _current_session.set(self._session)
+        span_token = _current_span.set(self.span_id)
+        try:
+            yield self
+        finally:
+            _current_span.reset(span_token)
+            _current_session.reset(session_token)
+
+    def event(
+        self,
+        name: str,
+        attributes: Attributes = None,
+        *,
+        explanation: str | None = None,
+        **extra: Any,
+    ) -> None:
+        if self._ended:
+            raise RuntimeError("Cannot emit an event from an ended run-log span")
+        self._session.event(
+            name,
+            attributes,
+            span_id=self.span_id,
+            explanation=explanation,
+            **extra,
+        )
+
+    def end(
+        self,
+        *,
+        status: SpanStatus = "ok",
+        attributes: Attributes = None,
+        exc: BaseException | None = None,
+        **extra: Any,
+    ) -> None:
+        if self._ended:
+            return
+        self._ended = True
+        payload = _merge_attributes(attributes, extra)
+        self._session._write_span_end(
+            span_id=self.span_id,
+            parent_span_id=self.parent_span_id,
+            kind=self.kind,
+            name=self.name,
+            started=self._started,
+            status="error" if exc is not None and status == "ok" else status,
+            explanation=self.explanation,
+            attributes=payload,
+            exc=exc,
+        )
+
+
+class _NullSpan:
+    __slots__ = ()
+    span_id = None
+    parent_span_id = None
+
+    def __enter__(self) -> _NullSpan:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    @contextlib.contextmanager
+    def activate(self) -> Iterator[_NullSpan]:
+        yield self
+
+    def event(
+        self,
+        name: str,
+        attributes: Attributes = None,
+        *,
+        explanation: str | None = None,
+        **extra: Any,
+    ) -> None:
+        return None
+
+    def end(self, **kwargs: Any) -> None:
+        return None
+
+
+_NULL_SPAN = _NullSpan()
+
+
+class RunLogSession:
+    """One append-only v1 run-log bundle and its active span context."""
+
+    def __init__(
+        self,
+        config: RunLogConfig | None = None,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.config = config or RunLogConfig()
+        self.run_id = uuid.uuid4().hex
+        self._metadata = dict(metadata or {})
+        self._lock = threading.RLock()
+        self._file: Any = None
+        self._encoder: PayloadEncoder | None = None
+        self._seq = 0
+        self._started_perf = time.perf_counter()
+        self._started_at = _utc_now()
+        self._entered = False
+        self._closed = False
+        self._failed = False
+        self._failure_message: str | None = None
+        self._outcome: SpanStatus = "ok"
+        self._outcome_exc: BaseException | None = None
+        self._counters: dict[str, int] = {}
+        self._session_token: Token[RunLogSession | None] | None = None
+        self._span_token: Token[str | None] | None = None
+        self.root_span_id = uuid.uuid4().hex[:16]
+        self.output_dir, self.ndjson_path, self.meta_path, self.blobs_dir = (
+            _resolve_paths(self.config.path, self.run_id)
+        )
+
+    def __enter__(self) -> RunLogSession:
+        if self._entered:
+            raise RuntimeError("Run-log session is already open")
+        created_ndjson = False
+        try:
+            self.output_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            self.output_dir.chmod(0o700)
+            self._file = self.ndjson_path.open("x", encoding="utf-8", buffering=1)
+            created_ndjson = True
+            self.ndjson_path.chmod(0o600)
+            self._encoder = PayloadEncoder(self.blobs_dir, self.config)
+            self._session_token = _current_session.set(self)
+            self._span_token = _current_span.set(self.root_span_id)
+            self._write_meta(complete=False)
+            self._write_record(
+                "span.start",
+                span_id=self.root_span_id,
+                parent_span_id=None,
+                kind="run",
+                name="metis",
+                attributes=self._root_attributes(),
+                strict=True,
+            )
+        except Exception:
+            if self._file is not None:
+                try:
+                    self._file.close()
+                except Exception:
+                    pass
+            self._reset_context()
+            if created_ndjson:
+                self.ndjson_path.unlink(missing_ok=True)
+                self.meta_path.unlink(missing_ok=True)
+            raise
+        self._entered = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if exc is not None:
+            self.set_outcome(
+                "cancelled" if isinstance(exc, KeyboardInterrupt) else "error",
+                exc=exc,
+            )
+        self.close()
+        return False
+
+    @property
+    def enabled(self) -> bool:
+        return self._entered and not self._closed and not self._failed
+
+    @property
+    def counters(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._counters)
+
+    def bind(self) -> contextlib.AbstractContextManager[RunLogSession]:
+        return bind_runlog(self)
+
+    def set_outcome(
+        self,
+        status: SpanStatus,
+        *,
+        exc: BaseException | None = None,
+    ) -> None:
+        with self._lock:
+            if _status_rank(status) >= _status_rank(self._outcome):
+                self._outcome = status
+                self._outcome_exc = exc
+
+    def bump(self, key: str, amount: int = 1) -> None:
+        with self._lock:
+            self._counters[key] = self._counters.get(key, 0) + int(amount)
+
+    def span(
+        self,
+        kind: str,
+        name: str | None = None,
+        attributes: Attributes = None,
+        *,
+        explanation: str | None = None,
+        parent_span_id: str | None = None,
+        **extra: Any,
+    ) -> Span | _NullSpan:
+        if not self.enabled:
+            return _NULL_SPAN
+        parent = parent_span_id
+        if parent is None:
+            parent = (
+                _current_span.get()
+                if _current_session.get() is self
+                else self.root_span_id
+            )
+        span_name = name or kind
+        resolved_explanation = explanation or span_explanation(kind, span_name)
+        span_id = uuid.uuid4().hex[:16]
+        started = time.perf_counter()
+        self._write_record(
+            "span.start",
+            span_id=span_id,
+            parent_span_id=parent,
+            kind=kind,
+            name=span_name,
+            explanation=resolved_explanation,
+            attributes=_merge_attributes(attributes, extra),
+        )
+        return Span(
+            self,
+            span_id=span_id,
+            parent_span_id=parent,
+            kind=kind,
+            name=span_name,
+            explanation=resolved_explanation,
+            started=started,
+        )
+
+    def event(
+        self,
+        name: str,
+        attributes: Attributes = None,
+        *,
+        span_id: str | None = None,
+        explanation: str | None = None,
+        **extra: Any,
+    ) -> None:
+        if not self.enabled:
+            return
+        owner = span_id
+        if owner is None:
+            owner = (
+                _current_span.get()
+                if _current_session.get() is self
+                else self.root_span_id
+            )
+        self._write_record(
+            "event",
+            span_id=owner or self.root_span_id,
+            name=name,
+            attributes=_merge_attributes(attributes, extra),
+            explanation=explanation,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        try:
+            if self._entered and not self._failed:
+                self._write_span_end(
+                    span_id=self.root_span_id,
+                    parent_span_id=None,
+                    kind="run",
+                    name="metis",
+                    started=self._started_perf,
+                    status=self._outcome,
+                    attributes={"totals": self.counters},
+                    exc=self._outcome_exc,
+                )
+            if self._entered:
+                try:
+                    self._write_meta(complete=not self._failed)
+                except Exception as exc:
+                    self._disable_after_failure(exc)
+        finally:
+            self._closed = True
+            if self._file is not None:
+                try:
+                    self._file.flush()
+                except Exception as exc:
+                    self._disable_after_failure(exc)
+                try:
+                    self._file.close()
+                except Exception as exc:
+                    self._disable_after_failure(exc)
+            self._reset_context()
+
+    def _reset_context(self) -> None:
+        if self._span_token is not None:
+            _current_span.reset(self._span_token)
+            self._span_token = None
+        if self._session_token is not None:
+            _current_session.reset(self._session_token)
+            self._session_token = None
+
+    def _root_attributes(self) -> dict[str, Any]:
+        return {
+            **self._metadata,
+            "started_at": self._started_at,
+            "output_dir": str(self.output_dir),
+            "ndjson_path": str(self.ndjson_path),
+            "content": self.config.content,
+        }
+
+    def _write_span_end(
+        self,
+        *,
+        span_id: str,
+        parent_span_id: str | None,
+        kind: str,
+        name: str,
+        started: float,
+        status: SpanStatus,
+        attributes: Attributes,
+        explanation: str | None = None,
+        exc: BaseException | None = None,
+    ) -> None:
+        error = _exception_payload(exc) if exc is not None else None
+        self._write_record(
+            "span.end",
+            span_id=span_id,
+            parent_span_id=parent_span_id,
+            kind=kind,
+            name=name,
+            explanation=explanation,
+            status=status,
+            duration_ms=(time.perf_counter() - started) * 1000.0,
+            error=error,
+            attributes=attributes,
+        )
+
+    def _write_record(
+        self,
+        record_type: Literal["span.start", "span.end", "event"],
+        *,
+        span_id: str,
+        name: str,
+        attributes: Attributes,
+        parent_span_id: str | None = None,
+        explanation: str | None = None,
+        kind: str | None = None,
+        status: SpanStatus | None = None,
+        duration_ms: float | None = None,
+        error: Mapping[str, Any] | None = None,
+        strict: bool = False,
+    ) -> None:
+        try:
+            with self._lock:
+                if self._failed and not strict:
+                    return
+                if self._file is None or self._encoder is None:
+                    raise RuntimeError("Run-log session is not open")
+                materialized_attributes = _materialize_attributes(attributes)
+                resolved_explanation = (explanation or "").strip()
+                if not resolved_explanation:
+                    resolved_explanation = (
+                        event_explanation(name, materialized_attributes)
+                        if record_type == "event"
+                        else span_explanation(kind or "operation", name)
+                    )
+                record: dict[str, Any] = {
+                    "v": SCHEMA_VERSION,
+                    "record": record_type,
+                    "record_id": uuid.uuid4().hex[:16],
+                    "ts": _utc_now(),
+                    "mono_ns": time.perf_counter_ns(),
+                    "seq": self._seq,
+                    "run_id": self.run_id,
+                    "span_id": span_id,
+                    "name": name,
+                    "explanation": resolved_explanation,
+                    "thread": threading.current_thread().name,
+                    "thread_id": threading.get_ident(),
+                    "attributes": self._encoder.encode_mapping(materialized_attributes),
+                }
+                if record_type != "event":
+                    record["parent_span_id"] = parent_span_id
+                    record["kind"] = kind
+                if status is not None:
+                    record["status"] = status
+                if duration_ms is not None:
+                    record["duration_ms"] = round(duration_ms, 3)
+                if error is not None:
+                    record["error"] = self._encoder.encode_mapping(error)
+                line = json.dumps(
+                    record,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    separators=(",", ":"),
+                )
+                self._file.write(line + "\n")
+                self._file.flush()
+                self._seq += 1
+        except Exception as exc:
+            if strict or not self._entered:
+                raise
+            self._disable_after_failure(exc)
+
+    def _write_meta(self, *, complete: bool) -> None:
+        if self._encoder is None:
+            return
+        payload = {
+            "v": SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "started_at": self._started_at,
+            "ended_at": _utc_now() if complete else None,
+            "complete": complete,
+            "status": self._outcome if complete else "running",
+            "content": self.config.content,
+            "ndjson_path": str(self.ndjson_path),
+            "blobs_dir": str(self.blobs_dir),
+            "metadata": self._encoder.encode_mapping(self._metadata),
+            "totals": self.counters if complete else {},
+        }
+        temporary = self.meta_path.with_name(
+            f".{self.meta_path.name}.{uuid.uuid4().hex}.tmp"
+        )
+        temporary.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        try:
+            with temporary.open("x", encoding="utf-8") as handle:
+                json.dump(
+                    payload, handle, ensure_ascii=False, allow_nan=False, indent=2
+                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            temporary.chmod(0o600)
+            os.replace(temporary, self.meta_path)
+            self.meta_path.chmod(0o600)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _disable_after_failure(self, exc: BaseException) -> None:
+        with self._lock:
+            if self._failed:
+                return
+            self._failed = True
+            self._failure_message = f"{type(exc).__name__}: {exc}"
+        logger.warning("Workflow run logging disabled after write failure: %s", exc)
+
+
+@contextlib.contextmanager
+def bind_runlog(session: RunLogSession | None) -> Iterator[RunLogSession | None]:
+    if session is None:
+        yield None
+        return
+    if _current_session.get() is session:
+        yield session
+        return
+    session_token = _current_session.set(session)
+    span_token = _current_span.set(session.root_span_id)
+    try:
+        yield session
+    finally:
+        _current_span.reset(span_token)
+        _current_session.reset(session_token)
+
+
+def open_runlog(
+    config: RunLogConfig | None = None,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> RunLogSession:
+    return RunLogSession(config, metadata=metadata)
+
+
+def current_runlog() -> RunLogSession | None:
+    session = _current_session.get()
+    return session if session is not None and session.enabled else None
+
+
+def is_enabled() -> bool:
+    return current_runlog() is not None
+
+
+def span(
+    kind: str,
+    name: str | None = None,
+    attributes: Attributes = None,
+    *,
+    explanation: str | None = None,
+    **extra: Any,
+) -> Span | _NullSpan:
+    session = current_runlog()
+    if session is None:
+        return _NULL_SPAN
+    return session.span(
+        kind,
+        name,
+        attributes,
+        explanation=explanation,
+        **extra,
+    )
+
+
+def event(
+    name: str,
+    attributes: Attributes = None,
+    *,
+    explanation: str | None = None,
+    **extra: Any,
+) -> None:
+    session = current_runlog()
+    if session is not None:
+        session.event(name, attributes, explanation=explanation, **extra)
+
+
+def bump(key: str, amount: int = 1) -> None:
+    session = current_runlog()
+    if session is not None:
+        session.bump(key, amount)
+
+
+def build_run_metadata(
+    *,
+    argv: list[str] | None = None,
+    metis_version: str = "unknown",
+    codebase_path: str | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    command_argv = list(sys.argv if argv is None else argv)
+    cwd = os.getcwd()
+    return {
+        "argv": _redact_argv(command_argv),
+        "command": " ".join(_redact_argv(command_argv)),
+        "metis_version": metis_version,
+        "config": dict(config or {}),
+        "cwd": cwd,
+        "codebase_path": codebase_path,
+        "git": _git_info(codebase_path or cwd),
+        "host": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "pid": os.getpid(),
+        },
+    }
+
+
+def _resolve_paths(
+    path_override: str | Path | None,
+    run_id: str,
+) -> tuple[Path, Path, Path, Path]:
+    if path_override is not None:
+        requested = Path(path_override).expanduser()
+        if requested.suffix.lower() == ".ndjson":
+            ndjson = requested.resolve()
+            output_dir = ndjson.parent
+            meta = ndjson.with_suffix(ndjson.suffix + ".meta.json")
+            blobs = ndjson.with_suffix(".blobs")
+            return output_dir, ndjson, meta, blobs
+        base = requested
+    else:
+        base = Path("metis-runlog")
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = (base / f"{stamp}_{run_id[:6]}").resolve()
+    return (
+        output_dir,
+        output_dir / "run.ndjson",
+        output_dir / "meta.json",
+        output_dir / "blobs",
+    )
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _materialize_attributes(attributes: Attributes) -> Mapping[str, Any]:
+    if attributes is None:
+        return {}
+    if callable(attributes):
+        try:
+            return dict(attributes())
+        except Exception as exc:
+            return {"telemetry_attribute_error": f"{type(exc).__name__}: {exc}"}
+    return dict(attributes)
+
+
+def _merge_attributes(
+    attributes: Attributes,
+    extra: Mapping[str, Any],
+) -> Attributes:
+    if not extra:
+        return attributes
+    if callable(attributes):
+        return lambda: {**dict(attributes()), **extra}
+    return {**dict(attributes or {}), **extra}
+
+
+def _exception_payload(exc: BaseException) -> dict[str, Any]:
+    return {
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "traceback": "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        ),
+    }
+
+
+def _status_rank(status: SpanStatus) -> int:
+    return {"ok": 0, "inconclusive": 1, "cancelled": 2, "error": 3}[status]
+
+
+def _git_info(cwd: str) -> dict[str, Any]:
+    def run(*command: str) -> str | None:
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except Exception:
+            return None
+        return completed.stdout.strip() if completed.returncode == 0 else None
+
+    commit = run("git", "rev-parse", "HEAD")
+    if commit is None:
+        return {}
+    return {
+        "commit": commit,
+        "branch": run("git", "rev-parse", "--abbrev-ref", "HEAD"),
+        "dirty": bool(run("git", "status", "--porcelain")),
+    }
+
+
+def _redact_argv(argv: list[str]) -> list[str]:
+    redacted: list[str] = []
+    hide_next = False
+    for argument in argv:
+        if hide_next:
+            redacted.append("[REDACTED]")
+            hide_next = False
+            continue
+        lowered = argument.lower().replace("-", "_")
+        if argument.startswith("--") and "=" in argument:
+            flag, value = argument.split("=", 1)
+            if _sensitive_flag(flag):
+                redacted.append(f"{flag}=[REDACTED]")
+            else:
+                redacted.append(f"{flag}={value}")
+            continue
+        redacted.append(argument)
+        if argument.startswith("--") and _sensitive_flag(lowered):
+            hide_next = True
+    return redacted
+
+
+def _sensitive_flag(flag: str) -> bool:
+    normalized = flag.lower().replace("-", "_")
+    return any(
+        token in normalized
+        for token in (
+            "api_key",
+            "authorization",
+            "credential",
+            "password",
+            "secret",
+            "token",
+        )
+    )

--- a/src/metis/runlog/validation.py
+++ b/src/metis/runlog/validation.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .schema import SCHEMA_VERSION
+
+_SPAN_STATUSES = {"ok", "error", "cancelled", "inconclusive"}
+
+
+class TraceValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class TraceSummary:
+    run_id: str
+    records: int
+    spans: int
+    events: int
+    blobs: int
+    status: str
+
+
+def validate_runlog(path: str | Path, *, verify_blobs: bool = True) -> TraceSummary:
+    """Validates one complete v1 run-log bundle and its referenced blobs."""
+
+    trace_path = Path(path).resolve()
+    starts: dict[str, dict[str, Any]] = {}
+    ended: set[str] = set()
+    open_children: dict[str, set[str]] = {}
+    record_ids: set[str] = set()
+    run_id: str | None = None
+    root_span_id: str | None = None
+    root_status: str | None = None
+    event_count = 0
+    blob_refs: dict[str, dict[str, Any]] = {}
+    record_count = 0
+    last_record: dict[str, Any] | None = None
+
+    with trace_path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.endswith("\n"):
+                raise TraceValidationError(
+                    f"Trace line {line_number} is not newline-terminated"
+                )
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise TraceValidationError(
+                    f"Trace line {line_number} is invalid JSON: {exc}"
+                ) from exc
+            _require(isinstance(record, dict), line_number, "record object")
+            _require(record.get("v") == SCHEMA_VERSION, line_number, "schema version")
+            _require(record.get("seq") == record_count, line_number, "sequence")
+            _required_string(record, "ts", line_number)
+            _require(
+                isinstance(record.get("mono_ns"), int)
+                and not isinstance(record.get("mono_ns"), bool)
+                and record["mono_ns"] >= 0,
+                line_number,
+                "non-negative mono_ns",
+            )
+            _required_string(record, "thread", line_number)
+            _require(
+                isinstance(record.get("thread_id"), int)
+                and not isinstance(record.get("thread_id"), bool),
+                line_number,
+                "integer thread_id",
+            )
+            _require(
+                isinstance(record.get("attributes"), dict),
+                line_number,
+                "attributes object",
+            )
+            record_id = _required_string(record, "record_id", line_number)
+            _require(record_id not in record_ids, line_number, "unique record_id")
+            record_ids.add(record_id)
+            current_run_id = _required_string(record, "run_id", line_number)
+            if run_id is None:
+                run_id = current_run_id
+            _require(current_run_id == run_id, line_number, "single run_id")
+            _required_string(record, "name", line_number)
+            _required_string(record, "explanation", line_number)
+            span_id = _required_string(record, "span_id", line_number)
+            record_type = record.get("record")
+            if record_type == "span.start":
+                _require(span_id not in starts, line_number, "unique span start")
+                kind = _required_string(record, "kind", line_number)
+                _require("status" not in record, line_number, "start status omission")
+                _require(
+                    "duration_ms" not in record,
+                    line_number,
+                    "start duration omission",
+                )
+                _require("error" not in record, line_number, "start error omission")
+                parent = record.get("parent_span_id")
+                if kind == "run":
+                    _require(record_count == 0, line_number, "root span starts first")
+                    _require(root_span_id is None, line_number, "single root span")
+                    _require(parent is None, line_number, "root parent omission")
+                    root_span_id = span_id
+                else:
+                    _require(root_span_id is not None, line_number, "root span exists")
+                    _require(isinstance(parent, str), line_number, "child parent span")
+                    _require(parent in starts, line_number, "known parent span")
+                    _require(parent not in ended, line_number, "open parent span")
+                    open_children[parent].add(span_id)
+                starts[span_id] = record
+                open_children[span_id] = set()
+            elif record_type == "span.end":
+                _require(span_id in starts, line_number, "matching span start")
+                _require(span_id not in ended, line_number, "single span end")
+                _require(
+                    not open_children[span_id],
+                    line_number,
+                    "all child spans ended first",
+                )
+                start = starts[span_id]
+                _require(
+                    record.get("parent_span_id") == start.get("parent_span_id"),
+                    line_number,
+                    "stable parent_span_id",
+                )
+                _require(
+                    record.get("kind") == start.get("kind"), line_number, "stable kind"
+                )
+                _require(
+                    record.get("name") == start.get("name"), line_number, "stable name"
+                )
+                _require(
+                    record.get("explanation") == start.get("explanation"),
+                    line_number,
+                    "stable explanation",
+                )
+                status = _required_string(record, "status", line_number)
+                _require(status in _SPAN_STATUSES, line_number, "known span status")
+                duration = record.get("duration_ms")
+                _require(
+                    isinstance(duration, (int, float))
+                    and not isinstance(duration, bool)
+                    and duration >= 0,
+                    line_number,
+                    "non-negative duration_ms",
+                )
+                if "error" in record:
+                    _require(
+                        isinstance(record["error"], dict),
+                        line_number,
+                        "error object",
+                    )
+                ended.add(span_id)
+                parent = start.get("parent_span_id")
+                if isinstance(parent, str):
+                    open_children[parent].discard(span_id)
+                if span_id == root_span_id:
+                    root_status = status
+            elif record_type == "event":
+                _require(span_id in starts, line_number, "known containing span")
+                _require(span_id not in ended, line_number, "open containing span")
+                for forbidden in (
+                    "parent_span_id",
+                    "kind",
+                    "status",
+                    "duration_ms",
+                    "error",
+                ):
+                    _require(
+                        forbidden not in record,
+                        line_number,
+                        f"event {forbidden} omission",
+                    )
+                event_count += 1
+            else:
+                raise TraceValidationError(
+                    f"Trace line {line_number} has unknown record type {record_type!r}"
+                )
+            _collect_blob_refs(record.get("attributes"), blob_refs)
+            _collect_blob_refs(record.get("error"), blob_refs)
+            record_count += 1
+            last_record = record
+
+    if run_id is None or root_span_id is None:
+        raise TraceValidationError("Trace has no root span")
+    unclosed = set(starts) - ended
+    if unclosed:
+        raise TraceValidationError(f"Trace has unclosed spans: {sorted(unclosed)!r}")
+    if (
+        last_record is None
+        or last_record.get("record") != "span.end"
+        or last_record.get("span_id") != root_span_id
+    ):
+        raise TraceValidationError("Trace root span must end last")
+    meta_status = _validate_meta(trace_path, run_id)
+    if root_status != meta_status:
+        raise TraceValidationError(
+            f"Trace root status {root_status!r} does not match metadata {meta_status!r}"
+        )
+    if verify_blobs:
+        for reference, metadata in blob_refs.items():
+            _validate_blob(trace_path.parent, reference, metadata)
+    return TraceSummary(
+        run_id=run_id,
+        records=record_count,
+        spans=len(starts),
+        events=event_count,
+        blobs=len(blob_refs),
+        status=meta_status,
+    )
+
+
+def _validate_meta(trace_path: Path, run_id: str) -> str:
+    exact_meta = trace_path.with_suffix(trace_path.suffix + ".meta.json")
+    bundle_meta = trace_path.parent / "meta.json"
+    meta_path = exact_meta if exact_meta.is_file() else bundle_meta
+    if not meta_path.is_file():
+        raise TraceValidationError(f"Run-log metadata does not exist: {meta_path}")
+    try:
+        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise TraceValidationError(f"Run-log metadata is invalid JSON: {exc}") from exc
+    _meta_require(isinstance(metadata, dict), "metadata object")
+    _meta_require(metadata.get("v") == SCHEMA_VERSION, "metadata schema version")
+    _meta_require(metadata.get("run_id") == run_id, "metadata run_id")
+    _meta_require(metadata.get("complete") is True, "complete metadata")
+    status = metadata.get("status")
+    _meta_require(status in _SPAN_STATUSES, "known metadata status")
+    _meta_require(metadata.get("content") in {"full", "metadata"}, "content mode")
+    _meta_require(isinstance(metadata.get("started_at"), str), "started_at")
+    _meta_require(isinstance(metadata.get("ended_at"), str), "ended_at")
+    _meta_require(isinstance(metadata.get("metadata"), dict), "metadata payload")
+    _meta_require(isinstance(metadata.get("totals"), dict), "metadata totals")
+    return str(status)
+
+
+def _meta_require(condition: bool, invariant: str) -> None:
+    if not condition:
+        raise TraceValidationError(f"Run-log metadata violates invariant: {invariant}")
+
+
+def _collect_blob_refs(value: Any, references: dict[str, dict[str, Any]]) -> None:
+    if isinstance(value, dict):
+        reference = value.get("$ref")
+        if isinstance(reference, str):
+            previous = references.setdefault(reference, value)
+            if previous.get("sha256") != value.get("sha256"):
+                raise TraceValidationError(
+                    f"Blob reference {reference!r} has conflicting digests"
+                )
+            return
+        for item in value.values():
+            _collect_blob_refs(item, references)
+    elif isinstance(value, list):
+        for item in value:
+            _collect_blob_refs(item, references)
+
+
+def _validate_blob(base: Path, reference: str, metadata: dict[str, Any]) -> None:
+    path = (base / reference).resolve()
+    try:
+        path.relative_to(base)
+    except ValueError as exc:
+        raise TraceValidationError(
+            f"Blob reference escapes trace directory: {reference}"
+        ) from exc
+    if not path.is_file():
+        raise TraceValidationError(f"Blob reference does not exist: {reference}")
+    expected_bytes = metadata.get("bytes")
+    if (
+        not isinstance(expected_bytes, int)
+        or isinstance(expected_bytes, bool)
+        or expected_bytes < 0
+    ):
+        raise TraceValidationError(f"Blob byte count is invalid: {reference}")
+    expected_digest = metadata.get("sha256")
+    if not isinstance(expected_digest, str) or len(expected_digest) != 64:
+        raise TraceValidationError(f"Blob digest is invalid: {reference}")
+    try:
+        int(expected_digest, 16)
+    except ValueError as exc:
+        raise TraceValidationError(f"Blob digest is invalid: {reference}") from exc
+    if not isinstance(metadata.get("media_type"), str):
+        raise TraceValidationError(f"Blob media type is invalid: {reference}")
+    if not isinstance(metadata.get("preview"), str):
+        raise TraceValidationError(f"Blob preview is invalid: {reference}")
+    digest = hashlib.sha256()
+    actual_bytes = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            actual_bytes += len(chunk)
+            digest.update(chunk)
+    if actual_bytes != expected_bytes:
+        raise TraceValidationError(f"Blob byte count does not match: {reference}")
+    if digest.hexdigest() != expected_digest:
+        raise TraceValidationError(f"Blob digest does not match: {reference}")
+
+
+def _required_string(record: dict[str, Any], key: str, line_number: int) -> str:
+    value = record.get(key)
+    _require(isinstance(value, str) and bool(value), line_number, key)
+    return value
+
+
+def _require(condition: bool, line_number: int, invariant: str) -> None:
+    if not condition:
+        raise TraceValidationError(
+            f"Trace line {line_number} violates invariant: {invariant}"
+        )

--- a/src/metis/runlog/workflow.py
+++ b/src/metis/runlog/workflow.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from .session import span
+
+
+def traced_step(workflow: str, name: str, function: Callable[..., Any]):
+    """Wraps one inner-workflow node without changing its invocation contract."""
+
+    def invoke(state, *args, **kwargs):
+        with span(
+            "step",
+            f"{workflow}.{name}",
+            lambda: {
+                "workflow": workflow,
+                "step": name,
+                "input_keys": sorted(state) if isinstance(state, dict) else [],
+                "input": state,
+            },
+        ) as step_span:
+            result = function(state, *args, **kwargs)
+            step_span.end(attributes={"output": result})
+            return result
+
+    return invoke

--- a/src/metis/usage/langchain.py
+++ b/src/metis/usage/langchain.py
@@ -84,8 +84,6 @@ class UsageCallbackHandler(BaseCallbackHandler):
 
     def on_llm_end(self, response, **kwargs: Any) -> Any:
         scope_id = current_scope()
-        if not scope_id:
-            return None
         input_tokens, output_tokens, total_tokens = _extract_usage_metadata(response)
         if input_tokens <= 0 and output_tokens <= 0 and total_tokens <= 0:
             return None

--- a/src/metis/usage/runtime.py
+++ b/src/metis/usage/runtime.py
@@ -15,6 +15,8 @@ from .collector import UsageCollector
 from .context import usage_operation, usage_scope
 from .langchain import UsageCallbackHandler
 from .llamaindex import UsageLlamaIndexHandler
+from metis.runlog.langchain import RUNLOG_CALLBACK_HANDLER
+
 from metis.providers.base import (
     EmbedModelKwargs,
     ProviderChatModelKwargs,
@@ -65,7 +67,7 @@ class UsageRuntime:
         self.langchain_handler = UsageCallbackHandler(self.collector)
         self.hooks = UsageHooks(
             callback_manager=CallbackManager([UsageLlamaIndexHandler(self.collector)]),
-            callbacks=[self.langchain_handler],
+            callbacks=[self.langchain_handler, RUNLOG_CALLBACK_HANDLER],
         )
         self._lock = Lock()
         self._command_sequence = 0

--- a/src/metis/vector_store/retrievers.py
+++ b/src/metis/vector_store/retrievers.py
@@ -11,6 +11,7 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
 from metis.chat_model_options import merge_chat_model_kwargs
+from metis import runlog
 
 
 def retriever_query_config(runtime: dict[str, Any]) -> dict[str, Any]:
@@ -80,10 +81,21 @@ class QueryAnswerRetriever:
         )
 
     def _retrieve_context(self, query: str) -> str:
-        documents = retrieve_documents(self._retriever, query)
-        return "\n\n".join(
-            text for document in (documents or []) if (text := document_text(document))
-        )
+        with runlog.span(
+            "retrieval",
+            type(self._retriever).__name__,
+            {"query": query},
+        ) as retrieval_span:
+            documents = retrieve_documents(self._retriever, query)
+            texts = [
+                text
+                for document in (documents or [])
+                if (text := document_text(document))
+            ]
+            retrieval_span.end(
+                attributes={"hit_count": len(texts), "documents": documents}
+            )
+            return "\n\n".join(texts)
 
 
 class ChromaCollectionRetriever:

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -3,6 +3,7 @@
 
 from contextlib import nullcontext
 from pathlib import Path
+import json
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -572,3 +573,46 @@ def test_build_engine_allows_graphs_without_index_stage_to_omit_embeddings(
     engine, _backend = entry.build_engine(args, runtime)
 
     assert engine.kwargs["embedding_provider"] is None
+
+
+def test_main_writes_workflow_runlog_bundle(monkeypatch, tmp_path):
+    trace_path = tmp_path / "workflow.ndjson"
+
+    class Engine:
+        def execute_graph(self, **_kwargs):
+            return ExecutionResult(ExecutionStatus.OK, {}, ())
+
+    def build_engine(args, _runtime):
+        assert args._metis_runlog.ndjson_path == trace_path.resolve()
+        return Engine(), None
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "metis",
+            "--non-interactive",
+            "--log-workflow-debug-path",
+            str(trace_path),
+        ],
+    )
+    monkeypatch.setattr(entry, "load_runtime_config", lambda **_kwargs: {})
+    monkeypatch.setattr(entry, "build_engine", build_engine)
+    monkeypatch.setattr(entry, "determine_output_file", lambda *_args: None)
+    monkeypatch.setattr(entry, "print_console", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(entry, "finalize_cli_session_and_close", lambda *_args: None)
+
+    entry.main()
+
+    records = [
+        json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert records[0]["kind"] == "run"
+    command = next(
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "command"
+    )
+    assert command["name"] == "execution_graph"
+    assert records[-1]["kind"] == "run"
+    assert records[-1]["status"] == "ok"

--- a/tests/test_cli_triage.py
+++ b/tests/test_cli_triage.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import json
 import pytest
+from metis import runlog
 from metis.cli import triage_cli
 from metis.cli.command_runtime import CommandRuntime
 from metis.cli.commands import run_triage
@@ -44,6 +45,24 @@ def test_save_output_replaces_json_only_after_serialization_succeeds(tmp_path):
         save_output(output_path, {"invalid": object()}, quiet=True)
 
     assert output_path.read_text(encoding="utf-8") == '{"original": true}'
+
+
+def test_save_output_records_written_artifact(tmp_path):
+    trace_path = tmp_path / "trace.ndjson"
+    output_path = tmp_path / "report.json"
+    with runlog.open_runlog(runlog.RunLogConfig(path=trace_path)):
+        save_output(output_path, {"reviews": []}, quiet=True)
+
+    records = [
+        json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()
+    ]
+    artifact = next(
+        record for record in records if record["name"] == "artifact.written"
+    )
+    assert artifact["attributes"]["path"] == str(output_path.resolve())
+    assert artifact["attributes"]["format"] == "json"
+    assert artifact["attributes"]["bytes"] == output_path.stat().st_size
+    assert len(artifact["attributes"]["sha256"]) == 64
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runlog.py
+++ b/tests/test_runlog.py
@@ -1,0 +1,582 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.callbacks import CallbackManager
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableLambda
+
+from metis.engine import MetisEngine
+from metis.engine.execution import ExecutionResult
+from metis.engine.execution import ExecutionStatus
+from metis.engine.execution.catalog import NodeCatalog
+from metis.engine.execution.compiler import compile_stage
+from metis.engine.execution.contracts import NodeCallbacks
+from metis.engine.execution.contracts import NodeContext
+from metis.engine.execution.contracts import NodeRegistration
+from metis.engine.execution.contracts import NodeResult
+from metis.engine.execution.contracts import NodeRuntime
+from metis.engine.execution.graph import StageConfiguration
+from metis.engine.execution.runner import run_stage
+from metis.engine.llm_runner import JsonPromptRequest
+from metis.engine.llm_runner import JsonPromptRunner
+from metis.engine.model_tool_runner import invoke_model_with_tools
+from metis.execution_nodes import EmptyNodeConfiguration
+from metis.runlog.langchain import RUNLOG_CALLBACK_HANDLER
+from metis.runlog.langchain import RunLogCallbackHandler
+from metis.runlog.langchain import ensure_runlog_callback
+
+from metis import runlog
+
+
+def _records(session: runlog.RunLogSession) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in session.ndjson_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _exact_config(tmp_path: Path, **kwargs) -> runlog.RunLogConfig:
+    return runlog.RunLogConfig(path=tmp_path / "trace.ndjson", **kwargs)
+
+
+def test_disabled_helpers_do_not_evaluate_lazy_attributes(tmp_path):
+    evaluated = False
+
+    def attributes():
+        nonlocal evaluated
+        evaluated = True
+        return {"path": tmp_path}
+
+    with runlog.span("task", attributes=attributes):
+        runlog.event("progress", attributes)
+
+    assert evaluated is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_session_writes_v1_root_lifecycle_and_meta(tmp_path):
+    session = runlog.open_runlog(
+        _exact_config(tmp_path),
+        metadata={"command": "review", "api_key": "secret-value"},
+    )
+    with session:
+        assert runlog.current_runlog() is session
+        runlog.event("ready", {"value": 1})
+
+    records = _records(session)
+    assert [record["seq"] for record in records] == list(range(len(records)))
+    assert records[0]["record"] == "span.start"
+    assert records[0]["kind"] == "run"
+    assert records[0]["parent_span_id"] is None
+    assert records[-1]["record"] == "span.end"
+    assert records[-1]["span_id"] == records[0]["span_id"]
+    assert records[-1]["status"] == "ok"
+    assert runlog.SCHEMA_VERSION == 1
+    assert all(record["v"] == runlog.SCHEMA_VERSION for record in records)
+    assert len({record["record_id"] for record in records}) == len(records)
+    assert all(record["explanation"].strip() for record in records)
+    assert records[0]["explanation"] == records[-1]["explanation"]
+
+    meta = json.loads(session.meta_path.read_text(encoding="utf-8"))
+    assert meta["complete"] is True
+    assert meta["status"] == "ok"
+    assert meta["metadata"]["api_key"]["$redacted"] is True
+    assert runlog.current_runlog() is None
+
+
+def test_span_hierarchy_and_point_event_identity(tmp_path):
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        with runlog.span(
+            "command",
+            "review",
+            explanation="The review of one user-selected target.",
+        ) as command:
+            with runlog.span("stage", "review") as stage:
+                with runlog.span("task", "Global lifecycle chunk") as lifecycle:
+                    lifecycle.event(
+                        "progress",
+                        {
+                            "event": "global_lifecycle_start",
+                            "globals": 224,
+                            "functions": 59,
+                        },
+                    )
+
+    records = _records(session)
+    command_start = next(
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "command"
+    )
+    stage_start = next(
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "stage"
+    )
+    lifecycle_start = next(
+        record
+        for record in records
+        if record["record"] == "span.start"
+        and record.get("name") == "Global lifecycle chunk"
+    )
+    progress = next(record for record in records if record["record"] == "event")
+
+    assert command_start["parent_span_id"] == session.root_span_id
+    assert stage_start["parent_span_id"] == command_start["span_id"]
+    assert lifecycle_start["parent_span_id"] == stage_start["span_id"]
+    assert progress["span_id"] == lifecycle_start["span_id"]
+    assert "parent_span_id" not in progress
+    assert progress["record_id"] != progress["span_id"]
+    assert command_start["explanation"] == "The review of one user-selected target."
+    assert stage_start["explanation"] == (
+        "One configured initialize, review, or triage stage executed as part of "
+        "the workflow."
+    )
+    assert lifecycle_start["explanation"] == (
+        "A size-bounded batch of functions checked for lifecycle asymmetry "
+        "involving global callbacks, timers, work items, operation tables, or "
+        "shared references."
+    )
+    assert progress["explanation"] == (
+        "Global-lifecycle analysis began after global constructs and related "
+        "functions were selected; work was split into size-bounded chunks."
+    )
+    assert command.span_id != stage.span_id != lifecycle.span_id
+
+
+def test_exception_closes_span_and_run_as_error(tmp_path):
+    session = runlog.open_runlog(_exact_config(tmp_path))
+    with pytest.raises(ValueError, match="boom"):
+        with session:
+            with runlog.span("task", "failing"):
+                raise ValueError("boom")
+
+    records = _records(session)
+    task_end = next(
+        record
+        for record in records
+        if record["record"] == "span.end" and record.get("kind") == "task"
+    )
+    assert task_end["status"] == "error"
+    assert task_end["error"]["type"] == "ValueError"
+    assert task_end["error"]["message"] == "boom"
+    assert records[-1]["kind"] == "run"
+    assert records[-1]["status"] == "error"
+
+
+def test_large_text_and_structured_payloads_use_atomic_blobs(tmp_path):
+    config = _exact_config(tmp_path, blob_threshold=48)
+    with runlog.open_runlog(config) as session:
+        runlog.event(
+            "payload",
+            {
+                "prompt": "A" * 100,
+                "state": {"items": [f"item-{index}" for index in range(20)]},
+                "config": {
+                    "model": "test",
+                    "access_token": "top-secret",
+                    "client_secret": "client-secret",
+                    "private_key": "private-key",
+                    "headers": {"cookie": "session=secret"},
+                },
+            },
+        )
+        runlog.event("duplicate", {"prompt": "A" * 100})
+
+    records = _records(session)
+    payload = next(record for record in records if record["name"] == "payload")
+    duplicate = next(record for record in records if record["name"] == "duplicate")
+    prompt_ref = payload["attributes"]["prompt"]
+    state_ref = payload["attributes"]["state"]
+    config_value = payload["attributes"]["config"]
+
+    assert prompt_ref["$ref"] == duplicate["attributes"]["prompt"]["$ref"]
+    assert (session.output_dir / prompt_ref["$ref"]).read_text() == "A" * 100
+    assert json.loads((session.output_dir / state_ref["$ref"]).read_text())["items"]
+    if "$ref" in config_value:
+        config_value = json.loads(
+            (session.output_dir / config_value["$ref"]).read_text(encoding="utf-8")
+        )
+    assert config_value["access_token"]["$redacted"] is True
+    assert config_value["client_secret"]["$redacted"] is True
+    assert config_value["private_key"]["$redacted"] is True
+    headers_value = config_value["headers"]
+    if "$ref" in headers_value:
+        headers_value = json.loads(
+            (session.output_dir / headers_value["$ref"]).read_text(encoding="utf-8")
+        )
+    assert headers_value["cookie"]["$redacted"] is True
+    assert (
+        sum(
+            path.name == Path(prompt_ref["$ref"]).name
+            for path in session.blobs_dir.iterdir()
+        )
+        == 1
+    )
+
+
+def test_metadata_mode_hashes_but_does_not_write_content(tmp_path):
+    config = _exact_config(tmp_path, content="metadata", blob_threshold=16)
+    with runlog.open_runlog(config) as session:
+        runlog.event("payload", {"prompt": "sensitive source text" * 4})
+
+    payload = next(
+        record for record in _records(session) if record["name"] == "payload"
+    )
+    reference = payload["attributes"]["prompt"]
+    assert reference["$omitted"] is True
+    assert "$ref" not in reference
+    assert not session.blobs_dir.exists()
+
+
+def test_concurrent_writes_preserve_authoritative_line_order(tmp_path):
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+
+        def worker(worker_id: int):
+            for index in range(100):
+                session.event("tick", {"worker": worker_id, "index": index})
+
+        threads = [
+            threading.Thread(target=worker, args=(worker_id,)) for worker_id in range(8)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+    records = _records(session)
+    ticks = [record for record in records if record["name"] == "tick"]
+    assert len(ticks) == 800
+    assert [record["seq"] for record in records] == list(range(len(records)))
+    assert len({record["record_id"] for record in records}) == len(records)
+
+
+def test_explicit_ndjson_path_is_never_appended(tmp_path):
+    config = _exact_config(tmp_path)
+    with runlog.open_runlog(config):
+        pass
+    original = config.path.read_bytes()
+
+    with pytest.raises(FileExistsError):
+        with runlog.open_runlog(config):
+            pass
+    assert config.path.read_bytes() == original
+
+
+def test_execution_runner_nests_node_activity_under_stage(tmp_path):
+    def execute(_invocation):
+        runlog.event("node.custom", {"value": "inside"})
+        return NodeResult({"value": "done"})
+
+    registration = NodeRegistration(
+        "sample",
+        "initialize",
+        EmptyNodeConfiguration,
+        {},
+        {"value": str},
+        execute,
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"sample": {}}})
+    plan = compile_stage(
+        NodeCatalog((registration,), ()),
+        "initialize",
+        stage,
+        {},
+        {},
+    )
+    context = NodeContext(
+        stage="initialize",
+        codebase_path=".",
+        repository=object(),
+        capabilities={},
+        prompts=object(),
+        codegraphs=object(),
+        runtime=NodeRuntime("test", 1, 1000, {}, 1),
+        callbacks=NodeCallbacks(),
+    )
+
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        result = run_stage("initialize", plan, context, {})
+
+    assert result.outputs == {"sample": "done"}
+    records = _records(session)
+    stage_start = next(
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "stage"
+    )
+    node_start = next(
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "node"
+    )
+    custom = next(record for record in records if record["name"] == "node.custom")
+    assert node_start["parent_span_id"] == stage_start["span_id"]
+    assert custom["span_id"] == node_start["span_id"]
+    runlog.validate_runlog(session.ndjson_path)
+
+
+def test_prompt_retry_records_logical_attempts(tmp_path):
+    class Provider:
+        def get_chat_model(self, **_kwargs):
+            return RunnableLambda(lambda _messages: AIMessage(content="not-json"))
+
+    request = JsonPromptRequest(
+        model="test-model",
+        system_prompt="system",
+        user_prompt="user {value}",
+        variables={"value": "input"},
+        parse=lambda _raw: None,
+        logger=__import__("logging").getLogger("metis.test.runlog"),
+        label="Retry prompt",
+        batch_size=1,
+        invalid_message="invalid",
+        final_keep_message="giving up",
+    )
+
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        result = JsonPromptRunner(
+            Provider(), max_attempts=2, retry_backoff_seconds=0
+        ).invoke(request)
+
+    assert result is None
+    records = _records(session)
+    prompts = [
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "prompt"
+    ]
+    attempts = [
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "attempt"
+    ]
+    retries = [record for record in records if record["name"] == "retry"]
+    assert len(prompts) == 1
+    assert len(attempts) == 2
+    assert len(retries) == 1
+    assert all(
+        attempt["parent_span_id"] == prompts[0]["span_id"] for attempt in attempts
+    )
+
+
+def test_langchain_callback_records_physical_call_and_usage(tmp_path):
+    handler = RunLogCallbackHandler()
+    response = type(
+        "Response",
+        (),
+        {
+            "llm_output": {
+                "model_name": "fake-model",
+                "token_usage": {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 3,
+                    "total_tokens": 10,
+                },
+            },
+            "generations": [],
+        },
+    )()
+
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        handler.on_chat_model_start(
+            {"name": "fake-chat"},
+            [[AIMessage(content="request")]],
+            run_id="call-1",
+            invocation_params={"model": "fake-model"},
+        )
+        handler.on_llm_end(response, run_id="call-1")
+
+    records = _records(session)
+    call_start = next(
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "llm.call"
+    )
+    usage = next(record for record in records if record["name"] == "usage")
+    assert usage["span_id"] == call_start["span_id"]
+    assert usage["attributes"]["total_tokens"] == 10
+    assert session.counters["llm_calls"] == 1
+    assert session.counters["total_tokens"] == 10
+
+
+def test_callback_manager_receives_runlog_handler_once():
+    manager = CallbackManager([])
+
+    assert ensure_runlog_callback(manager) is manager
+    assert ensure_runlog_callback(manager) is manager
+    assert manager.handlers.count(RUNLOG_CALLBACK_HANDLER) == 1
+    assert manager.inheritable_handlers.count(RUNLOG_CALLBACK_HANDLER) == 1
+
+
+def test_model_tool_loop_records_tool_span(tmp_path):
+    class Tool:
+        name = "lookup"
+
+        def invoke(self, args):
+            return f"result:{args['query']}"
+
+    class ToolChat:
+        def __init__(self):
+            self.calls = 0
+
+        def invoke(self, _messages):
+            self.calls += 1
+            if self.calls == 1:
+                return AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "lookup",
+                            "args": {"query": "needle"},
+                            "id": "tool-1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            return AIMessage(content="final")
+
+    class Chat:
+        def __init__(self):
+            self.tool_chat = ToolChat()
+
+        def bind_tools(self, _tools):
+            return self.tool_chat
+
+    prompt = ChatPromptTemplate.from_messages([("user", "{question}")])
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        result = invoke_model_with_tools(
+            Chat(),
+            prompt,
+            {"question": "find it"},
+            (Tool(),),
+            max_tool_rounds=2,
+        )
+
+    assert result == "final"
+    records = _records(session)
+    loop = next(
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "model_loop"
+    )
+    tool = next(
+        record
+        for record in records
+        if record["record"] == "span.start" and record.get("kind") == "tool"
+    )
+    assert tool["parent_span_id"] == loop["span_id"]
+    assert session.counters["tool_calls"] == 1
+
+
+def test_engine_api_preserves_command_parentage(tmp_path):
+    engine = object.__new__(MetisEngine)
+    engine.execution = SimpleNamespace(
+        execute_graph=lambda **_kwargs: ExecutionResult(
+            ExecutionStatus.OK,
+            {"review": {"value": "done"}},
+            (),
+        )
+    )
+
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        engine._runlog = session
+        with runlog.span("command", "programmatic") as command:
+            result = engine.execute_graph()
+
+    assert result.outputs == {"review": {"value": "done"}}
+    execution = next(
+        record
+        for record in _records(session)
+        if record["record"] == "span.start" and record.get("kind") == "execution"
+    )
+    assert execution["parent_span_id"] == command.span_id
+
+
+def test_validator_accepts_complete_trace_and_blobs(tmp_path):
+    with runlog.open_runlog(_exact_config(tmp_path, blob_threshold=16)) as session:
+        runlog.event("payload", {"text": "large content" * 20})
+
+    summary = runlog.validate_runlog(session.ndjson_path)
+    assert summary.run_id == session.run_id
+    assert summary.records == len(_records(session))
+    assert summary.spans == 1
+    assert summary.events == 1
+    assert summary.blobs >= 1
+    assert summary.status == "ok"
+
+
+def test_ended_span_rejects_new_activity(tmp_path):
+    with runlog.open_runlog(_exact_config(tmp_path)):
+        task = runlog.span("task", "finished")
+        task.end()
+        with pytest.raises(RuntimeError, match="ended run-log span"):
+            task.event("late")
+        with pytest.raises(RuntimeError, match="ended run-log span"):
+            with task.activate():
+                pass
+
+
+def test_validator_rejects_event_after_containing_span_ended(tmp_path):
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        task = session.span("task", "finished")
+        task.end()
+        session.event("late", span_id=task.span_id)
+
+    with pytest.raises(runlog.TraceValidationError, match="open containing span"):
+        runlog.validate_runlog(session.ndjson_path)
+
+
+def test_validator_rejects_parent_ending_before_child(tmp_path):
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        parent = session.span("task", "parent")
+        child = session.span("task", "child", parent_span_id=parent.span_id)
+        parent.end()
+        child.end()
+
+    with pytest.raises(runlog.TraceValidationError, match="child spans ended first"):
+        runlog.validate_runlog(session.ndjson_path)
+
+
+def test_validator_rejects_incomplete_metadata(tmp_path):
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        pass
+    metadata = json.loads(session.meta_path.read_text(encoding="utf-8"))
+    metadata["complete"] = False
+    session.meta_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    with pytest.raises(runlog.TraceValidationError, match="complete metadata"):
+        runlog.validate_runlog(session.ndjson_path)
+
+
+def test_runtime_write_failure_disables_logging_without_failing_run(tmp_path):
+    class BrokenFile:
+        def __init__(self, delegate):
+            self.delegate = delegate
+
+        def write(self, _value):
+            raise OSError("disk unavailable")
+
+        def flush(self):
+            raise OSError("disk unavailable")
+
+        def close(self):
+            self.delegate.close()
+
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        session._file = BrokenFile(session._file)
+        runlog.event("unwritable", {"value": 1})
+        assert session.enabled is False
+
+    meta = json.loads(session.meta_path.read_text(encoding="utf-8"))
+    assert meta["complete"] is False


### PR DESCRIPTION
Adds a local, machine-readable run log and instruments Metis execution so a visualizer can reconstruct what ran, why each record exists, and what inputs and results were produced.

Trace format
- Defines the v1 NDJSON envelope with ordered span.start, span.end, and event records; run/record/span identities; parent links; timestamps; status; duration; errors; and typed attributes.
- Adds a required trace-reader explanation to every record. Span start/end explanations remain stable, progress explanations resolve from the concrete progress subtype, and instrumentation can override catalogue text.
- Writes self-contained bundles with run.ndjson, atomic meta.json lifecycle metadata, and content-addressed text/JSON/binary blobs. Exact .ndjson paths use sibling metadata and blob paths and are never appended to.

Execution coverage
- Traces run -> command -> execution -> stage -> node boundaries centrally in the execution runner, including topology, validated inputs/outputs, capabilities, diagnostics, dependency skips, and final status.
- Adds task spans for file review, SARIF finding triage, reachability jobs/chunks, and threat-model sources, with ContextVar propagation through the existing worker helper.
- Traces simple review/triage inner workflows and steps without switching their normal invoke path, preserving behavior when logging is enabled.
- Relays progress, debug, checkpoint, diagnostic, decision, in-memory artifact, and written-output events into the active span tree.

Model and tool telemetry
- Separates logical prompts and retry attempts from physical provider calls so structured-output fallback, retries, and tool rounds remain visible individually.
- Adds a LangChain callback handler for rendered messages, provider responses, call duration, model identity, and token usage; supports callback lists, tuples, and callback-manager instances.
- Traces model/tool loops and each requested tool with round, call ID, arguments, output, byte count, status, and errors.
- Covers direct helper and retriever model calls through UsageRuntime callback wiring and records retrieval and threat-context memory activity.

Safety and durability
- Serializes concurrent writes under one lock so NDJSON line order and seq agree across worker threads; flushes each record and writes blobs/meta through atomic temporary files.
- Uses private file/directory permissions, recursive key-based secret redaction, bounded depth/collection serialization, cycle markers, deterministic set encoding, and blob deduplication.
- Treats requested-path setup failures as fatal, but disables telemetry after runtime write failures without changing analysis results.
- Rejects activity on ended spans and keeps node-end progress inside the node span.

Interfaces
- Adds --log-workflow-debug and --log-workflow-debug-path for CLI runs, plus RunLogConfig/RunLogSession/open_runlog for programmatic MetisEngine callers.
- Keeps the Execution Node API at v1: external nodes are traced as opaque node spans while context.prompts and their progress/debug/diagnostic callbacks are captured automatically.
- Records output files with path, format, byte count, and SHA-256 digest and ignores the default metis-runlog directory in Git.

Validation, documentation, and tests
- Adds validate_runlog() to verify the full bundle: required envelope types, contiguous order, single root, open parent/event containment, child-before-parent closure, stable span fields, metadata completion/status, and streamed blob size/digest checks.
- Documents the format, hierarchy, security model, explanations, extension behavior, CLI flags, and public API in docs/workflow-log-format.md and README.md.
- Adds contract and integration coverage for concurrency, lifecycle errors, redaction, blob handling, retries, physical model usage, tool loops, execution parentage, CLI output artifacts, callback managers, and malformed traces.