### PR TITLE
refactor(usage): share LangChain response parsing

### DIFF
--- a/src/metis/runlog/langchain.py
+++ b/src/metis/runlog/langchain.py
@@ -66,8 +66,8 @@ class RunLogCallbackHandler(BaseCallbackHandler):
         call = self._pop(run_id)
         if call is None:
             return None
-        usage = _usage(response)
-        model = _model_name(response)
+        usage = extract_response_usage(response)
+        model = extract_response_model_name(response)
         if usage:
             call.event("usage", {"model": model, **usage})
             bump("input_tokens", usage["input_tokens"])
@@ -152,7 +152,7 @@ def _serialized_name(serialized: dict[str, Any]) -> str:
     return "model"
 
 
-def _usage(response: Any) -> dict[str, int]:
+def extract_response_usage(response: Any) -> dict[str, int]:
     llm_output = getattr(response, "llm_output", None) or {}
     token_usage = llm_output.get("token_usage") if isinstance(llm_output, dict) else {}
     if not isinstance(token_usage, dict):
@@ -187,10 +187,12 @@ def _usage(response: Any) -> dict[str, int]:
     }
 
 
-def _model_name(response: Any) -> str:
+def extract_response_model_name(response: Any) -> str:
     llm_output = getattr(response, "llm_output", None) or {}
-    if isinstance(llm_output, dict) and llm_output.get("model_name"):
-        return str(llm_output["model_name"])
+    if isinstance(llm_output, dict):
+        name = str(llm_output.get("model_name") or "").strip()
+        if name:
+            return name
     for generation_list in getattr(response, "generations", None) or []:
         for generation in (
             generation_list if isinstance(generation_list, Iterable) else ()
@@ -198,9 +200,11 @@ def _model_name(response: Any) -> str:
             message = getattr(generation, "message", generation)
             metadata = getattr(message, "response_metadata", None) or {}
             if isinstance(metadata, dict):
-                name = metadata.get("model_name") or metadata.get("model")
-                if name:
-                    return str(name)
+                candidate = metadata.get("model_name") or metadata.get("model")
+                if candidate:
+                    normalized = str(candidate).strip()
+                    if normalized:
+                        return normalized
     return "unknown"
 
 

--- a/src/metis/usage/langchain.py
+++ b/src/metis/usage/langchain.py
@@ -1,98 +1,29 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import Any
 
 from langchain_core.callbacks.base import BaseCallbackHandler
 
+from metis.runlog.langchain import extract_response_model_name
+from metis.runlog.langchain import extract_response_usage
+
 from .collector import UsageCollector
 from .context import current_operation, current_scope
-
-
-def _as_int(value: Any) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return 0
-    return parsed if parsed > 0 else 0
-
-
-def _extract_usage_metadata(response) -> tuple[int, int, int]:
-    llm_output = getattr(response, "llm_output", None) or {}
-    token_usage = {}
-    if isinstance(llm_output, dict):
-        token_usage = llm_output.get("token_usage") or {}
-    if isinstance(token_usage, dict) and token_usage:
-        input_tokens = _as_int(
-            token_usage.get("prompt_tokens") or token_usage.get("input_tokens")
-        )
-        output_tokens = _as_int(
-            token_usage.get("completion_tokens") or token_usage.get("output_tokens")
-        )
-        total_tokens = _as_int(token_usage.get("total_tokens"))
-        if total_tokens <= 0:
-            total_tokens = input_tokens + output_tokens
-        if input_tokens or output_tokens or total_tokens:
-            return input_tokens, output_tokens, total_tokens
-
-    input_tokens = 0
-    output_tokens = 0
-    total_tokens = 0
-    generations = getattr(response, "generations", None) or []
-    for generation_list in generations:
-        if not isinstance(generation_list, Iterable):
-            continue
-        for generation in generation_list:
-            message = getattr(generation, "message", None)
-            usage_metadata = getattr(message, "usage_metadata", None) or {}
-            if not isinstance(usage_metadata, dict):
-                continue
-            input_tokens += _as_int(usage_metadata.get("input_tokens"))
-            output_tokens += _as_int(usage_metadata.get("output_tokens"))
-            total_tokens += _as_int(usage_metadata.get("total_tokens"))
-    if total_tokens <= 0:
-        total_tokens = input_tokens + output_tokens
-    return input_tokens, output_tokens, total_tokens
-
-
-def _extract_model_name(response) -> str:
-    llm_output = getattr(response, "llm_output", None) or {}
-    if isinstance(llm_output, dict):
-        model_name = str(llm_output.get("model_name") or "").strip()
-        if model_name:
-            return model_name
-    generations = getattr(response, "generations", None) or []
-    for generation_list in generations:
-        if not isinstance(generation_list, Iterable):
-            continue
-        for generation in generation_list:
-            message = getattr(generation, "message", None)
-            response_metadata = getattr(message, "response_metadata", None) or {}
-            if not isinstance(response_metadata, dict):
-                continue
-            model_name = str(
-                response_metadata.get("model_name") or response_metadata.get("model")
-            ).strip()
-            if model_name:
-                return model_name
-    return "unknown"
 
 
 class UsageCallbackHandler(BaseCallbackHandler):
     def __init__(self, collector: UsageCollector):
         self._collector = collector
 
-    def on_llm_end(self, response, **kwargs: Any) -> Any:
+    def on_llm_end(self, response: Any, **kwargs: Any) -> Any:
         scope_id = current_scope()
-        input_tokens, output_tokens, total_tokens = _extract_usage_metadata(response)
-        if input_tokens <= 0 and output_tokens <= 0 and total_tokens <= 0:
+        usage = extract_response_usage(response)
+        if not usage:
             return None
         self._collector.record(
             scope_id=scope_id,
             operation=current_operation(),
-            model=_extract_model_name(response),
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            total_tokens=total_tokens,
+            model=extract_response_model_name(response),
+            **usage,
         )
         return None

--- a/tests/test_runlog.py
+++ b/tests/test_runlog.py
@@ -524,15 +524,15 @@ def test_langchain_callback_records_physical_call_and_usage(tmp_path):
         "Response",
         (),
         {
-            "llm_output": {
-                "model_name": "fake-model",
-                "token_usage": {
-                    "prompt_tokens": 7,
-                    "completion_tokens": 3,
-                    "total_tokens": 10,
-                },
-            },
-            "generations": [],
+            "llm_output": {},
+            "generations": [
+                [
+                    SimpleNamespace(
+                        usage_metadata={"input_tokens": 7, "output_tokens": 3},
+                        response_metadata={"model_name": " fake-model "},
+                    )
+                ]
+            ],
         },
     )()
 
