### PR TITLE
refactor(core): remove dead infrastructure duplication

### DIFF
--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -4,11 +4,9 @@
 import contextlib
 import hashlib
 import importlib.metadata
-import json
 import logging
 import os
 import re
-import tempfile
 import warnings
 from datetime import datetime
 from pathlib import Path
@@ -21,6 +19,7 @@ from metis.runlog import RunLogConfig
 from metis.runlog import build_run_metadata
 from metis.runlog import open_runlog
 from metis import runlog
+from metis.json_io import write_json_atomic
 from rich.markup import escape
 from rich.progress import (
     Progress,
@@ -384,28 +383,9 @@ def save_output(output_files, data, quiet=False, sarif_payload=None):
     )
     sarif_payload_local = sarif_payload
 
-    def _write_payload(path, payload, label):
+    def _write_payload(path: Path, payload: object, label: str) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        serialized = json.dumps(payload, indent=4)
-        tmp_path = None
-        try:
-            with tempfile.NamedTemporaryFile(
-                mode="w",
-                encoding="utf-8",
-                dir=path.parent,
-                prefix=f".{path.name}.",
-                suffix=".tmp",
-                delete=False,
-            ) as tmp:
-                tmp.write(serialized)
-                tmp.flush()
-                os.fsync(tmp.fileno())
-                tmp_path = tmp.name
-            os.replace(tmp_path, path)
-        except Exception:
-            if tmp_path is not None:
-                Path(tmp_path).unlink(missing_ok=True)
-            raise
+        write_json_atomic(path, payload, indent=4)
         _record_output_artifact(path, output_format(path))
         print_console(
             f"[blue]{label} saved to {escape(str(path))}[/blue]",

--- a/src/metis/engine/nodes/reachability/limits.py
+++ b/src/metis/engine/nodes/reachability/limits.py
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
-# SPDX-License-Identifier: Apache-2.0
-
-FUNCTION_BODY_DEFAULT_CHARS = 3000
-FUNCTION_BODY_FALLBACK_LINES = 80

--- a/src/metis/engine/nodes/reachability/source_context.py
+++ b/src/metis/engine/nodes/reachability/source_context.py
@@ -8,31 +8,6 @@ from metis.engine.codegraph import FunctionNode
 from metis.engine.source import SourceMap
 from metis.utils import split_snippet
 
-from .limits import FUNCTION_BODY_DEFAULT_CHARS, FUNCTION_BODY_FALLBACK_LINES
-
-
-def _read_function_body(codebase_path, node, max_chars=FUNCTION_BODY_DEFAULT_CHARS):
-    smap = SourceMap.for_file(codebase_path, node.file_path)
-    if smap is None:
-        return ""
-    return smap.function_slice(
-        node.line_number,
-        node.end_line,
-        max_chars=max_chars,
-        fallback_lines=FUNCTION_BODY_FALLBACK_LINES,
-    )
-
-
-def _read_line_context(codebase_path, rel_file, line_number, context=2, max_chars=1200):
-    smap = SourceMap.for_file(codebase_path, rel_file)
-    if smap is None:
-        return ""
-    return smap.context_slice(
-        int(line_number or 1),
-        radius=context,
-        max_chars=max_chars,
-    )
-
 
 def _build_file_grouped_node_chunks(
     codebase_path: str,

--- a/src/metis/exceptions.py
+++ b/src/metis/exceptions.py
@@ -2,13 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-class DatabaseNotFoundError(Exception):
-    """Exception raised when the database is not found."""
-
-    def __init__(self, db_name: str):
-        super().__init__(f"Requested database '{db_name}' not found.")
-
-
 class RetrieverInitError(Exception):
     """Exception raised when retriever initialization fails."""
 

--- a/src/metis/json_io.py
+++ b/src/metis/json_io.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+def write_json_atomic(
+    path: str | Path,
+    payload: object,
+    *,
+    indent: int,
+    ensure_ascii: bool = True,
+    allow_nan: bool = True,
+    mode: int | None = None,
+) -> None:
+    target = Path(path)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            json.dump(
+                payload,
+                handle,
+                indent=indent,
+                ensure_ascii=ensure_ascii,
+                allow_nan=allow_nan,
+            )
+            handle.flush()
+            os.fsync(handle.fileno())
+        if mode is not None:
+            temporary.chmod(mode)
+        os.replace(temporary, target)
+        if mode is not None:
+            target.chmod(mode)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)

--- a/src/metis/providers/registry.py
+++ b/src/metis/providers/registry.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib import metadata
 from importlib import import_module
-from pathlib import Path
-import tomllib
 from typing import Type
 
 from metis.providers.base import ChatProvider
@@ -92,35 +90,7 @@ def _discover_provider_loaders() -> None:
         else:
             _register_provider_loader(provider_name, embedding=entry_point.value)
 
-    _discover_source_tree_provider_loaders()
-
     _PROVIDER_LOADERS_DISCOVERED = True
-
-
-def _discover_source_tree_provider_loaders() -> None:
-    pyproject_path = _find_pyproject_path()
-    if pyproject_path is None:
-        return
-
-    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
-    provider_entry_points = (
-        data.get("project", {}).get("entry-points", {}).get(_PROVIDER_ENTRY_POINT_GROUP)
-        or {}
-    )
-    for entry_point_name, dotted_path in provider_entry_points.items():
-        provider_name, surface = _parse_provider_entry_point_name(entry_point_name)
-        if surface == "chat":
-            _register_provider_loader(provider_name, chat=dotted_path)
-        else:
-            _register_provider_loader(provider_name, embedding=dotted_path)
-
-
-def _find_pyproject_path() -> Path | None:
-    for parent in Path(__file__).resolve().parents:
-        pyproject_path = parent / "pyproject.toml"
-        if pyproject_path.is_file():
-            return pyproject_path
-    return None
 
 
 def _parse_provider_entry_point_name(name: str) -> tuple[str, str]:

--- a/src/metis/runlog/session.py
+++ b/src/metis/runlog/session.py
@@ -25,6 +25,8 @@ from pathlib import Path
 from typing import Any
 from typing import Literal
 
+from metis.json_io import write_json_atomic
+
 from .encoding import PayloadEncoder
 from .schema import event_explanation
 from .schema import RunLogConfig
@@ -521,22 +523,15 @@ class RunLogSession:
             "metadata": self._encoder.encode_mapping(self._metadata),
             "totals": self.counters if complete else {},
         }
