### PR TITLE
feat(codegraph): reduce review input tokens

### DIFF
--- a/src/metis/engine/diff_utils.py
+++ b/src/metis/engine/diff_utils.py
@@ -1,16 +1,10 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
-import os
-
-from metis.utils import count_tokens, read_file_content
+from typing import Any
 
 
-logger = logging.getLogger("metis")
-
-
-def extract_content_from_diff(file_diff):
+def extract_content_from_diff(file_diff: Any) -> str:
     content_lines = []
     for hunk in file_diff:
         for line in hunk:
@@ -19,8 +13,7 @@ def extract_content_from_diff(file_diff):
     return "".join(content_lines)
 
 
-def process_diff_file(codebase_path, file_diff, max_token_length, token_counter=None):
-    counter = token_counter or count_tokens
+def process_diff_file(file_diff: Any) -> str:
     changed_lines = []
     for hunk in file_diff:
         for line in hunk:
@@ -28,14 +21,4 @@ def process_diff_file(codebase_path, file_diff, max_token_length, token_counter=
                 changed_lines.append("+" + line.value)
             elif line.is_removed:
                 changed_lines.append("-" + line.value)
-    snippet = "".join(changed_lines)
-    original_file_path = os.path.join(codebase_path, file_diff.path)
-    original_content = read_file_content(original_file_path)
-    if original_content:
-        logger.info(f"Fetched original content for {file_diff.path}.")
-        total_tokens = counter(original_content) + counter(snippet)
-        if total_tokens <= max_token_length:
-            snippet = f"ORIGINAL_FILE:\n{original_content}\n\nFILE_CHANGES:\n{snippet}"
-        else:
-            snippet = f"FILE_CHANGES:\n{snippet}"
-    return snippet
+    return "".join(changed_lines)

--- a/src/metis/engine/nodes/reachability/incremental_review.py
+++ b/src/metis/engine/nodes/reachability/incremental_review.py
@@ -450,6 +450,8 @@ class IncrementalGraphReviewer:
                     threat_sections=threat_sections,
                     contracts=contracts,
                 )
+                chunks: list[tuple[list[FunctionNode], str]] = []
+                overflow_error: RuntimeError | ValueError | None = None
                 try:
                     source_token_budget = self._source_token_budget(
                         system_prompt,
@@ -457,6 +459,18 @@ class IncrementalGraphReviewer:
                         response_schema_json,
                     )
                 except RuntimeError as exc:
+                    overflow_error = exc
+                if overflow_error is None:
+                    try:
+                        chunks = _build_file_grouped_node_chunks(
+                            self._config.codebase_path,
+                            group_nodes,
+                            max_tokens=source_token_budget,
+                            token_counter=self._llm_provider.count_tokens,
+                        )
+                    except ValueError as exc:
+                        overflow_error = exc
+                if overflow_error is not None:
                     if len(group_nodes) > 1:
                         midpoint = len(group_nodes) // 2
                         for child_nodes in reversed(
@@ -466,7 +480,7 @@ class IncrementalGraphReviewer:
                         continue
                     logger.warning(
                         "%s for %s; leaving %s incomplete",
-                        exc,
+                        overflow_error,
                         file_path,
                         group_nodes[0].unique_name,
                     )
@@ -475,23 +489,6 @@ class IncrementalGraphReviewer:
                             function_id=group_nodes[0].unique_name,
                             kind="context_overflow",
                         )
-                    )
-                    continue
-                try:
-                    chunks = _build_file_grouped_node_chunks(
-                        self._config.codebase_path,
-                        group_nodes,
-                        max_tokens=source_token_budget,
-                        token_counter=self._llm_provider.count_tokens,
-                    )
-                except ValueError as exc:
-                    logger.warning("%s; leaving local functions incomplete", exc)
-                    failures.update(
-                        FrontierReviewFailure(
-                            function_id=node.unique_name,
-                            kind="context_overflow",
-                        )
-                        for node in group_nodes
                     )
                     continue
                 for chunk_nodes, source_text in chunks:
