### PR TITLE
fix: keep llama.cpp embedding inputs as text

### DIFF
--- a/src/metis/providers/llamacpp.py
+++ b/src/metis/providers/llamacpp.py
@@ -62,6 +62,7 @@ class LlamaCppProvider(OpenAICompatibleChatProvider):
 class LlamaCppEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
     DEFAULT_BASE_URL = LlamaCppProvider.DEFAULT_BASE_URL
     DEFAULT_API_KEY = LlamaCppProvider.DEFAULT_API_KEY
+    DEFAULT_CHECK_EMBEDDING_CTX_LENGTH = False
     CONFIG_SPEC = ProviderConfigSpec(
         display_name="llama.cpp embeddings",
         required_keys=("code_embedding_model", "docs_embedding_model"),
@@ -75,6 +76,3 @@ class LlamaCppEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
             "docs_extra_kwargs",
         ),
     )
-
-    def __init__(self, config):
-        super().__init__(config)

--- a/src/metis/providers/openai_compatible.py
+++ b/src/metis/providers/openai_compatible.py
@@ -106,6 +106,7 @@ class OpenAICompatibleChatProvider(ChatProvider):
 class OpenAICompatibleEmbeddingProvider(EmbeddingProvider):
     DEFAULT_BASE_URL: str | None = None
     DEFAULT_API_KEY: str | None = None
+    DEFAULT_CHECK_EMBEDDING_CTX_LENGTH: bool | None = None
 
     def __init__(self, config: OpenAICompatibleEmbeddingConfig) -> None:
         self.config = config
@@ -154,6 +155,10 @@ class OpenAICompatibleEmbeddingProvider(EmbeddingProvider):
             params["base_url"] = self.base_url
         if self.default_headers:
             params["default_headers"] = self.default_headers
+        if self.DEFAULT_CHECK_EMBEDDING_CTX_LENGTH is not None:
+            params["check_embedding_ctx_length"] = (
+                self.DEFAULT_CHECK_EMBEDDING_CTX_LENGTH
+            )
         if extra_kwargs:
             params.update(extra_kwargs)
 

--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from langchain_openai import ChatOpenAI
 
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
+from metis.providers.llamacpp import LlamaCppEmbeddingProvider
 from metis.providers.openai_compatible import OpenAICompatibleChatConfig
 from metis.providers.openai_compatible import OpenAICompatibleChatProvider
 from metis.providers.openai_compatible import OpenAICompatibleEmbeddingConfig
@@ -103,3 +104,10 @@ def test_embedding_provider_builds_separate_code_and_docs_models() -> None:
     assert code_client.openai_api_base == "https://example.test/v1"
     assert code_client.default_headers == {"X-Test-Header": "test"}
     assert code_client.dimensions == 1536
+    assert code_client.check_embedding_ctx_length is True
+    llama_provider = LlamaCppEmbeddingProvider(_embedding_config())
+    for embedding in (
+        llama_provider.get_embed_model_code(),
+        llama_provider.get_embed_model_docs(),
+    ):
+        assert cast(Any, embedding._client).check_embedding_ctx_length is False


### PR DESCRIPTION
## Why

llama.cpp embedding servers can reject token-ID payloads from `OpenAIEmbeddings`. Sending the original text avoids the `Prompt contains invalid tokens` error for models such as `nomic-embed-text-v1.5`.

## Change

- Set llama.cpp's embedding default to send raw text.
- Keep the existing OpenAI-compatible default unchanged; provider configuration can still override the default where token IDs are supported.

## Verification

- `pytest -q`
- `pre-commit run --files src/metis/providers/openai_compatible.py src/metis/providers/llamacpp.py tests/test_openai_compatible_provider.py`

Fixes #247