-        temporary = self.meta_path.with_name(
-            f".{self.meta_path.name}.{uuid.uuid4().hex}.tmp"
+        self.meta_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        write_json_atomic(
+            self.meta_path,
+            payload,
+            indent=2,
+            ensure_ascii=False,
+            allow_nan=False,
+            mode=0o600,
         )
-        temporary.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        try:
-            with temporary.open("x", encoding="utf-8") as handle:
-                json.dump(
-                    payload, handle, ensure_ascii=False, allow_nan=False, indent=2
-                )
-                handle.flush()
-                os.fsync(handle.fileno())
-            temporary.chmod(0o600)
-            os.replace(temporary, self.meta_path)
-            self.meta_path.chmod(0o600)
-        finally:
-            temporary.unlink(missing_ok=True)
 
     def _disable_after_failure(self, exc: BaseException) -> None:
         with self._lock:

--- a/src/metis/sarif/triage.py
+++ b/src/metis/sarif/triage.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
-import os
-import tempfile
 from pathlib import Path
 from typing import Any
+
+from metis.json_io import write_json_atomic
 
 METIS_TRIAGED_KEY = "metisTriaged"
 METIS_TRIAGE_STATUS_KEY = "metisTriageStatus"
@@ -48,19 +48,7 @@ def load_sarif_file(path: str | Path) -> dict[str, Any]:
 def save_sarif_file(path: str | Path, payload: dict[str, Any]) -> None:
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=p.parent,
-        prefix=f".{p.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as tmp:
-        json.dump(payload, tmp, indent=4)
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp_path = tmp.name
-    os.replace(tmp_path, p)
+    write_json_atomic(p, payload, indent=4)
 
 
 def extract_findings(

--- a/src/metis/utils.py
+++ b/src/metis/utils.py
@@ -5,7 +5,6 @@ import codecs
 import json
 import math
 import os
-import sys
 from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
@@ -264,25 +263,3 @@ def read_file_content(file_path):
             return f.read()
     except Exception:
         return ""
-
-
-def retry_on_recursion_error(fn, *args, bump=5000, retries=10, **kwargs):
-    """
-    Calls `fn(*args, **kwargs)`, catching RecursionError up to `retries` times.
-    On each failure, increase the recursion limit by `bump` * `attempt` and retry.
-    Restores the original limit before returning.
-    """
-    original_limit = sys.getrecursionlimit()
-    try:
-        return fn(*args, **kwargs)
-    except RecursionError as e:
-        for attempt in range(1, retries + 1):
-            new_limit = original_limit + bump * attempt
-            sys.setrecursionlimit(new_limit)
-            try:
-                return fn(*args, **kwargs)
-            except RecursionError:
-                continue
-        raise e
-    finally:
-        sys.setrecursionlimit(original_limit)

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from metis.json_io import write_json_atomic
+
+
+def test_write_json_atomic_preserves_target_and_cleans_temporary_file(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "result.json"
+    write_json_atomic(
+        target,
+        {"text": "£"},
+        indent=2,
+        ensure_ascii=False,
+        allow_nan=False,
+        mode=0o600,
+    )
+
+    expected = target.read_text(encoding="utf-8")
+    assert expected == '{\n  "text": "£"\n}'
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    with pytest.raises(ValueError):
+        write_json_atomic(target, {"value": float("nan")}, indent=2, allow_nan=False)
+
+    assert target.read_text(encoding="utf-8") == expected
+    assert list(tmp_path.iterdir()) == [target]

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-import metis.providers.registry as registry
 from metis.providers.registry import get_chat_provider
 from metis.providers.registry import get_embedding_provider
 
@@ -59,20 +58,3 @@ def test_registry_loads_embedding_providers(name, class_name, module_name):
 def test_registry_rejects_embedding_for_chat_only_providers(name):
     with pytest.raises(ValueError, match="Unsupported embedding provider"):
         get_embedding_provider(name)
-
-
-def test_registry_loads_source_tree_providers_without_installed_entry_points(
-    monkeypatch,
-):
-    class _NoEntryPoints:
-        def select(self, **_kwargs):
-            return []
-
-    monkeypatch.setattr(registry.metadata, "entry_points", lambda: _NoEntryPoints())
-    monkeypatch.setattr(registry, "_CHAT_PROVIDERS", {})
-    monkeypatch.setattr(registry, "_EMBEDDING_PROVIDERS", {})
-    monkeypatch.setattr(registry, "_PROVIDER_LOADERS", {})
-    monkeypatch.setattr(registry, "_PROVIDER_LOADERS_DISCOVERED", False)
-
-    assert get_chat_provider("openai").__name__ == "OpenAIProvider"
-    assert get_embedding_provider("openai").__name__ == "OpenAIEmbeddingProvider"


### PR DESCRIPTION
- Delete unused recursion, database, and reachability helpers.
- Rely on installed provider entry points instead of scanning pyproject.toml.
- Share atomic JSON writes across CLI, SARIF, and runlog.
- Preserve serialization, fsync, and file-permission behavior.