@@ -648,12 +645,12 @@ class IncrementalGraphReviewer:
         contracts: Mapping[str, FunctionContract] | None = None,
     ) -> str:
         evidence = prompt_evidence._compact_source_evidence(
-            graph,
             prompt_evidence._codegraph_evidence_data(
                 graph,
                 nodes,
-                contracts or {},
+                contracts,
                 shown_lines=prompt_evidence._shown_lines(source_text),
+                file_path=file_path,
             ),
             codebase_path=self._config.codebase_path,
             file_path=file_path,

--- a/src/metis/engine/nodes/reachability/prompt_evidence.py
+++ b/src/metis/engine/nodes/reachability/prompt_evidence.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections import Counter
 from collections.abc import Mapping
 from collections.abc import Sequence
+from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
@@ -33,6 +35,22 @@ from .state import SecuritySubject
 from .state import TrackedObjectSubject
 
 _NUMBERED_LINE = re.compile(r"^\s*(\d+):", re.MULTILINE)
+_EXPRESSION_MARKERS = frozenset(
+    {"text", "span", "ids", "fields", "direct_id", "direct_field", "cols"}
+)
+_EXPRESSION_FIELDS = _EXPRESSION_MARKERS | {"line", "result_index"}
+_ATOM_LIST_FIELDS = frozenset(
+    {"ids", "fields", "writes", "addresses", "condition_writes"}
+)
+_ATOM_VALUE_FIELDS = frozenset({"direct_id", "direct_field"})
+
+
+@dataclass(frozen=True, slots=True)
+class _PromptReferences:
+    function_indexes: Mapping[str, int]
+    call_symbol_indexes: Mapping[str, int]
+    condition_indexes: Mapping[tuple[str, ControlCondition], int]
+    result_indexes: Mapping[tuple[str, int], int]
 
 
 def _sparse_prompt_data(value: object) -> object:
@@ -51,7 +69,7 @@ def _sparse_prompt_data(value: object) -> object:
 
 def _prompt_json(value: object) -> str:
     return json.dumps(
-        _sparse_prompt_data(value),
+        _compact_repeated_evidence(_sparse_prompt_data(value)),
         sort_keys=True,
         separators=(",", ":"),
     )
@@ -61,19 +79,133 @@ def _shown_lines(source_text: str) -> frozenset[int]:
     return frozenset(int(match) for match in _NUMBERED_LINE.findall(source_text))
 
 
-def _evidence_file_path(
-    graph: CodeGraph,
-    value: Mapping[object, object],
+def _expression_key(
+    value: object,
     *,
-    owning_file_path: str,
-) -> str:
-    explicit_file_path = value.get("file_path")
-    if isinstance(explicit_file_path, str):
-        return explicit_file_path
-    function_id = value.get("function_id")
-    if isinstance(function_id, str) and (node := graph.get_node(function_id)):
-        return node.file_path
-    return owning_file_path
+    inherited_line: int | None,
+) -> str | None:
+    if not isinstance(value, Mapping) or not value:
+        return None
+    fields = frozenset(value)
+    if not fields <= _EXPRESSION_FIELDS or not fields & _EXPRESSION_MARKERS:
+        return None
+    prompt_value = value
+    if "cols" in value and not isinstance(value.get("line"), int):
+        if inherited_line is None:
+            return None
+        prompt_value = {**value, "line": inherited_line}
+    return json.dumps(prompt_value, sort_keys=True, separators=(",", ":"))
+
+
+def _compact_repeated_evidence(value: object) -> object:
+    expression_counts: Counter[str] = Counter()
+
+    def collect_expressions(
+        item: object,
+        *,
+        inherited_line: int | None,
+    ) -> None:
+        expression_key = _expression_key(item, inherited_line=inherited_line)
+        if expression_key is not None:
+            expression_counts[expression_key] += 1
+            return
+        if isinstance(item, Mapping):
+            explicit_line = item.get("line")
+            mapped_line = (
+                explicit_line if isinstance(explicit_line, int) else inherited_line
+            )
+            for child in item.values():
+                collect_expressions(child, inherited_line=mapped_line)
+        elif isinstance(item, (list, tuple)):
+            for child in item:
+                collect_expressions(child, inherited_line=inherited_line)
+
+    collect_expressions(value, inherited_line=None)
+    expression_rows = sorted(
+        key for key, count in expression_counts.items() if count >= 2
+    )
+    expression_indexes = {
+        expression: index for index, expression in enumerate(expression_rows)
+    }
+
+    def replace_expressions(
+        item: object,
+        *,
+        inherited_line: int | None,
+    ) -> object:
+        expression_key = _expression_key(item, inherited_line=inherited_line)
+        if expression_key in expression_indexes:
+            return expression_indexes[expression_key]
+        if isinstance(item, Mapping):
+            explicit_line = item.get("line")
+            mapped_line = (
+                explicit_line if isinstance(explicit_line, int) else inherited_line
+            )
+            return {
+                key: replace_expressions(child, inherited_line=mapped_line)
+                for key, child in item.items()
+            }
+        if isinstance(item, (list, tuple)):
+            return [
+                replace_expressions(child, inherited_line=inherited_line)
+                for child in item
+            ]
+        return item
+
+    compact = replace_expressions(value, inherited_line=None)
+    if not isinstance(compact, Mapping):
+        return compact
+    compact = dict(compact)
+    if expression_rows:
+        compact["expression_table"] = [
+            json.loads(expression) for expression in expression_rows
+        ]
+
+    atom_counts: Counter[str] = Counter()
+
+    def collect_atoms(item: object) -> None:
+        if isinstance(item, Mapping):
+            for key, child in item.items():
+                if key in _ATOM_VALUE_FIELDS and isinstance(child, str):
+                    atom_counts[child] += 1
+                elif key in _ATOM_LIST_FIELDS and isinstance(child, (list, tuple)):
+                    atom_counts.update(
+                        value for value in child if isinstance(value, str)
+                    )
+                else:
+                    collect_atoms(child)
+        elif isinstance(item, (list, tuple)):
+            for child in item:
+                collect_atoms(child)
+
+    collect_atoms(compact)
+    atom_rows = sorted(atom for atom, count in atom_counts.items() if count >= 2)
+    atom_indexes = {atom: index for index, atom in enumerate(atom_rows)}
+
+    def replace_atoms(item: object) -> object:
+        if isinstance(item, Mapping):
+            result: dict[object, object] = {}
+            for key, child in item.items():
+                if key in _ATOM_VALUE_FIELDS and isinstance(child, str):
+                    result[key] = atom_indexes.get(child, child)
+                elif key in _ATOM_LIST_FIELDS and isinstance(child, (list, tuple)):
+                    result[key] = [
+                        atom_indexes.get(value, value)
+                        if isinstance(value, str)
+                        else value
+                        for value in child
+                    ]
+                else:
+                    result[key] = replace_atoms(child)
+            return result
+        if isinstance(item, (list, tuple)):
+            return [replace_atoms(child) for child in item]
+        return item
+
+    compact = replace_atoms(compact)
+    if isinstance(compact, dict) and atom_rows:
+        compact["atom_table"] = atom_rows
+    return compact
 
 
 def _source_span_replacement(
@@ -81,9 +213,12 @@ def _source_span_replacement(
     *,
     source_map: SourceMap,
     complete_lines: frozenset[int],
+    evidence_line: int | None,
 ) -> tuple[frozenset[str], tuple[int, int] | None]:
-    start_byte = value.get("start_byte")
-    end_byte = value.get("end_byte")
+    span = value.get("span")
+    if not isinstance(span, (list, tuple)) or len(span) != 2:
+        return frozenset(), None
+    start_byte, end_byte = span
     if not isinstance(start_byte, int) or not isinstance(end_byte, int):
         return frozenset(), None
     if start_byte < 0 or end_byte <= start_byte:
@@ -92,7 +227,7 @@ def _source_span_replacement(
     end_line = source_map.byte_to_line(end_byte - 1)
     if (
         start_line != end_line
-        or value.get("line") != start_line
+        or evidence_line != start_line
         or start_line not in complete_lines
     ):
         return frozenset(), None
@@ -100,12 +235,18 @@ def _source_span_replacement(
     omitted_fields = frozenset(
         field for field in ("text", "expression") if value.get(field) == source_text
     )
+    if not omitted_fields:
+        return frozenset(), None
     line_start_byte = source_map.line_to_byte(start_line)
     start_column = len(source_map.byte_slice(line_start_byte, start_byte))
     columns = (start_column, start_column + len(source_text))
-    removed_size = sum(
-        len(json.dumps({field: source_text}, separators=(",", ":"))) - 2
-        for field in omitted_fields
+    removed_size = (
+        len(json.dumps({"span": span}, separators=(",", ":")))
+        - 2
+        + sum(
+            len(json.dumps({field: source_text}, separators=(",", ":"))) - 2
+            for field in omitted_fields
+        )
     )
     replacement_size = len(json.dumps({"cols": columns}, separators=(",", ":"))) - 2
     if replacement_size >= removed_size:
@@ -114,28 +255,31 @@ def _source_span_replacement(
 
 
 def _source_span_prompt_data(
-    graph: CodeGraph,
     value: object,
     *,
     source_map: SourceMap,
     file_path: str,
     complete_lines: frozenset[int],
     owning_file_path: str,
+    owning_line: int | None,
 ) -> object:
     if isinstance(value, Mapping):
-        mapped_file_path = _evidence_file_path(
-            graph,
-            value,
-            owning_file_path=owning_file_path,
+        explicit_file_path = value.get("file_path")
+        mapped_file_path = (
+            explicit_file_path
+            if isinstance(explicit_file_path, str)
+            else owning_file_path
         )
+        explicit_line = value.get("line")
+        mapped_line = explicit_line if isinstance(explicit_line, int) else owning_line
         result = {
             key: _source_span_prompt_data(
-                graph,
                 item,
                 source_map=source_map,
                 file_path=file_path,
                 complete_lines=complete_lines,
                 owning_file_path=mapped_file_path,
+                owning_line=mapped_line,
             )
             for key, item in value.items()
         }
@@ -145,6 +289,7 @@ def _source_span_prompt_data(
             value,
             source_map=source_map,
             complete_lines=complete_lines,
+            evidence_line=mapped_line,
         )
         if source_columns is None:
             return result
@@ -152,19 +297,19 @@ def _source_span_prompt_data(
             **{
                 key: item
                 for key, item in result.items()
-                if key not in omitted_fields | {"start_byte", "end_byte"}
+                if key not in omitted_fields | {"span"}
             },
             "cols": list(source_columns),
         }
     if isinstance(value, (list, tuple)):
         return [
             _source_span_prompt_data(
-                graph,
                 item,
                 source_map=source_map,
                 file_path=file_path,
                 complete_lines=complete_lines,
                 owning_file_path=owning_file_path,
+                owning_line=owning_line,
             )
             for item in value
         ]
@@ -172,7 +317,6 @@ def _source_span_prompt_data(
 
 
 def _compact_source_evidence(
-    graph: CodeGraph,
     value: object,
     *,
     codebase_path: str,
@@ -197,39 +341,51 @@ def _compact_source_evidence(
     if not complete_lines:
         return value
     return _source_span_prompt_data(
-        graph,
         value,
         source_map=source_map,
         file_path=file_path,
         complete_lines=complete_lines,
         owning_file_path=file_path,
+        owning_line=None,
     )
 
 
-def _expression_data(expression: CodeExpression) -> dict[str, object]:
+def _function_ref(references: _PromptReferences, function_id: str) -> int | str:
+    return references.function_indexes.get(function_id, function_id)
+
+
+def _expression_data(
+    expression: CodeExpression,
+    *,
+    inherited_line: int | None = None,
+) -> dict[str, object]:
     return {
         "text": expression.text,
-        "line": expression.line,
-        "start_byte": expression.start_byte,
-        "end_byte": expression.end_byte,
-        "identifiers": list(expression.identifiers),
-        "field_paths": list(expression.field_paths),
-        "direct_identifier": expression.direct_identifier,
-        "direct_field_path": expression.direct_field_path,
+        "line": expression.line if expression.line != inherited_line else None,
+        "span": [expression.start_byte, expression.end_byte],
+        "ids": list(expression.identifiers),
+        "fields": list(expression.field_paths),
+        "direct_id": expression.direct_identifier,
+        "direct_field": expression.direct_field_path,
     }
 
 
 def _condition_data(condition: ControlCondition) -> dict[str, object]:
     return {
-        "expression": _expression_data(condition.expression),
+        "line": condition.expression.line,
+        "expression": _expression_data(
+            condition.expression,
+            inherited_line=condition.expression.line,
+        ),
         "truth": condition.truth,
         "null_condition": (
             {
                 "when_true": [
-                    _null_fact_data(fact) for fact in condition.null_condition.when_true
+                    _null_fact_data(fact, inherited_line=condition.expression.line)
+                    for fact in condition.null_condition.when_true
                 ],
                 "when_false": [
-                    _null_fact_data(fact)
+                    _null_fact_data(fact, inherited_line=condition.expression.line)
                     for fact in condition.null_condition.when_false
                 ],
             }
@@ -239,63 +395,123 @@ def _condition_data(condition: ControlCondition) -> dict[str, object]:
     }
 
 
-def _null_fact_data(fact: NullFact) -> dict[str, object]:
+def _null_fact_data(
+    fact: NullFact,
+    *,
+    inherited_line: int,
+) -> dict[str, object]:
     return {
-        "value": _expression_data(fact.value),
+        "value": _expression_data(fact.value, inherited_line=inherited_line),
         "is_null": fact.is_null,
     }
 
 
-def _assignment_data(assignment: ValueAssignment) -> dict[str, object]:
+def _condition_refs(
+    conditions: Sequence[ControlCondition],
+    *,
+    file_path: str,
+    references: _PromptReferences,
+) -> list[int]:
+    return [references.condition_indexes[(file_path, item)] for item in conditions]
+
+
+def _assignment_data(
+    assignment: ValueAssignment,
+    *,
+    file_path: str,
+    references: _PromptReferences,
+) -> dict[str, object]:
     return {
-        "target": _expression_data(assignment.target),
-        "value": _expression_data(assignment.value),
+        "target": _expression_data(
+            assignment.target,
+            inherited_line=assignment.line,
+        ),
+        "value": _expression_data(
+            assignment.value,
+            inherited_line=assignment.line,
+        ),
         "operator": assignment.operator,
         "line": assignment.line,
-        "start_byte": assignment.start_byte,
-        "end_byte": assignment.end_byte,
-        "conditions": [_condition_data(item) for item in assignment.conditions],
+        "span": [assignment.start_byte, assignment.end_byte],
+        "conditions": _condition_refs(
+            assignment.conditions,
+            file_path=file_path,
+            references=references,
+        ),
     }
 
 
 def _loop_data(loop: LoopStructure) -> dict[str, object]:
     return {
         "condition": (
-            _expression_data(loop.condition) if loop.condition is not None else None
+            _expression_data(loop.condition, inherited_line=loop.line)
+            if loop.condition is not None
+            else None
         ),
         "line": loop.line,
-        "start_byte": loop.start_byte,
-        "end_byte": loop.end_byte,
-        "written_identifiers": list(loop.written_identifiers),
-        "addressed_identifiers": list(loop.addressed_identifiers),
-        "condition_identifiers_written": sorted(
+        "span": [loop.start_byte, loop.end_byte],
+        "writes": list(loop.written_identifiers),
+        "addresses": list(loop.addressed_identifiers),
+        "condition_writes": sorted(
             set(loop.condition.identifiers if loop.condition is not None else ())
             & set(loop.written_identifiers)
         ),
     }
 
 
-def _return_data(return_site: ReturnSite) -> dict[str, object]:
+def _return_data(
+    return_site: ReturnSite,
+    *,
+    file_path: str,
+    references: _PromptReferences,
+) -> dict[str, object]:
     return {
         "value": (
-            _expression_data(return_site.value)
+            _expression_data(return_site.value, inherited_line=return_site.line)
             if return_site.value is not None
             else None
         ),
         "line": return_site.line,
-        "start_byte": return_site.start_byte,
-        "end_byte": return_site.end_byte,
-        "conditions": [_condition_data(item) for item in return_site.conditions],
+        "span": [return_site.start_byte, return_site.end_byte],
+        "conditions": _condition_refs(
+            return_site.conditions,
+            file_path=file_path,
+            references=references,
+        ),
         "returns_null": return_site.returns_null,
     }
 
 
-def _call_expression_data(call: CallSite) -> dict[str, object]:
+def _call_expression_data(
+    call: CallSite,
+    *,
+    node: FunctionNode,
+    call_index: int,
+    references: _PromptReferences,
+) -> dict[str, object]:
+    result = (
+        _expression_data(call.result, inherited_line=call.line)
+        if call.result is not None
+        else None
+    )
+    result_index = references.result_indexes.get((node.unique_name, call_index))
+    if result is not None and result_index is not None:
+        result["result_index"] = result_index
     return {
-        "arguments": [_expression_data(item) for item in call.arguments],
-        "conditions": [_condition_data(item) for item in call.conditions],
-        "must_conditions": [_condition_data(item) for item in call.must_conditions],
-        "result": _expression_data(call.result) if call.result is not None else None,
+        "arguments": [
+            _expression_data(item, inherited_line=call.line) for item in call.arguments
+        ],
+        "conditions": _condition_refs(
+            call.conditions,
+            file_path=node.file_path,
+            references=references,
+        ),
+        "must_conditions": _condition_refs(
+            call.must_conditions,
+            file_path=node.file_path,
+            references=references,
+        ),
+        "result": result,
     }
 
 
@@ -303,63 +519,41 @@ def _tag_data(
     node: FunctionNode,
     *,
     include_syntax_tags: bool = False,
-) -> list[dict[str, str]]:
-    return [
-        {
-            "name": name,
-            "value": tag.value,
-            "reason": tag.reason,
-        }
+) -> dict[str, list[str]]:
+    return {
+        name: [tag.value, tag.reason]
         for name, tag in sorted(node.tags.items())
         if include_syntax_tags or not name.startswith("syntax.")
-    ]
-
-
-def _call_target_facts(
-    graph: CodeGraph,
-    call: CallSite,
-    *,
-    include_syntax_tags: bool,
-) -> list[dict[str, object]]:
-    facts: list[dict[str, object]] = []
-    for target_id in call.target_ids:
-        target = graph.get_node(target_id)
-        if target is None:
-            continue
-        tags = _tag_data(target, include_syntax_tags=include_syntax_tags)
-        if not tags:
-            continue
-        facts.append(
-            {
-                "function_id": target.unique_name,
-                "tags": tags,
-            }
-        )
-    return facts
+    }
 
 
 def _boundary_call_data(
-    graph: CodeGraph,
+    node: FunctionNode,
     call: CallSite,
+    call_index: int,
     *,
-    include_syntax_tags: bool,
+    include_call_index: bool,
+    references: _PromptReferences,
 ) -> dict[str, object]:
     return {
+        "call_index": call_index if include_call_index else None,
         "line": call.line,
-        "start_byte": call.start_byte,
-        "end_byte": call.end_byte,
-        "symbol": call.symbol,
-        "kind": call.kind,
-        "argument_count": call.argument_count,
-        "resolution": call.resolution,
-        "target_ids": list(call.target_ids),
-        "targets_complete": call.targets_complete,
-        "target_facts": _call_target_facts(
-            graph,
-            call,
-            include_syntax_tags=include_syntax_tags,
+        "span": [call.start_byte, call.end_byte],
+        "symbol": references.call_symbol_indexes[call.symbol],
+        "kind": call.kind if call.kind != "direct" else None,
+        "argument_count": (
+            call.argument_count if call.argument_count != len(call.arguments) else None
         ),
-        **_call_expression_data(call),
+        "target_ids": [
+            _function_ref(references, target_id) for target_id in call.target_ids
+        ],
+        "complete": True if call.targets_complete else None,
+        **_call_expression_data(
+            call,
+            node=node,
+            call_index=call_index,
+            references=references,
+        ),
     }
 
 
@@ -369,6 +563,7 @@ def _codegraph_evidence_data(
     contracts: Mapping[str, FunctionContract] | None = None,
     *,
     shown_lines: frozenset[int] | None = None,
+    file_path: str,
 ) -> dict[str, object]:
     contract_map = contracts or {}
     ordered_nodes = tuple(
@@ -378,56 +573,166 @@ def _codegraph_evidence_data(
         )
     )
     current_ids = {node.unique_name for node in ordered_nodes}
-    direct_edges = sorted(
-        {
-            (node.unique_name, target_id)
-            for node in ordered_nodes
-            for target_id in node.resolved_calls
-            if target_id in graph.nodes
-        }
-    )
-    direct_nodes = [
+    direct_edges = {
+        (node.unique_name, target_id)
+        for node in ordered_nodes
+        for target_id in node.resolved_calls
+        if target_id in graph.nodes
+    }
+    represented_edges = {
+        (node.unique_name, target_id)
+        for node in ordered_nodes
+        for call in _ordered_node_callsites(node)
+        for target_id in call.target_ids
+    }
+    direct_target_ids = {
+        target_id
+        for _caller_id, target_id in direct_edges | represented_edges
+        if target_id in graph.nodes
+    }
+    direct_nodes = tuple(
         graph.nodes[node_id]
         for node_id in sorted(
-            {target_id for _caller_id, target_id in direct_edges},
+            direct_target_ids,
             key=partial(_node_sort_key, graph),
         )
         if node_id not in current_ids
-    ]
+    )
+    all_nodes = (*ordered_nodes, *direct_nodes)
+    referenced_node_ids = {
+        target_id
+        for node in all_nodes
+        for call in _ordered_node_callsites(node)
+        for target_id in call.target_ids
+        if target_id in graph.nodes
+    }
+    referenced_only_ids = sorted(
+        referenced_node_ids - current_ids - direct_target_ids,
+        key=partial(_node_sort_key, graph),
+    )
+    function_ids = [node.unique_name for node in all_nodes] + referenced_only_ids
+    call_symbols = sorted(
+        {call.symbol for node in all_nodes for call in _ordered_node_callsites(node)}
+    )
+    condition_keys: list[tuple[str, ControlCondition]] = []
+    for node in ordered_nodes:
+        for assignment in node.assignments:
+            condition_keys.extend(
+                (node.file_path, condition) for condition in assignment.conditions
+            )
+        for return_site in node.returns:
+            condition_keys.extend(
+                (node.file_path, condition) for condition in return_site.conditions
+            )
+    for node in all_nodes:
+        for call in _ordered_node_callsites(node):
+            condition_keys.extend(
+                (node.file_path, condition)
+                for condition in (*call.conditions, *call.must_conditions)
+            )
+    ordered_conditions = tuple(dict.fromkeys(condition_keys))
+    call_results = _call_result_entries(
+        graph,
+        tuple(node.unique_name for node in ordered_nodes),
+        shown_lines=shown_lines,
+    )
+    references = _PromptReferences(
+        function_indexes={
+            function_id: function_index
+            for function_index, function_id in enumerate(function_ids)
+        },
+        call_symbol_indexes={
+            symbol: symbol_index for symbol_index, symbol in enumerate(call_symbols)
+        },
+        condition_indexes={
+            condition: condition_index
+            for condition_index, condition in enumerate(ordered_conditions)
+        },
+        result_indexes={
+            call_key: result_index
+            for result_index, (_subject, call_key) in enumerate(call_results)
+        },
+    )
+    residual_edges = sorted(direct_edges - represented_edges)
     direct_contract_ids = tuple(
-        sorted(
-            {target_id for _caller_id, target_id in direct_edges},
-            key=partial(_node_sort_key, graph),
-        )
+        sorted(direct_target_ids, key=partial(_node_sort_key, graph))
     )
     return {
-        "functions": [_discovery_function_data(graph, node) for node in ordered_nodes],
-        "call_results": _call_result_data(
-            graph,
-            tuple(node.unique_name for node in ordered_nodes),
-            shown_lines=shown_lines,
-        ),
-        "direct_edges": [list(edge) for edge in direct_edges],
+        "function_ids": [
+            (
+                function_id[len(file_path) :]
+                if function_id.startswith(f"{file_path}::")
+                else function_id
+            )
+            for function_id in function_ids
+        ],
+        "call_symbols": call_symbols,
+        "function_tags": {
+            str(references.function_indexes[node_id]): tags
+            for node_id in referenced_only_ids
+            if (tags := _tag_data(graph.nodes[node_id], include_syntax_tags=True))
+        },
+        "condition_table": [
+            {
+                "file_path": condition_file if condition_file != file_path else None,
+                **_condition_data(condition),
+            }
+            for condition_file, condition in ordered_conditions
+        ],
+        "functions": [
+            _discovery_function_data(
+                node,
+                file_path=file_path,
+                references=references,
+            )
+            for node in ordered_nodes
+        ],
+        "direct_edges": [
+            [
+                _function_ref(references, caller_id),
+                _function_ref(references, target_id),
+            ]
+            for caller_id, target_id in residual_edges
+        ],
         "direct_functions": [
             {
-                **_function_boundary_data(graph, node, include_syntax_tags=True),
-                "graph_entrypoint_candidate": node.is_public_entrypoint,
+                **_function_boundary_data(
+                    node,
+                    file_path=file_path,
+                    references=references,
+                    include_syntax_tags=True,
+                ),
+                "entrypoint": True if node.is_public_entrypoint else None,
             }
             for node in direct_nodes
         ],
         "direct_function_contracts": [
-            _direct_contract_data(contract_map[node_id])
+            {
+                "file_path": (
+                    graph.nodes[node_id].file_path
+                    if graph.nodes[node_id].file_path != file_path
+                    else None
+                ),
+                **_direct_contract_data(
+                    contract_map[node_id],
+                    references=references,
+                ),
+            }
             for node_id in direct_contract_ids
             if node_id in contract_map
         ],
     }
 
 
-def _direct_contract_data(contract: FunctionContract) -> dict[str, object]:
+def _direct_contract_data(
+    contract: FunctionContract,
+    *,
+    references: _PromptReferences,
+) -> dict[str, object]:
     return {
-        "function": contract.function_id,
-        "normal_return_transfers": [
-            _guarded_transfer_data(transfer)
+        "function": _function_ref(references, contract.function_id),
+        "normal_returns": [
+            _guarded_transfer_data(transfer, references=references)
             for transfer in contract.normal_return_transfers
         ],
         "normal_exit": {
@@ -438,12 +743,19 @@ def _direct_contract_data(contract: FunctionContract) -> dict[str, object]:
     }
 
 
-def _guarded_transfer_data(transfer: GuardedTransfer) -> dict[str, object]:
+def _guarded_transfer_data(
+    transfer: GuardedTransfer,
+    *,
+    references: _PromptReferences,
+) -> dict[str, object]:
     return {
         "requirements": [
             {
                 "atom": {
-                    "subject": _subject_model_data(item.atom.subject),
+                    "subject": _subject_model_data(
+                        item.atom.subject,
+                        references=references,
+                    ),
                     "predicate": item.atom.predicate,
                 },
                 "truth": item.truth,
@@ -456,7 +768,10 @@ def _guarded_transfer_data(transfer: GuardedTransfer) -> dict[str, object]:
             {
                 "operation": item.operation,
                 "atom": {
-                    "subject": _subject_model_data(item.atom.subject),
+                    "subject": _subject_model_data(
+                        item.atom.subject,
+                        references=references,
+                    ),
                     "predicate": item.atom.predicate,
                 },
                 "origin": item.origin,
@@ -482,67 +797,68 @@ def _ordered_node_callsites(node: FunctionNode) -> tuple[CallSite, ...]:
 
 
 def _function_boundary_data(
-    graph: CodeGraph,
     node: FunctionNode,
     *,
+    file_path: str,
+    include_call_indexes: bool = False,
+    references: _PromptReferences,
     include_syntax_tags: bool = False,
 ) -> dict[str, object]:
     return {
-        "function_id": node.unique_name,
-        "file_path": node.file_path,
-        "start_line": node.line_number,
-        "end_line": node.end_line or node.line_number,
+        "function_id": _function_ref(references, node.unique_name),
+        "file_path": node.file_path if node.file_path != file_path else None,
+        "lines": [node.line_number, node.end_line or node.line_number],
         "parameter_count": node.parameter_count,
         "parameters": [
-            {
-                "name": parameter.name,
-                "type_spelling": parameter.type_spelling,
-            }
-            for parameter in node.parameters
+            [parameter.name, parameter.type_spelling] for parameter in node.parameters
         ],
         "tags": _tag_data(node, include_syntax_tags=include_syntax_tags),
         "calls": [
-            {
-                "call_index": call_index,
-                **_boundary_call_data(
-                    graph,
-                    call,
-                    include_syntax_tags=include_syntax_tags,
-                ),
-            }
+            _boundary_call_data(
+                node,
+                call,
+                call_index,
+                include_call_index=include_call_indexes,
+                references=references,
+            )
             for call_index, call in enumerate(_ordered_node_callsites(node))
         ],
     }
 
 
 def _discovery_function_data(
-    graph: CodeGraph,
     node: FunctionNode,
+    *,
+    file_path: str,
+    references: _PromptReferences,
 ) -> dict[str, object]:
     return {
-        **_function_boundary_data(graph, node, include_syntax_tags=True),
-        "graph_entrypoint_candidate": node.is_public_entrypoint,
-        "assignments": [_assignment_data(item) for item in node.assignments],
+        **_function_boundary_data(
+            node,
+            file_path=file_path,
+            include_call_indexes=True,
+            references=references,
+            include_syntax_tags=True,
+        ),
+        "entrypoint": True if node.is_public_entrypoint else None,
+        "assignments": [
+            _assignment_data(
+                item,
+                file_path=node.file_path,
+                references=references,
+            )
+            for item in node.assignments
+        ],
         "loops": [_loop_data(item) for item in node.loops],
-        "returns": [_return_data(item) for item in node.returns],
+        "returns": [
+            _return_data(
+                item,
+                file_path=node.file_path,
+                references=references,
+            )
+            for item in node.returns
+        ],
     }
-
-
-def _call_result_data(
-    graph: CodeGraph,
-    node_ids: Sequence[str],
-    *,
-    shown_lines: frozenset[int] | None = None,
-) -> list[dict[str, object]]:
-    return [
-        {
-            "call_result_index": call_result_index,
-            **grounding,
-        }
-        for call_result_index, (_subject, grounding) in enumerate(
-            _call_result_entries(graph, node_ids, shown_lines=shown_lines)
-        )
-    ]
 
 
 def _call_result_entries(
@@ -550,13 +866,13 @@ def _call_result_entries(
     node_ids: Sequence[str],
     *,
     shown_lines: frozenset[int] | None,
-) -> tuple[tuple[TrackedObjectSubject, dict[str, object]], ...]:
-    results: list[tuple[TrackedObjectSubject, dict[str, object]]] = []
+) -> tuple[tuple[TrackedObjectSubject, tuple[str, int]], ...]:
+    results: list[tuple[TrackedObjectSubject, tuple[str, int]]] = []
     for node_id in sorted(node_ids, key=partial(_node_sort_key, graph)):
         node = graph.get_node(node_id)
         if node is None:
             continue
-        for callsite in _ordered_node_callsites(node):
+        for call_index, callsite in enumerate(_ordered_node_callsites(node)):
             result = callsite.result
             if result is None or not (
                 result.direct_identifier or result.direct_field_path
@@ -572,35 +888,33 @@ def _call_result_entries(
                         result.start_byte,
                         result.end_byte,
                     ),
-                    {
-                        "kind": "call_result",
-                        "function_id": node_id,
-                        "line": result.line,
-                        "start_byte": result.start_byte,
-                        "end_byte": result.end_byte,
-                        "expression": result.text,
-                        "call_symbol": callsite.symbol,
-                    },
+                    (node_id, call_index),
                 )
             )
     return tuple(results)
 
 
-def _subject_model_data(subject: SecuritySubject) -> dict[str, object]:
+def _subject_model_data(
+    subject: SecuritySubject,
+    *,
+    references: _PromptReferences,
+) -> dict[str, object]:
     if isinstance(subject, ParameterSubject):
         return {
             "kind": "parameter",
-            "function_id": subject.function_id,
+            "function_id": _function_ref(references, subject.function_id),
             "index": subject.index,
         }
     if isinstance(subject, ReturnSubject):
-        return {"kind": "return", "function_id": subject.function_id}
+        return {
+            "kind": "return",
+            "function_id": _function_ref(references, subject.function_id),
+        }
     return {
         "kind": "tracked_object",
-        "function_id": subject.function_id,
+        "function_id": _function_ref(references, subject.function_id),
         "file_path": subject.file_path,
-        "start_byte": subject.start_byte,
-        "end_byte": subject.end_byte,
+        "span": [subject.start_byte, subject.end_byte],
     }
 
 

--- a/src/metis/engine/nodes/reachability/source_context.py
+++ b/src/metis/engine/nodes/reachability/source_context.py
@@ -77,6 +77,11 @@ def _build_file_grouped_node_chunks(
             )
             if not body:
                 continue
+            if any(
+                token_counter(line) > max_tokens
+                for line in body.splitlines(keepends=True)
+            ):
+                raise ValueError("max_tokens cannot hold one numbered source line")
             for body_part, _start_line in split_snippet(
                 body,
                 max_tokens,

--- a/src/metis/engine/nodes/simple_llm_review/service.py
+++ b/src/metis/engine/nodes/simple_llm_review/service.py
@@ -275,12 +275,7 @@ class SimpleLlmReviewService:
             plugin = self._repository.get_plugin_for_path(file_diff.path)
             if not plugin:
                 continue
-            snippet = process_diff_file(
-                self._config.codebase_path,
-                file_diff,
-                self._config.max_token_length,
-                token_counter=self._config.llm_provider.count_tokens,
-            )
+            snippet = process_diff_file(file_diff)
             if not snippet:
                 continue
             language_prompts = plugin.get_prompts()

--- a/src/metis/engine/prompts/reachability_incremental_review.yaml
+++ b/src/metis/engine/prompts/reachability_incremental_review.yaml
@@ -1,5 +1,19 @@
 omission_convention: |-
-  OMISSION_CONVENTION: When cols is present, omitted text/expression is the exact source at zero-based [start,end] character columns on line in SNIPPET, and omitted start_byte/end_byte are replaced by line and cols. All other omitted properties mean exactly null or empty, not unavailable evidence.
+  COMPACT_EVIDENCE: function_ids and call_symbols map integer references to strings; a function_ids value beginning ::
+  expands by prepending FILE. function_tags maps function indexes to target tags when no function record is included.
+  condition_table maps the integer references in conditions and must_conditions.
+  ids/fields are expression identifier/field paths; direct_id/direct_field
+  mark exact expressions. span is [start_byte,end_byte], lines is [start_line,end_line], each parameters item is
+  [name,type], and tags maps a tag name to [value,reason]. cols is the exact source at zero-based [start,end] columns on
+  line; it replaces matching text and span. Missing file_path inherits the nearest enclosing record's file_path; without
+  one it means FILE. A missing nested line inherits its enclosing line. Omitted kind is direct, resolution derives from target_ids, and
+  omitted complete/entrypoint are false; omitted argument_count equals len(arguments). direct_edges contains only edges
+  not already represented by call target_ids.
+  expression_table maps integer expression references to records; expand each reference at its use site before applying
+  line and file_path inheritance.
+  atom_table maps integer references in ids/fields/direct_id/direct_field/writes/addresses/condition_writes to strings;
+  strings remain literal.
+  Other omitted properties are exactly null or empty, not unavailable evidence.
 discovery_graph_guidance: |-
   CODEGRAPH_EVIDENCE is source-grounded syntax data from the scanned repository, augmented by selected-build compiler
   facts when available. Use its call arguments,
@@ -7,7 +21,7 @@ discovery_graph_guidance: |-
   direct_function_contracts are compact summaries for resolved direct callees. An observed or derived normal-exit or
   normal-return fact is code-owned evidence; apply every listed requirement before relying on its effect. Hypothesis or
   incomplete contract data remains uncertain and cannot establish safety.
-  graph_entrypoint_candidate marks a traversal seed; it does not prove a supported public API, attacker control, or that
+  entrypoint marks a traversal seed; it does not prove a supported public API, attacker control, or that
   a caller may violate a handle or argument precondition.
   syntax.macro_function_arguments preserves raw non-signature wrapper tokens referenced by every matching repository
   macro definition; it is not proof of active-build expansion or control-flow semantics. Confirm the unsafe sequence
@@ -18,8 +32,8 @@ discovery_graph_guidance: |-
   temporary stack alias requires a demonstrated escape or post-lifetime use.
   For every review, return EVERY unsafe execution alternative in necessary_condition_alternatives; the outer list is
   their OR. Each alternative selects the exact sink_call_index from the finding function's calls and contains all_of,
-  the non-empty conjunction of call results that must be null at that sink. Select only call_result_index values supplied
-  in CODEGRAPH_EVIDENCE.call_results.
+  the non-empty conjunction of call results that must be null at that sink. Select only result_index values supplied on
+  call results in CODEGRAPH_EVIDENCE, and return those values as call_result_index.
   If exhaustive enumeration of every unsafe alternative is uncertain, use an empty outer list so the finding remains
   visible. Also use an empty outer list when exploitability does not depend on a listed value state. Missing or unproven
   conditions remain feasible rather than establishing safety. These structured conditions describe the claim; they are

--- a/tests/test_diff_utils.py
+++ b/tests/test_diff_utils.py
@@ -24,13 +24,7 @@ def test_extract_content_from_diff_additions_only():
     assert content == "alpha\nbeta\ngamma\n"
 
 
-def test_process_diff_includes_original_when_available(tmp_path):
-    # Create a fake codebase with an original file
-    codebase = tmp_path / "codebase"
-    codebase.mkdir()
-    original = codebase / "foo.txt"
-    original.write_text("orig1\norig2\n")
-
+def test_process_diff_preserves_added_and_removed_lines_without_wrappers():
     patch = """--- a/foo.txt
 +++ b/foo.txt
 @@ -1,2 +1,3 @@
@@ -42,26 +36,4 @@ def test_process_diff_includes_original_when_available(tmp_path):
     ps = _make_patch(patch)
     file_diff = next(iter(ps))
 
-    # Set a very large token limit to force including original content
-    snippet = process_diff_file(str(codebase), file_diff, max_token_length=10_000_000)
-    assert "ORIGINAL_FILE:" in snippet
-    assert "FILE_CHANGES:" in snippet
-    assert "orig1" in snippet
-    assert "+new2" in snippet and "+new3" in snippet and "-orig2" in snippet
-
-
-def test_process_diff_without_original(tmp_path):
-    # No original file present in the codebase directory
-    codebase = tmp_path / "codebase"
-    codebase.mkdir()
-    patch = """--- a/bar.txt
-+++ b/bar.txt
-@@ -0,0 +1,1 @@
-+line
-"""
-    ps = _make_patch(patch)
-    file_diff = next(iter(ps))
-    snippet = process_diff_file(str(codebase), file_diff, max_token_length=100)
-    # Should not include ORIGINAL_FILE heading, but should include change lines
-    assert "ORIGINAL_FILE:" not in snippet
-    assert "+line\n" in snippet
+    assert process_diff_file(file_diff) == "-orig2\n+new2\n+new3\n"

--- a/tests/test_engine_review.py
+++ b/tests/test_engine_review.py
@@ -307,24 +307,31 @@ def test_reachability_empty_scope_is_inconclusive(engine):
 class _DummyReviewGraph:
     def __init__(self, review):
         self._review = review
+        self.requests = []
 
     def review(self, req):
+        self.requests.append(req)
         if self._review is None:
             return {"file": "test.py", "reviews": []}
         return self._review
 
 
 def test_review_patch_parses_and_reviews(engine, monkeypatch, tmp_path):
+    (Path(engine.codebase_path) / "test.py").write_text(
+        "print('Old')\n",
+        encoding="utf-8",
+    )
     patch_file = tmp_path / "change.diff"
     patch_file.write_text(
-        "--- a/test.py\n+++ b/test.py\n@@ -0,0 +1,2 @@\n+print('Hello')\n+print('World')\n"
+        "--- a/test.py\n+++ b/test.py\n@@ -1 +1 @@\n-print('Old')\n+print('New')\n"
+    )
+    review_graph = _DummyReviewGraph(
+        {"file": "test.py", "reviews": [{"issue": "Issue"}]}
     )
     monkeypatch.setattr(
         engine,
         "_get_review_graph",
-        lambda _index=None: _DummyReviewGraph(
-            {"file": "test.py", "reviews": [{"issue": "Issue"}]}
-        ),
+        lambda _index=None: review_graph,
     )
 
     import metis.engine.nodes.simple_llm_review.service as review_service_mod
@@ -336,6 +343,10 @@ def test_review_patch_parses_and_reviews(engine, monkeypatch, tmp_path):
     result = _simple_llm_review(engine).review_patch(str(patch_file))
     assert "reviews" in result and isinstance(result["reviews"], list)
     assert any(r.get("file") == "test.py" for r in result["reviews"])
+    (request,) = review_graph.requests
+    assert request["mode"] == "patch"
+    assert request["original_file"] == "print('Old')\n"
+    assert request["snippet"] == "-print('Old')\n+print('New')\n"
 
 
 def test_review_patch_handles_parse_error(engine, tmp_path):

--- a/tests/test_reachability_incremental_review.py
+++ b/tests/test_reachability_incremental_review.py
@@ -11,12 +11,15 @@ from unittest.mock import Mock
 from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableLambda
 from pytest import MonkeyPatch
+from pytest import raises
 
 from metis import runlog
 from metis.engine.codegraph import CallSite
 from metis.engine.codegraph import CodeExpression
 from metis.engine.codegraph import CodeGraph
+from metis.engine.codegraph import ControlCondition
 from metis.engine.codegraph import FunctionNode
+from metis.engine.codegraph import ValueAssignment
 from metis.engine.llm_runner import JsonPromptRunner
 from metis.engine.nodes.reachability import finding_admission
 from metis.engine.nodes.reachability import incremental_review
@@ -26,6 +29,7 @@ from metis.engine.nodes.reachability.options import ReachabilityReviewOptions
 from metis.engine.nodes.reachability.state import FactAtom
 from metis.engine.nodes.reachability.state import FunctionContract
 from metis.engine.nodes.reachability.state import GuardedTransfer
+from metis.engine.nodes.reachability.state import NormalExit
 from metis.engine.nodes.reachability.state import ReturnSubject
 from metis.engine.nodes.reachability.state import StateEffect
 from metis.engine.nodes.reachability.state import TrackedObjectSubject
@@ -108,7 +112,7 @@ def test_review_runs_one_discovery_pass_with_deterministic_contracts(
         evidence_text = body.partition("CODEGRAPH_EVIDENCE (untrusted JSON):\n")[2]
         evidence, _end = json.JSONDecoder().raw_decode(evidence_text)
         contract = evidence["direct_function_contracts"][0]
-        assert contract["function"] == "graph.c::sink"
+        assert evidence["function_ids"][contract["function"]] == "::sink"
         assert contract["normal_exit"] == {
             "line": 2,
             "origin": "observed",
@@ -140,6 +144,181 @@ def test_default_review_prompt_has_no_domain_hints(tmp_path: Path) -> None:
     assert "User-provided domain hints:" not in prompt
 
 
+def test_compact_packet_uses_tables_numbered_source_and_target_tags(
+    tmp_path: Path,
+) -> None:
+    source_lines = [
+        "void root(int a, int b) {",
+        "  int x = a + b;",
+        "  int y = a - b;",
+        "}",
+    ]
+    source = "\n".join(source_lines) + "\n"
+    (tmp_path / "graph.c").write_text(source, encoding="utf-8")
+    expressions: list[CodeExpression] = []
+    assignments: list[ValueAssignment] = []
+    for line, text in ((2, "a + b"), (3, "a - b")):
+        start = source.index(text)
+        expression = CodeExpression(
+            text,
+            line,
+            start,
+            start + len(text),
+            identifiers=("a", "b"),
+        )
+        expressions.append(expression)
+        assignments.append(
+            ValueAssignment(
+                expression,
+                expression,
+                "=",
+                line,
+                start,
+                source.index(";", start),
+            )
+        )
+    root = _function("root", 1)
+    root.end_line = len(source_lines)
+    root.assignments = assignments
+    root.calls = ["helper"]
+    root.call_sites = [
+        CallSite(
+            "helper",
+            2,
+            0,
+            start_byte=expressions[0].start_byte,
+            end_byte=source.index(";", expressions[0].start_byte),
+            target_ids=("helper.c::helper",),
+        )
+    ]
+    helper_condition = ControlCondition(
+        CodeExpression(
+            "ready",
+            1,
+            6,
+            11,
+            identifiers=("ready",),
+            direct_identifier="ready",
+        ),
+        True,
+    )
+    helper = FunctionNode(
+        "helper.c::helper",
+        "helper.c",
+        "helper",
+        1,
+        end_line=1,
+        calls=["stop"],
+        call_sites=[
+            CallSite(
+                "stop",
+                1,
+                0,
+                start_byte=1,
+                end_byte=5,
+                target_ids=("stop.c::stop",),
+                conditions=(helper_condition,),
+            )
+        ],
+    )
+    stop = FunctionNode("stop.c::stop", "stop.c", "stop", 1, end_line=1)
+    stop.set_tag("control.noreturn", value="_Noreturn", reason="test fact")
+    reviewer = _reviewer(tmp_path)
+
+    packets, failures = reviewer._build_packets(
+        _graph(root, helper, stop),
+        (root.unique_name, helper.unique_name, stop.unique_name),
+        options=ReachabilityReviewOptions(max_workers=1),
+        memory_service=None,
+        selected_node_ids={root.unique_name},
+        contracts={
+            helper.unique_name: FunctionContract(
+                helper.unique_name,
+                normal_exit=NormalExit("impossible", "observed", 1),
+            )
+        },
+    )
+
+    assert not failures
+    assert len(packets) == 1
+    body_text = packets[0].body_text
+    evidence_text = body_text.partition("CODEGRAPH_EVIDENCE (untrusted JSON):\n")[2]
+    evidence, _end = json.JSONDecoder().raw_decode(evidence_text)
+    assert evidence["expression_table"] == [
+        {"cols": [10, 15], "ids": [0, 1], "line": 2},
+        {"cols": [10, 15], "ids": [0, 1], "line": 3},
+    ]
+    assert evidence["atom_table"] == ["a", "b", "ready"]
+    assignment_data = evidence["functions"][0]["assignments"]
+    assert [item["target"] for item in assignment_data] == [0, 1]
+    assert all(item["target"] == item["value"] for item in assignment_data)
+    direct_function = evidence["direct_functions"][0]
+    assert direct_function["file_path"] == "helper.c"
+    assert "call_index" not in direct_function["calls"][0]
+    foreign_condition = evidence["condition_table"][0]
+    assert foreign_condition["file_path"] == "helper.c"
+    assert direct_function["calls"][0]["conditions"] == [0]
+    assert "file_path" not in foreign_condition["expression"]
+    direct_contract = evidence["direct_function_contracts"][0]
+    assert direct_contract["file_path"] == "helper.c"
+    assert direct_contract["normal_exit"]["line"] == 1
+    assert evidence["function_tags"]["2"]["control.noreturn"] == [
+        "_Noreturn",
+        "test fact",
+    ]
+    assert "expression_table maps integer expression references" in body_text
+    assert "atom_table maps integer references" in body_text
+    assert "expand each reference at its use site" in body_text
+    snippet = body_text.partition("\nSNIPPET:\n")[2].rstrip("\n").splitlines()
+    assert snippet == [
+        f"{number}: {line}" for number, line in enumerate(source_lines, 1)
+    ]
+
+
+def test_oversized_source_line_only_fails_its_function(tmp_path: Path) -> None:
+    reviewer = _reviewer(tmp_path)
+    source = "void small(void) {}\n" + "x" * (reviewer._config.max_token_length + 1)
+    (tmp_path / "graph.c").write_text(source, encoding="utf-8")
+    small = _function("small", 1)
+    oversized = _function("oversized", 2)
+
+    packets, failures = reviewer._build_packets(
+        _graph(small, oversized),
+        (small.unique_name, oversized.unique_name),
+        options=ReachabilityReviewOptions(max_workers=1),
+        memory_service=None,
+    )
+
+    assert [[node.unique_name for node in packet.nodes] for packet in packets] == [
+        [small.unique_name]
+    ]
+    assert {(failure.function_id, failure.kind) for failure in failures} == {
+        (oversized.unique_name, "context_overflow")
+    }
+
+
+def test_source_chunk_runtime_error_propagates(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    (tmp_path / "graph.c").write_text("void root(void) {}\n", encoding="utf-8")
+    reviewer = _reviewer(tmp_path)
+    root = _function("root", 1)
+    monkeypatch.setattr(
+        incremental_review,
+        "_build_file_grouped_node_chunks",
+        Mock(side_effect=RuntimeError("token counter failed")),
+    )
+
+    with raises(RuntimeError, match="token counter failed"):
+        reviewer._build_packets(
+            _graph(root),
+            (root.unique_name,),
+            options=ReachabilityReviewOptions(max_workers=1),
+            memory_service=None,
+        )
+
+
 def test_invalid_discovery_packet_splits_and_reviews_children(tmp_path: Path) -> None:
     (tmp_path / "graph.c").write_text(
         "void first(void) {}\nvoid second(void) {}\n",
@@ -161,11 +340,7 @@ def test_invalid_discovery_packet_splits_and_reviews_children(tmp_path: Path) ->
         }
 
     chat = RunnableLambda(lambda _messages: AIMessage(content=""))
-    setattr(
-        chat,
-        "with_structured_output",
-        lambda *_args, **_kwargs: RunnableLambda(respond),
-    )
+    chat.with_structured_output = lambda *_args, **_kwargs: RunnableLambda(respond)
     reviewer._llm_provider.get_chat_model.return_value = chat
     reviewer._runner = JsonPromptRunner(
         reviewer._llm_provider,
@@ -261,18 +436,23 @@ def test_indexed_null_condition_reaches_deterministic_admission(
         body = request.variables["body_text"]
         evidence_text = body.partition("CODEGRAPH_EVIDENCE (untrusted JSON):\n")[2]
         evidence, _end = json.JSONDecoder().raw_decode(evidence_text)
-        assert evidence["call_results"] == [
-            {
-                "call_result_index": 0,
-                "call_symbol": "allocate",
-                "expression": "p",
-                "function_id": root.unique_name,
-                "kind": "call_result",
-                "line": 2,
-                "start_byte": 39,
-                "end_byte": 40,
-            }
-        ]
+        assert "call_results" not in evidence
+        allocator_index = evidence["function_ids"].index("::allocate")
+        contract_data = evidence["direct_function_contracts"][0]
+        assert contract_data["function"] == allocator_index
+        effect = contract_data["normal_returns"][0]["effects"][0]
+        assert (effect["operation"], effect["atom"]["subject"]) == (
+            "negate",
+            {"function_id": allocator_index, "kind": "return"},
+        )
+        root_index = evidence["function_ids"].index("::root")
+        root_data = next(
+            item for item in evidence["functions"] if item["function_id"] == root_index
+        )
+        producer_data = root_data["calls"][0]
+        assert [call["call_index"] for call in root_data["calls"]] == [0, 1]
+        assert evidence["call_symbols"][producer_data["symbol"]] == "allocate"
+        assert producer_data["result"]["result_index"] == 0
         parsed = request.parse(
             {
                 "reviews": [

--- a/tests/test_reachability_source_context.py
+++ b/tests/test_reachability_source_context.py
@@ -3,6 +3,8 @@
 
 import re
 
+import pytest
+
 from metis.engine.codegraph import CallSite, FunctionNode
 from metis.engine.nodes.reachability.source_context import (
     _build_file_grouped_node_chunks,
@@ -80,3 +82,15 @@ def test_function_chunks_never_cross_files_and_follow_source_order(tmp_path):
     assert all(len({node.file_path for node in nodes}) == 1 for nodes, _text in chunks)
     assert all("Function a.c::" not in text for _nodes, text in chunks)
     assert all("===== FILE:" not in text for _nodes, text in chunks)
+
+
+def test_function_chunks_reject_unlabelled_line_fragments(tmp_path):
+    (tmp_path / "sample.c").write_text("void target(void) { operation(); }\n")
+
+    with pytest.raises(ValueError, match="one numbered source line"):
+        _build_file_grouped_node_chunks(
+            str(tmp_path),
+            [_node("target", 1, 1)],
+            max_tokens=10,
+            token_counter=_character_count,
+        )


### PR DESCRIPTION
- Compact CodeGraph evidence with stable indexes and explicit provenance.
- Preserve numbered source lines while isolating oversized review packets.
- Eliminate duplicated original-file context from patch reviews.
- Keep deterministic call-result admission covered by focused regressions.