### PR TITLE
fix(engine): serialize review graph lazy initialization

### DIFF
--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -309,7 +309,13 @@ class MetisEngine:
     ):
         model = model or self._config.llama_query_model
         cache_key = (index is not None, model)
-        if cache_key not in self._state.review_graphs:
+        cached = self._state.review_graphs.get(cache_key)
+        if cached is not None:
+            return cached
+        with self._state.review_graph_lock:
+            cached = self._state.review_graphs.get(cache_key)
+            if cached is not None:
+                return cached
             model_tools = (
                 index_model_tools(
                     index,
@@ -336,7 +342,7 @@ class MetisEngine:
                     else None
                 ),
             )
-        return self._state.review_graphs[cache_key]
+            return self._state.review_graphs[cache_key]
 
     def _chat_model_kwargs(self) -> dict:
         return merge_chat_model_kwargs(

--- a/src/metis/engine/runtime.py
+++ b/src/metis/engine/runtime.py
@@ -51,3 +51,4 @@ class EngineState:
     retriever_docs: Any | None = None
     pending_nodes: tuple[Any, Any] | None = None
     retriever_lock: Lock = field(default_factory=Lock)
+    review_graph_lock: Lock = field(default_factory=Lock)


### PR DESCRIPTION
Guard _get_review_graph with a double-checked lock on EngineState.review_graph_lock so concurrent worker threads share a single ReviewGraph instead of each constructing (and discarding) their own. Same pattern as #171 applied to the query-engine cache.