@@ -553,6 +553,7 @@ def test_langchain_callback_records_physical_call_and_usage(tmp_path):
     )
     usage = next(record for record in records if record["name"] == "usage")
     assert usage["span_id"] == call_start["span_id"]
+    assert usage["attributes"]["model"] == "fake-model"
     assert usage["attributes"]["total_tokens"] == 10
     assert session.counters["llm_calls"] == 1
     assert session.counters["total_tokens"] == 10

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -3,6 +3,7 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 from llama_index.core import StorageContext, VectorStoreIndex
@@ -50,13 +51,14 @@ def test_usage_runtime_command_summary_and_persistence(tmp_path):
     runtime = UsageRuntime(tmp_path)
 
     with runtime.command("index") as command:
-        runtime.collector.record(
-            scope_id=command.scope_id,
-            operation="index",
-            model="embed-model",
-            input_tokens=80,
-            output_tokens=0,
-            total_tokens=80,
+        runtime.langchain_handler.on_llm_end(
+            SimpleNamespace(
+                llm_output={
+                    "model_name": "embed-model",
+                    "token_usage": {"prompt_tokens": 80},
+                },
+                generations=[],
+            )
         )
 
     record = runtime.finalize_command(command)


### PR DESCRIPTION
- Reuse runlog token and model extraction in usage callbacks.
- Preserve separate usage aggregation and physical-call tracing.
- Cover llm_output and direct-generation metadata behavior.