### PR TITLE
feat(codegraph): build profiled graphs during initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Metis includes support for the following languages:
 For the current review graph and SARIF triage flow, see
 [docs/execution-graph.md](docs/execution-graph.md) and
 [docs/triage-flow.md](docs/triage-flow.md).
+Optional compilation-database filtering for C/C++ review is documented in
+[docs/config/compilation_profile.md](docs/config/compilation_profile.md).
 
 Metis uses a plugin-based language system, making it easy to extend support to additional languages.
 

--- a/docs/config/compilation_profile.md
+++ b/docs/config/compilation_profile.md
@@ -1,0 +1,132 @@
+# Build-profiled C/C++ analysis
+
+By default, the Initialize `codegraph` node runs Tree-sitter on the checked-out
+source. Add the optional `compilation_profile` node to limit C/C++ analysis to
+the files and conditional branches used by a compilation database.
+
+`compile_commands.json` records how each source file is built: its compiler,
+working directory, include paths, and build flags. Metis reads this existing
+file; it does not create a new database.
+
+`compilation_profile` runs the compiler recorded by each C/C++
+`compile_commands.json` entry in preprocessing mode. It records included files
+and active source lines, then installs a source view with inactive lines blanked.
+The `codegraph` node still uses the normal C/C++ Tree-sitter provider. Metis does
+not build the project, fully expand macros for parsing, or consume a compiler
+AST.
+
+## Configuration
+
+Run `compilation_profile` before `codegraph` in Initialize. This example
+replaces the packaged execution graph and omits Triage.
+
+```yaml
+metis_engine:
+  execution:
+    inputs:
+      review_request: {mode: code}
+    stages:
+      initialize:
+        outputs:
+          threat_model: threat_model.threat_model
+          codegraph: codegraph.codegraph
+        nodes:
+          threat_model: {capabilities: [memory]}
+          compilation_profile:
+            max_concurrency: 16
+          codegraph:
+            depends_on: [compilation_profile]
+      review:
+        inputs:
+          codegraph: initialize.codegraph
+        nodes:
+          simple_llm_review: {capabilities: [memory]}
+          reachability: {capabilities: [memory]}
+          finding_dedup: {}
+          result: {formats: [sarif]}
+    node_configuration:
+      initialize:
+        compilation_profile:
+          compile_commands_path: build/compile_commands.json
+          timeout_seconds: 60
+```
+
+The explicit dependency guarantees that the source profile is installed before
+Tree-sitter reads any source. `node_configuration` holds node settings; it is
+not another stage.
+
+Set `max_concurrency` on the `compilation_profile` node to choose how many
+compiler processes may run at once. It cannot exceed `metis_engine.max_workers`.
+Omit it to use that global limit. There is no additional limit in the profiler.
+
+For ordinary Tree-sitter analysis, remove `compilation_profile`, its
+configuration, and the `codegraph.depends_on` entry. Keep `codegraph` for
+Reachability; a Simple Review-only graph does not require it.
+
+## Data flow
+
+```text
+compile_commands.json (optional)
+        |
+recorded compiler preprocessor
+        |
+active-line source view
+        |
+Tree-sitter codegraph
+        |
+persisted CodeGraphReference
+        |
+Review and Reachability
+```
+
+Without a compilation database, the flow starts at `Tree-sitter codegraph`.
+
+## Compiler and source contract
+
+- Metis executes the compiler command recorded in each database entry. It does
+  not replace GCC with Clang or another compiler.
+- Treat the compilation database and every recorded compiler or wrapper as
+  trusted build input: enabling this node executes those programs.
+- The current preprocessing invocation requires a GCC-compatible driver, such
+  as GCC, Clang, or an Arm GNU cross-compiler. Compilers with different command
+  interfaces are not supported by this node.
+- A relative `compile_commands_path` resolves from the codebase root. Each
+  entry's `directory` remains its working directory.
+- Metis prefers the `arguments` array when an entry provides both `arguments`
+  and a quoted `command` string. Compiler options and their values stay together;
+  build-output and dependency-output options are removed for preprocessing.
+- Forwarded `-Wp,...` arguments are supported only for the dependency-only
+  forms `-Wp,-MD,file` and `-Wp,-MMD,file`. Use separate compiler flags for other
+  groups. Unsupported groups are rejected without executing the command.
+- GCC's `-fpch-preprocess` mode is rejected because it can omit precompiled
+  header source from the preprocessing output. Remove this flag so included
+  headers are processed from source.
+- Compiler, source, included-header, generated-header, and sysroot paths must
+  exist in the runtime environment. Object files and linked outputs are not
+  required.
+- Only C/C++ entries are executed; only files under the codebase are stored in
+  the profile. Other-language entries are ignored.
+- Inactive source bytes are replaced with spaces while line endings and byte
+  positions remain unchanged. Tree-sitter and finding anchors therefore keep
+  using original-source coordinates.
+- Source files and included headers must use LF or CRLF line endings. Bare
+  carriage returns are rejected because compilers and Tree-sitter count them
+  differently, which would otherwise select the wrong source lines.
+- A file with different active lines in different translation units is omitted
+  from CodeGraph rather than choosing one build variant. Simple Review still
+  reviews its original source.
+- Invalid databases, unsupported arguments, preprocessing failures, source
+  `#line` directives, and source changes detected while building the graph stop
+  initialization. Later source changes are rejected when the file is read for
+  review.
+
+Finish builds and header generation before starting Initialize, and keep the
+source files unchanged while it runs. Preprocessing and reading the source files
+are separate operations; the profile is not an atomic filesystem snapshot.
+
+The effective source profile is part of the persisted graph fingerprint.
+Changing its raw or active source view rebuilds the graph.
+Edits to files excluded from the profile do not invalidate the graph. Changes
+to the selected file set still invalidate it so stored file coverage stays current.
+Source views are run-local: a later run rebuilds the profile before reusing its
+persisted graph revision.

--- a/docs/execution-graph.md
+++ b/docs/execution-graph.md
@@ -46,16 +46,17 @@ metis_engine:
     stages:
       initialize:
         outputs:
-          - threat_model
+          threat_model: threat_model.threat_model
+          codegraph: codegraph.codegraph
         nodes:
           threat_model:
             capabilities:
               - memory
-      review:
-        depends_on:
-          - initialize
-        nodes:
           codegraph: {}
+      review:
+        inputs:
+          codegraph: initialize.codegraph
+        nodes:
           simple_llm_review:
             capabilities:
               - memory
@@ -69,7 +70,7 @@ metis_engine:
       triage:
         inputs:
           sarif: review.sarif
-          codegraph: review.codegraph
+          codegraph: initialize.codegraph
         nodes:
           triage:
             capabilities:
@@ -121,8 +122,17 @@ are rejected when the YAML is loaded.
 - `threat_model` updates threat-model memory and returns its initialization
   status.
 
+- `codegraph` uses language providers such as Tree-sitter to build, validate,
+  annotate, and persist the complete project graph at
+  `<codebase>/.metis/codegraph.sqlite3`.
+
 - `index` builds the configured repository index when explicitly included in
   the graph. The packaged graph omits it.
+
+- [`compilation_profile`](config/compilation_profile.md) optionally runs before
+  `codegraph`. It uses a C/C++ compilation database and the recorded compiler
+  preprocessor to install an active-line source view. `codegraph` then builds
+  the usual Tree-sitter graph from that view.
 
 Enable index construction by adding it to `initialize`. The example below is
 an Initialize fragment; because a project execution section replaces the
@@ -135,20 +145,21 @@ metis_engine:
     stages:
       initialize:
         outputs:
-          - threat_model
-          - index
+          threat_model: threat_model.threat_model
+          codegraph: codegraph.codegraph
+          index: index.index
         nodes:
           threat_model:
             capabilities:
               - memory
+          codegraph: {}
           index:
             capabilities:
               - index
 ```
 
-Initialize lists the nodes whose status values it publishes. Each listed node
-must have one output. A graph that replaces its nodes must list the
-corresponding stage outputs explicitly.
+Initialize explicitly maps the node outputs it publishes. A graph that replaces
+its nodes must list the corresponding stage outputs.
 
 The `capabilities` list is the complete allowlist for a node. Required and
 optional capabilities are declared by the node registration. Omitting an
@@ -167,23 +178,15 @@ Nodes without a row do not declare engine capabilities.
 
 ### Review
 
-The review request supports `code`, `dir`, `file`, and `patch` modes.
-
-`codegraph` groups the selected source files by language manifest, invokes the
-corresponding providers, validates exact file coverage, composes their outputs
-into one `CodeGraph`, and adds deterministic entrypoint, source, and sink
-annotations. File review selects only the requested file; other review modes
-select the project's supported source files.
-It persists fingerprinted canonical graphs at
-`<codebase>/.metis/codegraph.sqlite3` and publishes a typed reference to the
-selected revision. An unchanged source set, language mapping, annotation
-configuration, and Metis version reuse that revision.
+The review request supports `code`, `dir`, `file`, and `patch` modes. When
+configured, Review receives the persisted graph reference from Initialize;
+it does not build or modify the graph.
 
 `simple_llm_review` is the generic review node. It reviews every file in the
 selected scope with the language plugin's prompts and does not require a
 CodeGraph.
 
-`reachability` resolves the declared CodeGraph reference and reviews selected
+`reachability` resolves the initialized CodeGraph reference and reviews selected
 function source with the normal language security-review prompt. The evidence
 includes deterministic function, call, control-flow, assignment, loop, return,
 and direct-callee contract facts. The model must identify every
@@ -193,12 +196,10 @@ source facts; missing, ambiguous, or incomplete evidence remains fail-open.
 
 Same-file functions are batched in source order. Invalid or output-limited
 multi-function batches are split immediately and their children are reviewed
-in the same run. Batch results and split decisions are not persisted. The
-language plugin supplies deterministic CodeGraph semantics during
-materialization.
-Directory review derives an in-memory analysis scope from the persisted project
-graph. File review materializes and persists a graph for the requested file
-only. Neither mode replaces or mutates another fingerprinted graph revision.
+in the same run. Batch results and split decisions are not persisted. Language
+plugins supply deterministic CodeGraph semantics during initialization.
+Directory and file review derive in-memory scopes from the same persisted
+project graph; neither mode rebuilds or mutates it.
 Patch review is supported by `simple_llm_review`. If `reachability` is selected
 for a patch request, it publishes an inconclusive warning rather than silently
 running another node. For code, directory, and file review, Reachability sends
@@ -220,9 +221,8 @@ unchanged.
 Its `formats` list declares
 the representations written for that execution. Every listed format is saved.
 Review publishes canonical `findings` for JSON, HTML, and CSV renderers and
-always publishes `sarif` in memory for downstream stages. It also publishes a
-CodeGraph reference when the selected stage has one compatible CodeGraph
-output.
+always publishes `sarif` in memory for downstream stages. It also republishes
+the initialized CodeGraph reference when one is provided.
 Omitting `sarif` from `formats` prevents a SARIF file from being written; it
 does not remove the in-memory SARIF contract.
 
@@ -321,9 +321,9 @@ materializes a graph itself.
 Normal review-to-triage execution does not deduplicate twice: `triage` receives
 SARIF generated from the `FinalReviewRun` already produced by `finding_dedup`.
 
-The stage bindings `sarif: review.sarif` and `codegraph: review.codegraph`
-transfer those values and make Review a
-data dependency. Do not repeat that relationship in `depends_on`.
+The bindings `sarif: review.sarif` and `codegraph: initialize.codegraph`
+transfer those values and make both earlier stages data dependencies. Do not
+repeat those relationships in `depends_on`.
 
 Triage has its own `result` node because its SARIF represents a later state.
 
@@ -558,9 +558,15 @@ and execution inputs in the complete graph:
 metis_engine:
   execution:
     stages:
-      review:
+      initialize:
+        outputs:
+          codegraph: codegraph.codegraph
         nodes:
           codegraph: {}
+      review:
+        inputs:
+          codegraph: initialize.codegraph
+        nodes:
           reachability: {}
           new_analysis: {}
           finding_dedup: {}
@@ -697,8 +703,9 @@ A handler receives validated inputs and a small context containing its granted
 capabilities together with the repository lookup contract, CodeGraph
 materialize/load API, model runner, runtime limits, shared job scheduler, and
 callbacks. Dependency-ready nodes run concurrently. For example,
-`codegraph` and `simple_llm_review` start together, then `reachability` starts
-as soon as `codegraph` completes while `simple_llm_review` may continue.
+`threat_model` and `codegraph` run together in Initialize. After its barrier,
+`simple_llm_review` and `reachability` may run together over the initialized
+graph.
 `max_concurrency` limits that node's active jobs; omitted values use the global
 `metis_engine.max_workers` limit. All nodes on one engine share that job pool,
 so their combined active jobs never exceed the global limit and newly active

--- a/src/metis/engine/codegraph/provider.py
+++ b/src/metis/engine/codegraph/provider.py
@@ -60,6 +60,7 @@ class CodeGraphProvider(Protocol):
 class CodeGraphProviderContext:
     get_language_name_for_path: Callable[[str], str | None]
     has_language_file_role: Callable[[str, str], bool]
+    source_for_path: Callable[[str], bytes | None] | None = None
 
 
 CodeGraphProviderFactory = Callable[

--- a/src/metis/engine/execution/contracts.py
+++ b/src/metis/engine/execution/contracts.py
@@ -42,6 +42,9 @@ def annotation_allows_none(annotation: Any) -> bool:
 
 
 class NodeRepository(Protocol):
+    @property
+    def profiled_source_fingerprint(self) -> str | None: ...
+
     def get_code_files(
         self,
         *,
@@ -50,6 +53,8 @@ class NodeRepository(Protocol):
     ) -> list[str]: ...
 
     def get_language_name_for_path(self, path: str) -> str | None: ...
+
+    def source_profile_applies_to_path(self, path: str) -> bool: ...
 
 
 class NodePromptRunner(Protocol):
@@ -60,7 +65,6 @@ class NodeCodeGraphs(Protocol):
     def materialize(
         self,
         *,
-        seed_file: str | None = None,
         progress_callback: Callable[[dict[str, object]], None] | None = None,
         diagnostic_callback: Callable[[CodeGraphDiagnostic], None] | None = None,
     ) -> CodeGraphReference: ...

--- a/src/metis/engine/nodes/builtins.py
+++ b/src/metis/engine/nodes/builtins.py
@@ -18,6 +18,7 @@ from ..stages.service import ExecutionGraphService
 from ..stages.triage.service import TriageService
 from .codegraph import CodeGraphService
 from .codegraph import registration as codegraph_node
+from .compilation_profile import registration as compilation_profile_node
 from .finding_dedup import registration as finding_dedup_node
 from .index import registration as index_node
 from .reachability import review as reachability_node
@@ -71,6 +72,8 @@ def build_builtin_execution(
 
     if ("initialize", "threat_model") in selected_nodes:
         registrations.append(threat_model_node.create_node(engine_config, repository))
+    if ("initialize", "compilation_profile") in selected_nodes:
+        registrations.append(compilation_profile_node.create_node(repository))
 
     simple_llm_review = None
     simple_review_selected = ("review", "simple_llm_review") in selected_nodes
@@ -94,7 +97,6 @@ def build_builtin_execution(
             repository=repository,
             llm_provider=engine_config.llm_provider,
             usage_runtime=engine_config.usage_runtime,
-            codegraphs=codegraphs,
         )
         if reachability_selected
         else None
@@ -107,6 +109,9 @@ def build_builtin_execution(
             reachability,
             None if simple_review_selected else simple_llm_review,
             reachability_settings,
+            supports_file=lambda path: (
+                codegraphs.supports_file(path) and codegraphs.supports_semantics(path)
+            ),
         )
         registrations.append(reachability_node.create_node(reachability_review))
 

--- a/src/metis/engine/nodes/codegraph/registration.py
+++ b/src/metis/engine/nodes/codegraph/registration.py
@@ -10,23 +10,37 @@ from metis.engine.execution.contracts import EmptyNodeConfiguration
 from metis.engine.execution.contracts import NodeInvocation
 from metis.engine.execution.contracts import NodeRegistration
 from metis.engine.execution.contracts import NodeResult
-from metis.engine.stages.review.models import ReviewCommand
+from metis.engine.source import ProfiledSourceReference
 
 
 def execute(invocation: NodeInvocation) -> NodeResult:
-    command = cast(ReviewCommand, invocation.inputs["request"])
+    profiled = cast(
+        ProfiledSourceReference | None, invocation.inputs.get("profiled_source")
+    )
+    if (
+        profiled is not None
+        and profiled.fingerprint
+        != invocation.context.repository.profiled_source_fingerprint
+    ):
+        raise RuntimeError(
+            "CodeGraph source profile does not match the installed profile"
+        )
     reference = invocation.context.codegraphs.materialize(
-        seed_file=command.target if command.mode == "file" else None,
         progress_callback=invocation.context.report_progress,
     )
+    if profiled is not None and any(
+        invocation.context.repository.source_profile_applies_to_path(path)
+        for path in reference.failed_files
+    ):
+        raise RuntimeError("Profiled CodeGraph contains failed files")
     return NodeResult({"codegraph": reference})
 
 
 registration = NodeRegistration(
     name="codegraph",
-    stage="review",
+    stage="initialize",
     configuration=EmptyNodeConfiguration,
-    inputs={"request": ReviewCommand},
+    inputs={"profiled_source": ProfiledSourceReference | None},
     outputs={"codegraph": CodeGraphReference},
     execute=execute,
 )

--- a/src/metis/engine/nodes/codegraph/service.py
+++ b/src/metis/engine/nodes/codegraph/service.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from metis.engine.repository import EngineRepository
     from metis.engine.runtime import EngineConfig
 
-CODEGRAPH_FINGERPRINT_VERSION = 1
+CODEGRAPH_FINGERPRINT_VERSION = 2
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,7 @@ class CodeGraphService:
         self._provider_context = CodeGraphProviderContext(
             get_language_name_for_path=repository.get_language_name_for_path,
             has_language_file_role=repository.has_language_file_role,
+            source_for_path=repository.analysis_source_for_path,
         )
         self._provider_factories = {
             normalize_provider_name(name): factory
@@ -71,17 +72,14 @@ class CodeGraphService:
         self._materialize_active = False
         self._materialize_generation = 0
         self._last_materialization: CodeGraphReference | None = None
-        self._last_materialization_key: str | None = None
         self._lock = threading.RLock()
 
     def materialize(
         self,
         *,
-        seed_file: str | None = None,
         progress_callback: Callable[[dict[str, object]], None] | None = None,
         diagnostic_callback: Callable[[CodeGraphDiagnostic], None] | None = None,
     ) -> CodeGraphReference:
-        materialization_key = seed_file
         with self._materialize_condition:
             while self._materialize_active:
                 generation = self._materialize_generation
@@ -89,33 +87,27 @@ class CodeGraphService:
                     lambda: self._materialize_generation > generation
                 )
                 completed = self._last_materialization
-                if (
-                    completed is not None
-                    and self._last_materialization_key == materialization_key
-                ):
+                if completed is not None:
                     _replay_diagnostics(completed, diagnostic_callback)
                     return completed
             self._materialize_active = True
         try:
             completed = self._materialize(
-                seed_file=seed_file,
                 progress_callback=progress_callback,
                 diagnostic_callback=diagnostic_callback,
             )
         except Exception:
-            self._finish_materialization(None, materialization_key)
+            self._finish_materialization(None)
             raise
-        self._finish_materialization(completed, materialization_key)
+        self._finish_materialization(completed)
         return completed
 
     def _finish_materialization(
         self,
         reference: CodeGraphReference | None,
-        materialization_key: str | None,
     ) -> None:
         with self._materialize_condition:
             self._last_materialization = reference
-            self._last_materialization_key = materialization_key
             self._materialize_generation += 1
             self._materialize_active = False
             self._materialize_condition.notify_all()
@@ -123,13 +115,12 @@ class CodeGraphService:
     def _materialize(
         self,
         *,
-        seed_file: str | None,
         progress_callback: Callable[[dict[str, object]], None] | None,
         diagnostic_callback: Callable[[CodeGraphDiagnostic], None] | None,
     ) -> CodeGraphReference:
         store = self._store_instance()
         while True:
-            selected_files = self._selected_files(seed_file=seed_file)
+            selected_files = self._selected_files()
             fingerprint = self._fingerprint(selected_files)
             reference = store.reference_for_fingerprint(
                 fingerprint,
@@ -158,7 +149,7 @@ class CodeGraphService:
             for diagnostic in semantics_diagnostics:
                 if diagnostic_callback is not None:
                     diagnostic_callback(diagnostic)
-            current_files = self._selected_files(seed_file=seed_file)
+            current_files = self._selected_files()
             if (
                 current_files != selected_files
                 or self._fingerprint(current_files) != fingerprint
@@ -178,32 +169,10 @@ class CodeGraphService:
                 ),
             )
 
-    def _selected_files(
-        self,
-        *,
-        seed_file: str | None,
-    ) -> tuple[str, ...]:
-        if seed_file is None:
-            candidates = self._repository.get_code_files(include_suffixed_sources=True)
-        else:
-            relative_seed = os.path.normpath(
-                os.path.relpath(seed_file, self._config.codebase_path)
-                if os.path.isabs(seed_file)
-                else seed_file
-            )
-            candidates = (
-                (os.path.join(self._config.codebase_path, relative_seed),)
-                if self._repository.is_code_file_selected(
-                    relative_seed, include_suffixed_sources=True
-                )
-                else ()
-            )
+    def _selected_files(self) -> tuple[str, ...]:
+        candidates = self._repository.get_code_files(include_suffixed_sources=True)
         return tuple(
-            sorted(
-                dict.fromkeys(
-                    str(path) for path in candidates if self.supports_file(str(path))
-                )
-            )
+            sorted({str(path) for path in candidates if self.supports_file(str(path))})
         )
 
     def load(self, reference: CodeGraphReference) -> CodeGraph:
@@ -329,13 +298,12 @@ class CodeGraphService:
                     "errors": [diagnostic.message for diagnostic in diagnostics],
                 }
             )
-        built = CodeGraphResult(
+        return CodeGraphResult(
             graph=graph,
             processed_files=processed_file_tuple,
             diagnostics=tuple(diagnostics),
             failed_files=tuple(failed_files),
         )
-        return built
 
     def supports_file(self, path: str) -> bool:
         provider_name = self._registration_name(path)
@@ -358,7 +326,13 @@ class CodeGraphService:
                 else os.path.join(self._config.codebase_path, path)
             )
             identity = os.path.normcase(os.path.abspath(absolute))
-            content_identity = _file_identity(identity)
+            # The profile fingerprints its source views and verifies the snapshot.
+            # Files outside that profile must not invalidate an unchanged graph.
+            content_identity = (
+                {"profiled": True}
+                if self._repository.analysis_source_for_path(identity) is not None
+                else _file_identity(identity)
+            )
             provider_name = self._registration_name(path)
             semantics_name = self._semantics_registration_name(path)
             entries.append(
@@ -379,6 +353,9 @@ class CodeGraphService:
             "producer_version": METIS_VERSION,
             "fingerprint_version": CODEGRAPH_FINGERPRINT_VERSION,
         }
+        profile = self._repository.profiled_source_fingerprint
+        if profile is not None:
+            payload["profiled_source"] = profile
         encoded = json.dumps(
             payload,
             sort_keys=True,

--- a/src/metis/engine/nodes/compilation_profile/__init__.py
+++ b/src/metis/engine/nodes/compilation_profile/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compilation-database source profiling initialization."""

--- a/src/metis/engine/nodes/compilation_profile/database.py
+++ b/src/metis/engine/nodes/compilation_profile/database.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read compile_commands.json and normalize its recorded compiler commands."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class CompilationUnit:
+    profile_id: str
+    directory: Path
+    source: Path
+    argv: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CompilationDatabase:
+    path: Path
+    sha256: str
+    units: tuple[CompilationUnit, ...]
+
+
+def load_compilation_database(
+    *,
+    codebase_path: str,
+    compile_commands_path: str,
+    include_source: Callable[[str], bool] | None = None,
+) -> CompilationDatabase:
+    root = Path(codebase_path).expanduser().resolve()
+    path = Path(compile_commands_path).expanduser()
+    path = (path if path.is_absolute() else root / path).resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"Compilation database does not exist: {path}")
+    payload = path.read_bytes()
+    return CompilationDatabase(
+        path,
+        hashlib.sha256(payload).hexdigest(),
+        _load_units(path, payload, include_source),
+    )
+
+
+def _load_units(
+    database: Path,
+    payload: bytes,
+    include_source: Callable[[str], bool] | None,
+) -> tuple[CompilationUnit, ...]:
+    try:
+        raw = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Invalid compilation database {database}: {exc}") from exc
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("Compilation database must contain a non-empty JSON array")
+    units = (
+        _load_unit(
+            item,
+            index=index,
+            database=database,
+            include_source=include_source,
+        )
+        for index, item in enumerate(raw)
+    )
+    return tuple(
+        sorted(
+            (unit for unit in units if unit is not None),
+            key=lambda unit: unit.profile_id,
+        )
+    )
+
+
+def _load_unit(
+    raw: object,
+    *,
+    index: int,
+    database: Path,
+    include_source: Callable[[str], bool] | None,
+) -> CompilationUnit | None:
+    if not isinstance(raw, dict):
+        raise TypeError(f"Compilation database entry {index} must be an object")
+    directory_value = raw.get("directory")
+    file_value = raw.get("file")
+    if not isinstance(file_value, str) or not file_value.strip():
+        raise ValueError(f"Compilation database entry {index} has no file")
+    if include_source is not None and not include_source(file_value):
+        return None
+    if not isinstance(directory_value, str) or not directory_value.strip():
+        raise ValueError(f"Compilation database entry {index} has no directory")
+
+    directory = Path(directory_value).expanduser()
+    directory = (
+        directory if directory.is_absolute() else database.parent / directory
+    ).resolve()
+    if not directory.is_dir():
+        raise FileNotFoundError(
+            f"Compilation database entry {index} directory does not exist: {directory}"
+        )
+    source = Path(file_value).expanduser()
+    source = (source if source.is_absolute() else directory / source).resolve()
+    if not source.is_file():
+        raise FileNotFoundError(
+            f"Compilation database entry {index} source does not exist: {source}"
+        )
+
+    arguments = raw.get("arguments")
+    command = raw.get("command")
+    if (
+        isinstance(arguments, list)
+        and arguments
+        and all(isinstance(argument, str) for argument in arguments)
+    ):
+        argv = tuple(arguments)
+    elif isinstance(command, str) and command.strip():
+        try:
+            argv = tuple(shlex.split(command, posix=os.name != "nt"))
+        except ValueError as exc:
+            raise ValueError(
+                f"Compilation database entry {index} has an invalid command"
+            ) from exc
+    else:
+        raise ValueError(
+            f"Compilation database entry {index} requires arguments or command"
+        )
+    executable = _resolve_executable(argv[0], directory)
+    argv = (executable, *argv[1:])
+    profile_payload = json.dumps(
+        {"directory": str(directory), "file": str(source), "argv": argv},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return CompilationUnit(
+        hashlib.sha256(profile_payload).hexdigest(),
+        directory,
+        source,
+        argv,
+    )
+
+
+def _resolve_executable(value: str, directory: Path) -> str:
+    candidate = Path(value).expanduser()
+    if candidate.is_absolute() or candidate.parent != Path("."):
+        candidate = candidate if candidate.is_absolute() else directory / candidate
+        candidate = candidate.resolve()
+        if not candidate.is_file() or not os.access(candidate, os.X_OK):
+            raise FileNotFoundError(f"Compiler is not executable: {candidate}")
+        return str(candidate)
+    resolved = shutil.which(value)
+    if resolved is None:
+        raise FileNotFoundError(f"Compiler is not available on PATH: {value}")
+    return resolved

--- a/src/metis/engine/nodes/compilation_profile/registration.py
+++ b/src/metis/engine/nodes/compilation_profile/registration.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import cast
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+from metis import runlog
+from metis.engine.execution.contracts import NodeInvocation
+from metis.engine.execution.contracts import NodeRegistration
+from metis.engine.execution.contracts import NodeResult
+from metis.engine.repository import EngineRepository
+from metis.engine.source import ProfiledSourceReference
+
+from .database import load_compilation_database
+from .service import build_profiled_source
+
+
+class CompilationProfileConfiguration(BaseModel):
+    compile_commands_path: str = Field(min_length=1)
+    timeout_seconds: int = Field(default=60, ge=1)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def create_node(repository: EngineRepository) -> NodeRegistration:
+    def execute(invocation: NodeInvocation) -> NodeResult:
+        configuration = cast(CompilationProfileConfiguration, invocation.configuration)
+        database = load_compilation_database(
+            codebase_path=invocation.context.codebase_path,
+            compile_commands_path=configuration.compile_commands_path,
+            include_source=lambda path: (
+                repository.get_language_name_for_path(path) in {"c", "cpp"}
+            ),
+        )
+        if not database.units:
+            raise ValueError("Compilation database contains no C/C++ units")
+        artifact = build_profiled_source(
+            codebase_path=invocation.context.codebase_path,
+            database=database,
+            timeout_seconds=configuration.timeout_seconds,
+            jobs=invocation.context.jobs,
+            progress_callback=invocation.context.report_progress,
+        )
+        repository.install_profiled_source(artifact)
+        runlog.event(
+            "artifact",
+            {
+                "kind": "profiled_source_snapshot",
+                "payload": artifact.reference,
+            },
+        )
+        return NodeResult({"profiled_source": artifact.reference})
+
+    return NodeRegistration(
+        name="compilation_profile",
+        stage="initialize",
+        configuration=CompilationProfileConfiguration,
+        inputs={},
+        outputs={"profiled_source": ProfiledSourceReference},
+        execute=execute,
+    )

--- a/src/metis/engine/nodes/compilation_profile/service.py
+++ b/src/metis/engine/nodes/compilation_profile/service.py
@@ -1,0 +1,470 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import os
+import re
+import subprocess
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from metis.engine.source import ProfiledSourceArtifact
+from metis.engine.source import ProfiledSourceReference
+from metis.plugins.c_family.runtime import _mask_c_comments_and_literals
+
+from .database import CompilationDatabase
+from .database import CompilationUnit
+
+_LINE_MARKER = re.compile(rb'^\s*#\s+(\d+)\s+"((?:\\.|[^"\\])*)"((?:\s+\d+)*)\s*$')
+_SOURCE_LINE_DIRECTIVE = re.compile(
+    rb"(?m)^[\t\v\f ]*(?:#|%:|\?\?=)[\t\v\f ]*"
+    rb"(?:line\b|[0-9]+(?:[\t\v\f ]|$))"
+)
+_BLANK_LINE = bytes(13 if value == 13 else 32 for value in range(256))
+_DROP_FLAGS = frozenset(
+    {
+        "-c",
+        "-S",
+        "-E",
+        "-M",
+        "-MM",
+        "-MD",
+        "-MMD",
+        "-MG",
+        "-MP",
+        "-P",
+        "--dependencies",
+        "--user-dependencies",
+        "--write-dependencies",
+        "--write-user-dependencies",
+        "--print-missing-file-dependencies",
+        "--no-line-commands",
+        "-dD",
+        "-dI",
+        "-dM",
+        "-dN",
+        "-fdirectives-only",
+        "-fsyntax-only",
+        "-frewrite-includes",
+        "-save-stats",
+        "-save-temps",
+        "--save-temps",
+    }
+)
+_DROP_WITH_VALUE = frozenset(
+    {
+        "-o",
+        "--output",
+        "-MF",
+        "-MT",
+        "-MQ",
+        "-MJ",
+        "-dependency-file",
+        "-serialize-diagnostics",
+        "--serialize-diagnostics",
+        "--dump",
+    }
+)
+_DROP_ATTACHED = (
+    "-o",
+    "-MF",
+    "-MT",
+    "-MQ",
+    "-MJ",
+    "--output=",
+    "-dependency-file=",
+    "-serialize-diagnostics=",
+    "--serialize-diagnostics=",
+    "-save-stats=",
+    "-fdeps-file=",
+    "-fdeps-format=",
+    "-fdeps-target=",
+    "--dump=",
+)
+_KEEP_WITH_VALUE = frozenset(
+    {
+        "-D",
+        "-U",
+        "-A",
+        "-I",
+        "-F",
+        "-B",
+        "-x",
+        "-include",
+        "-imacros",
+        "-iquote",
+        "-isystem",
+        "-idirafter",
+        "-iprefix",
+        "-iwithprefix",
+        "-iwithprefixbefore",
+        "-isysroot",
+        "-imultilib",
+        "-imultiarch",
+        "-iframework",
+        "-iframeworkwithsysroot",
+        "-target",
+        "--target",
+        "-arch",
+        "--sysroot",
+        "-resource-dir",
+        "--gcc-toolchain",
+        "-Xassembler",
+        "-Xlinker",
+        "--define-macro",
+        "--undefine-macro",
+        "--include",
+        "--imacros",
+        "--include-directory",
+        "--include-directory-after",
+        "--include-prefix",
+        "--include-with-prefix",
+        "--include-with-prefix-after",
+        "--include-with-prefix-before",
+    }
+)
+_UNSUPPORTED_PREFIXES = (
+    "-fpch-preprocess",
+    "-save-temps=",
+    "--save-temps=",
+    "-ftime-trace",
+    "-fmodule-output",
+    "-fmodules",
+    "-fplugin",
+    "-plugin",
+    "-Xclang",
+    "-Xpreprocessor",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ProfiledUnit:
+    profile_id: str
+    seen_files: frozenset[str]
+    active_lines: Mapping[str, frozenset[int]]
+    directive_sources: frozenset[Path]
+
+
+def build_profiled_source(
+    *,
+    codebase_path: str,
+    database: CompilationDatabase,
+    timeout_seconds: int,
+    jobs,
+    progress_callback=None,
+) -> ProfiledSourceArtifact:
+    root = Path(codebase_path).expanduser().resolve()
+    _validate_source_paths({unit.source for unit in database.units}, root)
+
+    def preprocess(entry: CompilationUnit) -> _ProfiledUnit:
+        return _preprocess(entry, root=root, timeout_seconds=timeout_seconds)
+
+    units = jobs.run(
+        database.units,
+        preprocess,
+        label=None,
+        result_key=lambda entry: entry.profile_id,
+        on_complete=(
+            (
+                lambda entry, completed, total: progress_callback(
+                    {
+                        "event": "compilation_profile_progress",
+                        "completed": completed,
+                        "total": total,
+                        "file": _display_path(entry.source, root),
+                    }
+                )
+            )
+            if progress_callback is not None
+            else None
+        ),
+    )
+    views: dict[str, dict[str, frozenset[int]]] = defaultdict(dict)
+    _validate_source_paths(
+        {path for unit in units for path in unit.directive_sources},
+        root,
+    )
+    raw_by_file = _read_sources(
+        root,
+        {path for unit in units for path in unit.seen_files},
+    )
+    for unit in units:
+        for path in unit.seen_files:
+            views[path][unit.profile_id] = unit.active_lines.get(path, frozenset())
+
+    sources: dict[str, bytes] = {}
+    active_line_count = 0
+    for path, profiles in sorted(views.items()):
+        source = raw_by_file[path]
+        distinct = {
+            frozenset(_include_line_continuations(source, active))
+            for active in set(profiles.values())
+        }
+        if len(distinct) != 1:
+            continue
+        active = set(next(iter(distinct)))
+        sources[path] = _mask_inactive_lines(source, active)
+        active_line_count += len(active)
+    if not views:
+        raise ValueError(
+            "Compilation database preprocessing produced no source under the codebase"
+        )
+    reference = ProfiledSourceReference(
+        fingerprint=_fingerprint(raw_by_file, sources),
+        compile_commands_path=_display_path(database.path, root),
+        compile_commands_sha256=database.sha256,
+        translation_units=len(database.units),
+        source_views=sum(len(profile) for profile in views.values()),
+        profiled_files=len(sources),
+        ambiguous_files=len(views) - len(sources),
+        active_line_count=active_line_count,
+        compiler_names=tuple(
+            sorted({Path(unit.argv[0]).name for unit in database.units})
+        ),
+    )
+    return ProfiledSourceArtifact(
+        reference=reference,
+        languages=frozenset({"c", "cpp"}),
+        raw_sources=raw_by_file,
+        canonical_sources=sources,
+    )
+
+
+def _sanitized_argv(unit: CompilationUnit) -> tuple[str, ...]:
+    filtered = [unit.argv[0]]
+    source_present = False
+    arguments = iter(unit.argv[1:])
+    for argument in arguments:
+        if argument in _KEEP_WITH_VALUE or argument in _DROP_WITH_VALUE:
+            value = next(arguments, None)
+            if value is None:
+                raise ValueError(f"Compiler option {argument!r} requires a value")
+            if value.startswith("@"):
+                raise ValueError(
+                    f"Compilation unit uses unsupported argument {value!r}"
+                )
+            if argument in _KEEP_WITH_VALUE:
+                filtered.extend((argument, value))
+            continue
+        if (
+            argument == "--"
+            or argument.startswith("@")
+            or argument.startswith(_UNSUPPORTED_PREFIXES)
+        ):
+            raise ValueError(f"Compilation unit uses unsupported argument {argument!r}")
+        if argument.startswith("-Wp,"):
+            parts = argument.split(",")
+            if len(parts) == 3 and parts[1] in {"-MD", "-MMD"} and parts[2]:
+                continue
+            raise ValueError(
+                f"Compilation unit uses unsupported argument group {argument!r}; "
+                "use separate compiler flags for macros, includes, and dependencies"
+            )
+        if argument in _DROP_FLAGS or argument.startswith(_DROP_ATTACHED):
+            continue
+        filtered.append(argument)
+        if not argument.startswith("-"):
+            candidate = Path(argument)
+            candidate = (
+                candidate if candidate.is_absolute() else unit.directory / candidate
+            )
+            try:
+                source_present = source_present or candidate.resolve() == unit.source
+            except OSError:
+                pass
+    if not source_present:
+        filtered.append(str(unit.source))
+    return tuple(filtered)
+
+
+def _preprocess(
+    unit: CompilationUnit,
+    *,
+    root: Path,
+    timeout_seconds: int,
+) -> _ProfiledUnit:
+    argv = (*_sanitized_argv(unit), "-E", "-fdirectives-only", "-o", "-")
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=unit.directory,
+            check=False,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(
+            f"Preprocessing failed for {_display_path(unit.source, root)}: "
+            f"{type(exc).__name__}"
+        ) from exc
+    if completed.returncode:
+        detail = completed.stderr[:4096].decode("utf-8", errors="replace").strip()
+        if len(completed.stderr) > 4096:
+            detail += "\n[compiler diagnostics truncated]"
+        raise RuntimeError(
+            f"Preprocessing failed for {_display_path(unit.source, root)} "
+            f"with exit code {completed.returncode}"
+            + (f":\n{detail}" if detail else "")
+        )
+    seen, lines, directive_sources = _mapped_lines(
+        completed.stdout,
+        directory=unit.directory,
+        root=root,
+        source=unit.source,
+    )
+    if not seen:
+        raise RuntimeError(
+            f"Preprocessing produced no source markers for "
+            f"{_display_path(unit.source, root)}"
+        )
+    return _ProfiledUnit(
+        unit.profile_id,
+        frozenset(seen),
+        {path: frozenset(active) for path, active in lines.items()},
+        frozenset(directive_sources),
+    )
+
+
+def _mapped_lines(
+    output: bytes,
+    *,
+    directory: Path,
+    root: Path,
+    source: Path,
+) -> tuple[set[str], dict[str, set[int]], set[Path]]:
+    seen: set[str] = set()
+    mapped: dict[str, set[int]] = defaultdict(set)
+    directive_sources: set[Path] = set()
+    current_path: str | None = None
+    current_line = 0
+    physical_path: Path | None = source.resolve()
+    for line in output.splitlines():
+        marker = _LINE_MARKER.match(line)
+        if marker is not None:
+            current_line = int(marker.group(1))
+            flags = {int(value) for value in marker.group(3).split()}
+            marker_file, marker_path = _marker_paths(
+                marker.group(2), directory=directory, root=root
+            )
+            if physical_path is not None and marker_file != physical_path:
+                directive_sources.add(physical_path)
+            if flags & {1, 2} and marker_file is not None:
+                physical_path = marker_file
+            current_path = marker_path
+            if current_path is not None:
+                seen.add(current_path)
+            continue
+        if current_path is not None and line.strip():
+            mapped[current_path].add(current_line)
+        current_line += 1
+    return seen, mapped, directive_sources
+
+
+def _marker_paths(
+    raw: bytes,
+    *,
+    directory: Path,
+    root: Path,
+) -> tuple[Path | None, str | None]:
+    try:
+        literal = "".join(
+            chr(value) if value < 128 else f"\\x{value:02x}" for value in raw
+        )
+        decoded = ast.literal_eval(f'b"{literal}"')
+        value = os.fsdecode(decoded)
+    except (SyntaxError, ValueError):
+        return None, None
+    if value.startswith("<") or value.endswith("//"):
+        return None, None
+    candidate = Path(value)
+    candidate = candidate if candidate.is_absolute() else directory / candidate
+    try:
+        resolved = candidate.resolve()
+    except OSError:
+        return None, None
+    try:
+        relative = resolved.relative_to(root).as_posix()
+    except ValueError:
+        relative = None
+    return resolved, relative
+
+
+def _read_sources(root: Path, paths: set[str]) -> dict[str, bytes]:
+    try:
+        sources = {path: (root / path).read_bytes() for path in paths}
+    except OSError as exc:
+        raise RuntimeError("Unable to snapshot profiled source") from exc
+    _validate_sources(sources)
+    return sources
+
+
+def _validate_source_paths(paths: set[Path], root: Path) -> None:
+    try:
+        sources = {_display_path(path, root): path.read_bytes() for path in paths}
+    except OSError as exc:
+        raise RuntimeError("Unable to verify included source") from exc
+    _validate_sources(sources)
+
+
+def _validate_sources(sources: Mapping[str, bytes]) -> None:
+    for path, source in sources.items():
+        if b"\r" in source.replace(b"\r\n", b""):
+            raise RuntimeError(
+                f"Compilation profiles require LF or CRLF line endings: {path}"
+            )
+        logical = re.sub(rb"\\\r?\n", b"", source.replace(b"??/", b"\\"))
+        if _SOURCE_LINE_DIRECTIVE.search(_mask_c_comments_and_literals(logical)):
+            raise RuntimeError(
+                f"Compilation profiles do not support source #line directives: {path}"
+            )
+
+
+def _mask_inactive_lines(source: bytes, active_lines: set[int]) -> bytes:
+    return b"\n".join(
+        line if line_number in active_lines else line.translate(_BLANK_LINE)
+        for line_number, line in enumerate(source.split(b"\n"), 1)
+    )
+
+
+def _include_line_continuations(
+    source: bytes, active: Mapping | set | frozenset
+) -> set[int]:
+    lines = source.splitlines()
+    expanded = set(active)
+    for line_number in active:
+        current = line_number
+        while 1 <= current <= len(lines) and lines[current - 1].rstrip(
+            b" \t\r"
+        ).endswith(b"\\"):
+            current += 1
+            if current <= len(lines):
+                expanded.add(current)
+    return expanded
+
+
+def _fingerprint(
+    raw_sources: Mapping[str, bytes],
+    sources: Mapping[str, bytes],
+) -> str:
+    digest = hashlib.sha256(b"metis-compilation-profile-v2\0")
+    for path in sorted(raw_sources):
+        for value in (
+            os.fsencode(path),
+            raw_sources[path],
+            b"\1" + sources[path] if path in sources else b"\0",
+        ):
+            digest.update(len(value).to_bytes(8, "big"))
+            digest.update(value)
+    return digest.hexdigest()
+
+
+def _display_path(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except (OSError, ValueError):
+        return str(path)

--- a/src/metis/engine/nodes/reachability/incremental_review.py
+++ b/src/metis/engine/nodes/reachability/incremental_review.py
@@ -516,6 +516,7 @@ class IncrementalGraphReviewer:
                             group_nodes,
                             max_tokens=source_token_budget,
                             token_counter=token_counter,
+                            source_for_path=self._repository.analysis_source_for_path,
                         )
                     except ValueError as exc:
                         overflow_error = exc
@@ -714,6 +715,7 @@ class IncrementalGraphReviewer:
             codebase_path=self._config.codebase_path,
             file_path=file_path,
             source_text=source_text,
+            source_for_path=self._repository.analysis_source_for_path,
         )
         return "\n".join(
             (
@@ -815,7 +817,16 @@ class IncrementalGraphReviewer:
         packet: _FrontierPacket,
         item: dict[str, Any],
     ) -> tuple[FunctionNode, Any] | None:
-        source_map = SourceMap.for_file(self._config.codebase_path, packet.file_path)
+        source_view = self._repository.source_view_for_path(packet.file_path)
+        source_map = (
+            SourceMap.for_bytes(
+                packet.file_path,
+                source_view.canonical,
+                anchor_source=source_view.raw,
+            )
+            if source_view is not None
+            else SourceMap.for_file(self._config.codebase_path, packet.file_path)
+        )
         if source_map is None or not packet.shown_lines:
             return None
         hint = range(min(packet.shown_lines), max(packet.shown_lines) + 1)
@@ -827,8 +838,17 @@ class IncrementalGraphReviewer:
             context_text=f"{item.get('issue') or ''} {item.get('reasoning') or ''}",
         )
         shown_span = range(anchor.start_line, anchor.end_line + 1)
-        if anchor.start_line <= 0 or any(
-            line not in packet.shown_lines for line in shown_span
+        if (
+            anchor.start_line <= 0
+            or not {
+                anchor.start_line,
+                anchor.end_line,
+            }
+            <= packet.shown_lines
+            or any(
+                line not in packet.shown_lines and source_map.lines[line - 1].strip()
+                for line in shown_span
+            )
         ):
             return None
         matching_nodes = [

--- a/src/metis/engine/nodes/reachability/prompt_evidence.py
+++ b/src/metis/engine/nodes/reachability/prompt_evidence.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import re
 from collections import Counter
+from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -25,8 +26,10 @@ from metis.engine.codegraph import NullFact
 from metis.engine.codegraph import ReturnSite
 from metis.engine.codegraph import ValueAssignment
 from metis.engine.source import SourceMap
+from metis.utils import source_lines
 
 from .graph_utils import _node_sort_key
+from .source_context import _source_map
 from .state import FunctionContract
 from .state import GuardedTransfer
 from .state import ParameterSubject
@@ -34,7 +37,7 @@ from .state import ReturnSubject
 from .state import SecuritySubject
 from .state import TrackedObjectSubject
 
-_NUMBERED_LINE = re.compile(r"^\s*(\d+):", re.MULTILINE)
+_NUMBERED_LINE = re.compile(r"^[ \t]*(\d+):[^\S\n]*\S", re.MULTILINE)
 _EXPRESSION_MARKERS = frozenset(
     {"text", "span", "ids", "fields", "direct_id", "direct_field", "cols"}
 )
@@ -322,12 +325,13 @@ def _compact_source_evidence(
     codebase_path: str,
     file_path: str,
     source_text: str,
+    source_for_path: Callable[[str], bytes | None] | None = None,
 ) -> object:
-    source_map = SourceMap.for_file(codebase_path, file_path)
+    source_map = _source_map(codebase_path, file_path, source_for_path)
     if source_map is None:
         return value
     complete_line_numbers: set[int] = set()
-    for rendered_line in source_text.splitlines():
+    for rendered_line in source_lines(source_text):
         match = re.fullmatch(r"\s*(\d+): (.*)", rendered_line)
         if match is None:
             continue

--- a/src/metis/engine/nodes/reachability/review.py
+++ b/src/metis/engine/nodes/reachability/review.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 from typing import cast
 
+from metis.engine.codegraph import CodeGraph
 from metis.engine.codegraph import CodeGraphDiagnostic
 from metis.engine.codegraph import CodeGraphReference
 from metis.engine.execution.contracts import CapabilityRequirement
@@ -98,12 +100,15 @@ class ReachabilityReviewService:
         reachability_service,
         simple_llm_review: SimpleLlmReviewService | None,
         settings: dict[str, object] | None = None,
+        *,
+        supports_file: Callable[[str], bool],
     ) -> None:
         self._config = config
         self._repository = repository
         self._service = reachability_service
         self._simple_llm_review = simple_llm_review
         self._settings = dict(settings or {})
+        self._supports_file = supports_file
 
     def run_review(
         self,
@@ -139,6 +144,10 @@ class ReachabilityReviewService:
         selected_match_paths = {
             self._repository.normalize_match_path(path) for path in files
         }
+        graph_files = {
+            self._repository.normalize_match_path(node.file_path)
+            for node in codegraph.nodes.values()
+        }
         supported_files: list[str] = []
         fallback_files: list[str] = []
         outside_codebase: list[str] = []
@@ -150,9 +159,12 @@ class ReachabilityReviewService:
                 outside_codebase.append(path)
             else:
                 resolved_path = str(resolved)
-                if self._repository.normalize_match_path(
-                    resolved_path
-                ) not in unavailable and self.supports_file(resolved_path):
+                normalized = self._repository.normalize_match_path(resolved_path)
+                if (
+                    normalized not in unavailable
+                    and normalized in graph_files
+                    and self._supports_file(resolved_path)
+                ):
                     supported_files.append(resolved_path)
                 else:
                     fallback_files.append(resolved_path)
@@ -263,7 +275,6 @@ class ReachabilityReviewService:
                     settings=settings,
                     jobs=jobs,
                     progress_callback=progress_callback,
-                    diagnostic_callback=provider_diagnostics.append,
                     codegraph=codegraph,
                     memory_service=memory_service,
                     checkpoint_session=checkpoint_session,
@@ -311,9 +322,6 @@ class ReachabilityReviewService:
         status = ReviewStatus.INCONCLUSIVE if diagnostics else ReviewStatus.SUCCEEDED
         return ReviewRun(status, result, tuple(diagnostics))
 
-    def supports_file(self, file_path):
-        return self._service.supports_file(str(file_path))
-
     def review_options(
         self,
         *,
@@ -335,8 +343,7 @@ class ReachabilityReviewService:
         files=None,
         settings=None,
         progress_callback=None,
-        diagnostic_callback=None,
-        codegraph=None,
+        codegraph: CodeGraph,
         memory_service: MemoryService | None = None,
         checkpoint_session: ReviewCheckpointSession | None = None,
     ) -> tuple[list[dict[str, object]], ReachabilityAnalysis]:
@@ -350,7 +357,6 @@ class ReachabilityReviewService:
             options=options,
             files=files,
             codegraph=codegraph,
-            diagnostic_callback=diagnostic_callback,
             memory_service=memory_service,
         )
         return (
@@ -369,7 +375,7 @@ class ReachabilityReviewService:
         settings=None,
         progress_callback=None,
         diagnostic_callback=None,
-        codegraph=None,
+        codegraph: CodeGraph,
         memory_service: MemoryService | None = None,
         checkpoint_session: ReviewCheckpointSession | None = None,
     ) -> tuple[dict[str, object] | None, ReachabilityAnalysis | None]:

--- a/src/metis/engine/nodes/reachability/service.py
+++ b/src/metis/engine/nodes/reachability/service.py
@@ -3,17 +3,17 @@
 
 
 import logging
-import os
 from collections.abc import Callable
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 from metis.engine.codegraph import CodeGraph
 from metis.engine.codegraph import CodeGraphDiagnostic
 from metis.engine.execution.contracts import NodeJobs
-from metis.engine.nodes.codegraph import CodeGraphService
 from metis.engine.threat_context_retrieval import get_threat_model_context
 from metis.engine.threat_context_retrieval import threat_model_scope_policy
+from metis.utils import resolve_path_within_root
 
 from .domain import ReachabilityAnalysis
 from .domain import VulnerabilityFinding
@@ -37,7 +37,6 @@ class ReachabilityService:
         repository,
         llm_provider,
         usage_runtime,
-        codegraphs: CodeGraphService,
     ):
         self._config = config
         self._frontier_reviewer = IncrementalGraphReviewer(
@@ -46,7 +45,6 @@ class ReachabilityService:
             llm_provider,
             usage_runtime,
         )
-        self._codegraphs = codegraphs
 
     def analyze_file(
         self,
@@ -54,16 +52,12 @@ class ReachabilityService:
         *,
         jobs: NodeJobs,
         options: ReachabilityReviewOptions,
-        codegraph: CodeGraph | None = None,
+        codegraph: CodeGraph,
         diagnostic_callback: Callable[[CodeGraphDiagnostic], None] | None = None,
         memory_service=None,
     ):
         abs_target, relative_target = self._normalize_target_file(file_path)
-        graph = codegraph or self._load_graph(
-            options=options,
-            diagnostic_callback=diagnostic_callback,
-        )
-        if graph.node_count() == 0:
+        if codegraph.node_count() == 0:
             if diagnostic_callback is not None:
                 diagnostic_callback(
                     CodeGraphDiagnostic(
@@ -81,7 +75,7 @@ class ReachabilityService:
                 codegraph_failures=(f"codegraph.empty:{relative_target}",),
             )
         focus = FileFocusBuilder(
-            graph,
+            codegraph,
             max_path_length=options.max_path_length,
         ).build(relative_target)
         if not focus.target_nodes:
@@ -101,13 +95,13 @@ class ReachabilityService:
                 target_path=abs_target,
                 codegraph_failures=(f"codegraph.target_missing:{relative_target}",),
             )
-        analysis_graph = _copy_graph_nodes(graph, focus.node_names)
+        analysis_graph = _copy_graph_nodes(codegraph, focus.node_names)
         outcome = self._frontier_reviewer.review(
             analysis_graph,
             jobs=jobs,
             options=options,
             memory_service=memory_service,
-            evidence_graph=graph,
+            evidence_graph=codegraph,
         )
         scoped_findings = self._filter_authoritative_scope(
             outcome.findings,
@@ -146,31 +140,26 @@ class ReachabilityService:
         *,
         jobs: NodeJobs,
         options: ReachabilityReviewOptions,
+        codegraph: CodeGraph,
         files=None,
-        codegraph: CodeGraph | None = None,
-        diagnostic_callback: Callable[[CodeGraphDiagnostic], None] | None = None,
         memory_service=None,
     ):
-        graph = codegraph or self._load_graph(
-            options=options,
-            diagnostic_callback=diagnostic_callback,
-        )
         selected_files = None
         if files is not None:
             selected_files = {
                 self._normalize_target_file(path)[1] for path in dict.fromkeys(files)
             }
-        if graph.node_count() == 0:
+        if codegraph.node_count() == 0:
             return ReachabilityAnalysis(
                 findings=(),
                 codegraph_failures=("codegraph.empty",),
             )
-        analysis_graph = graph
+        analysis_graph = codegraph
         missing_selected_files: list[str] = []
         if selected_files is not None:
             focus_nodes: set[str] = set()
             focus_builder = FileFocusBuilder(
-                graph,
+                codegraph,
                 max_path_length=options.max_path_length,
             )
             ordered_files = sorted(selected_files)
@@ -188,7 +177,7 @@ class ReachabilityService:
                     completed,
                     len(ordered_files),
                 )
-            analysis_graph = _copy_graph_nodes(graph, focus_nodes)
+            analysis_graph = _copy_graph_nodes(codegraph, focus_nodes)
         if analysis_graph.node_count() == 0:
             return ReachabilityAnalysis(
                 findings=(),
@@ -203,7 +192,7 @@ class ReachabilityService:
             jobs=jobs,
             options=options,
             memory_service=memory_service,
-            evidence_graph=graph,
+            evidence_graph=codegraph,
         )
         findings = self._filter_authoritative_scope(
             outcome.findings,
@@ -248,36 +237,6 @@ class ReachabilityService:
             review_failures=outcome.failures,
         )
 
-    def supports_file(self, file_path) -> bool:
-        _abs_target, relative_target = self._normalize_target_file(file_path)
-        return self._codegraphs.supports_file(
-            relative_target
-        ) and self._codegraphs.supports_semantics(relative_target)
-
-    def analysis_graph(
-        self,
-        *,
-        options: ReachabilityReviewOptions,
-        codegraph: CodeGraph | None = None,
-        diagnostic_callback: Callable[[CodeGraphDiagnostic], None] | None = None,
-    ) -> CodeGraph:
-        return codegraph or self._load_graph(
-            options=options,
-            diagnostic_callback=diagnostic_callback,
-        )
-
-    def _load_graph(
-        self,
-        *,
-        options: ReachabilityReviewOptions,
-        diagnostic_callback: Callable[[CodeGraphDiagnostic], None] | None = None,
-    ) -> CodeGraph:
-        reference = self._codegraphs.materialize(
-            progress_callback=options.progress_callback,
-            diagnostic_callback=diagnostic_callback,
-        )
-        return self._codegraphs.load(reference)
-
     def _filter_authoritative_scope(
         self,
         findings: Sequence[VulnerabilityFinding],
@@ -308,12 +267,6 @@ class ReachabilityService:
         return kept
 
     def _normalize_target_file(self, file_path):
-        base_path = os.path.abspath(self._config.codebase_path)
-        full = (
-            file_path
-            if os.path.isabs(str(file_path))
-            else os.path.join(base_path, str(file_path))
-        )
-        abs_target = os.path.abspath(full)
-        rel_target = os.path.relpath(abs_target, base_path).replace("\\", "/")
-        return abs_target, rel_target
+        root = Path(self._config.codebase_path).expanduser().resolve()
+        resolved = resolve_path_within_root(root, file_path)
+        return str(resolved), resolved.relative_to(root).as_posix()

--- a/src/metis/engine/nodes/reachability/source_context.py
+++ b/src/metis/engine/nodes/reachability/source_context.py
@@ -2,11 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
+from collections.abc import Sequence
 
 from metis.engine.codegraph import FunctionNode
 from metis.engine.source import SourceMap
+from metis.utils import source_lines
 from metis.utils import split_snippet
+
+
+def _source_map(
+    codebase_path: str,
+    file_path: str,
+    source_for_path: Callable[[str], bytes | None] | None,
+) -> SourceMap | None:
+    source = source_for_path(file_path) if source_for_path is not None else None
+    if source is None:
+        return SourceMap.for_file(codebase_path, file_path)
+    return SourceMap.for_bytes(file_path, source)
 
 
 def _build_file_grouped_node_chunks(
@@ -15,6 +28,7 @@ def _build_file_grouped_node_chunks(
     *,
     max_tokens: int,
     token_counter: Callable[[str], int],
+    source_for_path: Callable[[str], bytes | None] | None = None,
 ) -> list[tuple[list[FunctionNode], str]]:
     by_file: dict[str, list[FunctionNode]] = defaultdict(list)
     for function in sorted(
@@ -42,10 +56,10 @@ def _build_file_grouped_node_chunks(
 
     for file_path in sorted(by_file):
         flush_current()
+        source_map = _source_map(codebase_path, file_path, source_for_path)
+        if source_map is None:
+            continue
         for function in by_file[file_path]:
-            source_map = SourceMap.for_file(codebase_path, function.file_path)
-            if source_map is None:
-                continue
             body = source_map.numbered_slice(
                 function.line_number,
                 function.end_line or function.line_number,
@@ -54,7 +68,7 @@ def _build_file_grouped_node_chunks(
                 continue
             if any(
                 token_counter(line) > max_tokens
-                for line in body.splitlines(keepends=True)
+                for line in source_lines(body, keepends=True)
             ):
                 raise ValueError("max_tokens cannot hold one numbered source line")
             for body_part, _start_line in split_snippet(

--- a/src/metis/engine/nodes/simple_llm_review/graph.py
+++ b/src/metis/engine/nodes/simple_llm_review/graph.py
@@ -3,6 +3,8 @@
 
 import logging
 from functools import partial
+from hashlib import sha256
+from pathlib import Path
 from typing import Any
 from typing import cast
 
@@ -25,6 +27,7 @@ from metis.memory.fingerprints import stable_json_hash
 from metis.runlog.workflow import traced_step
 from metis.usage import usage_operation
 from metis.utils import parse_json_output
+from metis.utils import source_lines
 from metis.utils import split_snippet
 
 from .schema import ReviewResponseModel
@@ -279,7 +282,7 @@ class ReviewGraph:
         }
         return stable_json_hash(
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "provider": self.llm_provider.cache_identity(),
                 "model": self.llama_query_model,
                 "max_token_length": self.max_token_length,
@@ -303,7 +306,7 @@ class ReviewGraph:
             self._token_counter,
         )
 
-    def review(self, request: ReviewRequest):
+    def review(self, request: ReviewRequest, *, source_map: SourceMap | None = None):
         file_path = request["file_path"]
         snippet = request["snippet"]
         language_prompts = request["language_prompts"]
@@ -315,7 +318,21 @@ class ReviewGraph:
 
         rel_path = relative_file or file_path
         if mode == "file":
-            smap = SourceMap.for_text(rel_path, snippet)
+            expected_hash = request.get("anchor_source_hash")
+            if expected_hash is None:
+                smap = SourceMap.for_text(rel_path, snippet)
+            else:
+                try:
+                    anchor_source = Path(file_path).read_bytes()
+                except OSError as exc:
+                    raise RuntimeError(
+                        f"Source changed during review: {file_path}"
+                    ) from exc
+                if sha256(anchor_source).hexdigest() != expected_hash:
+                    raise RuntimeError(f"Source changed during review: {file_path}")
+                smap = source_map or SourceMap(
+                    rel_path, snippet, anchor_source=anchor_source
+                )
         elif original_file:
             smap = SourceMap.for_text(rel_path, original_file)
         else:
@@ -324,7 +341,7 @@ class ReviewGraph:
         accumulated: list[dict] = []
         app = self._build_app(language_prompts, default_prompt_key)
         for chunk, chunk_start in chunks:
-            chunk_end = chunk_start + len(chunk.splitlines()) - 1
+            chunk_end = chunk_start + len(source_lines(chunk)) - 1
             state = {
                 "file_path": file_path,
                 "snippet": chunk,

--- a/src/metis/engine/nodes/simple_llm_review/service.py
+++ b/src/metis/engine/nodes/simple_llm_review/service.py
@@ -7,34 +7,36 @@ import logging
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from hashlib import sha256
 from typing import TYPE_CHECKING
+from typing import Any
 
 import unidiff
 from pydantic import ValidationError
 
 from metis import runlog
-from metis.engine.execution.contracts import NodeJobs
-from metis.engine.llm_runner import ModelProviderConfigurationError
-from metis.engine.stages.review.checkpoints import ReviewCheckpointSession
-from metis.utils import read_file_content
-
 from metis.engine.diff_utils import process_diff_file
+from metis.engine.execution.contracts import NodeJobs
+from metis.engine.helpers import apply_custom_guidance
+from metis.engine.helpers import summarize_changes
+from metis.engine.llm_runner import ModelProviderConfigurationError
 from metis.engine.nodes.reachability.progress import emit_progress
-from metis.engine.helpers import apply_custom_guidance, summarize_changes
 from metis.engine.repository import EngineRepository
 from metis.engine.runtime import EngineConfig
-from metis.engine.threat_context_retrieval import get_threat_model_context
-
+from metis.engine.source import SourceMap
+from metis.engine.stages.review.checkpoints import ReviewCheckpointSession
 from metis.engine.stages.review.models import PatchReviewResult
-from metis.engine.stages.review.models import ReviewCommand, ReviewRequest
+from metis.engine.stages.review.models import ReviewCommand
 from metis.engine.stages.review.models import ReviewDiagnostic
 from metis.engine.stages.review.models import ReviewGroup
+from metis.engine.stages.review.models import ReviewRequest
 from metis.engine.stages.review.models import ReviewResult
 from metis.engine.stages.review.models import ReviewRun
 from metis.engine.stages.review.models import ReviewStatus
 from metis.engine.stages.review.models import StandardReviewResult
 from metis.engine.stages.review.scope import select_review_targets
+from metis.engine.threat_context_retrieval import get_threat_model_context
+from metis.utils import read_file_content
 
 logger = logging.getLogger("metis")
 
@@ -275,9 +277,14 @@ class SimpleLlmReviewService:
         checkpoint_session: ReviewCheckpointSession | None = None,
         cache_only: bool = False,
     ) -> dict[str, Any] | None:
-        base_path = os.path.abspath(self._config.codebase_path)
-        snippet = read_file_content(file_path)
-        if not snippet:
+        source_view = self._repository.source_view_for_path(file_path)
+        if source_view is None:
+            snippet = read_file_content(file_path)
+            anchor_source_hash = None
+        else:
+            snippet = source_view.canonical.decode("utf-8", errors="ignore")
+            anchor_source_hash = sha256(source_view.raw).hexdigest()
+        if not snippet.strip():
             return None
 
         plugin = self._repository.get_plugin_for_path(file_path)
@@ -285,7 +292,7 @@ class SimpleLlmReviewService:
             return None
 
         language_prompts = plugin.get_prompts()
-        relative_path = os.path.relpath(file_path, base_path)
+        relative_path = self._repository.normalize_match_path(file_path)
         threat_model_context = get_threat_model_context(
             memory_service,
             path=relative_path,
@@ -300,6 +307,8 @@ class SimpleLlmReviewService:
             "mode": "file",
             "threat_model_context": threat_model_context,
         }
+        if anchor_source_hash is not None:
+            req["anchor_source_hash"] = anchor_source_hash
         graph = review_graph or self._review_graph_factory(None, None)
         checkpoint_key = (
             graph.checkpoint_key(req) if checkpoint_session is not None else None
@@ -320,7 +329,18 @@ class SimpleLlmReviewService:
         if cache_only:
             return None
 
-        result = graph.review(req)
+        if source_view is None:
+            result = graph.review(req)
+        else:
+            result = graph.review(
+                req,
+                source_map=SourceMap(
+                    relative_path,
+                    snippet,
+                    source=source_view.canonical,
+                    anchor_source=source_view.raw,
+                ),
+            )
         if result:
             group = ReviewGroup.model_validate(result)
             result = _review_group_payload(

--- a/src/metis/engine/repository.py
+++ b/src/metis/engine/repository.py
@@ -10,8 +10,12 @@ from threading import Lock
 import pathspec
 from llama_index.core.node_parser import SentenceSplitter
 
+from metis.utils import resolve_path_within_root
+
 from .runtime import EngineConfig
 from .runtime import EngineState
+from .source import ProfiledSourceArtifact
+from .source import SourceView
 
 logger = logging.getLogger("metis")
 
@@ -31,6 +35,54 @@ class EngineRepository:
         self._metisignore_loaded = False
         self._metisignore_spec: pathspec.GitIgnoreSpec | None = None
         self._metisignore_lock = Lock()
+        self._profiled_source: ProfiledSourceArtifact | None = None
+
+    def install_profiled_source(self, artifact: ProfiledSourceArtifact) -> None:
+        self._profiled_source = artifact
+
+    @property
+    def profiled_source_fingerprint(self) -> str | None:
+        artifact = self._profiled_source
+        return artifact.reference.fingerprint if artifact is not None else None
+
+    def source_view_for_path(self, path: str) -> SourceView | None:
+        artifact = self._profiled_source
+        if (
+            artifact is None
+            or self.get_language_name_for_path(path) not in artifact.languages
+        ):
+            return None
+        view = artifact.view_for_path(self._config.codebase_path, path)
+        if view is not None:
+            try:
+                current = resolve_path_within_root(
+                    self._config.codebase_path,
+                    path,
+                ).read_bytes()
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Unable to verify profiled source {path!r}"
+                ) from exc
+            if current != view.raw:
+                raise RuntimeError(
+                    f"Profiled source changed after initialization: {path}"
+                )
+            return view
+        return SourceView(b"", b"")
+
+    def source_profile_applies_to_path(self, path: str) -> bool:
+        artifact = self._profiled_source
+        return (
+            artifact is not None
+            and self.get_language_name_for_path(path) in artifact.languages
+        )
+
+    def analysis_source_for_path(self, path: str) -> bytes | None:
+        if self.source_view_for_path(path) is None:
+            return None
+        artifact = self._profiled_source
+        assert artifact is not None
+        return artifact.analysis_for_path(self._config.codebase_path, path) or b""
 
     def get_plugin_for_extension(self, extension):
         registry = self._config.language_registry

--- a/src/metis/engine/source/__init__.py
+++ b/src/metis/engine/source/__init__.py
@@ -2,6 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .anchor import CodeAnchor
+from .profile import ProfiledSourceArtifact
+from .profile import ProfiledSourceReference
+from .profile import SourceView
 from .source_map import SourceMap, SourceRepository
 
-__all__ = ["CodeAnchor", "SourceMap", "SourceRepository"]
+__all__ = [
+    "CodeAnchor",
+    "ProfiledSourceArtifact",
+    "ProfiledSourceReference",
+    "SourceMap",
+    "SourceRepository",
+    "SourceView",
+]

--- a/src/metis/engine/source/profile.py
+++ b/src/metis/engine/source/profile.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+
+class ProfiledSourceReference(BaseModel):
+    schema_version: Literal[1] = 1
+    fingerprint: str = Field(min_length=1)
+    compile_commands_path: str = Field(min_length=1)
+    compile_commands_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    translation_units: int = Field(ge=1)
+    source_views: int = Field(ge=1)
+    profiled_files: int = Field(ge=0)
+    ambiguous_files: int = Field(ge=0)
+    active_line_count: int = Field(ge=0)
+    compiler_names: tuple[str, ...] = ()
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceView:
+    raw: bytes
+    canonical: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class ProfiledSourceArtifact:
+    reference: ProfiledSourceReference
+    languages: frozenset[str]
+    raw_sources: Mapping[str, bytes]
+    canonical_sources: Mapping[str, bytes]
+
+    def __post_init__(self) -> None:
+        languages = frozenset(language.strip().lower() for language in self.languages)
+        if not languages or "" in languages:
+            raise ValueError("Profiled source languages must be non-empty")
+        raw_sources = {
+            str(path): bytes(source) for path, source in self.raw_sources.items()
+        }
+        canonical_sources = {
+            str(path): bytes(source) for path, source in self.canonical_sources.items()
+        }
+        if not set(canonical_sources) <= set(raw_sources):
+            raise ValueError("Canonical source paths require raw snapshots")
+        if not raw_sources:
+            raise ValueError("Profiled source artifact requires source views")
+        object.__setattr__(self, "languages", languages)
+        object.__setattr__(self, "raw_sources", MappingProxyType(raw_sources))
+        object.__setattr__(
+            self, "canonical_sources", MappingProxyType(canonical_sources)
+        )
+
+    def view_for_path(self, codebase_path: str, path: str) -> SourceView | None:
+        relative = self._relative_path(codebase_path, path)
+        if relative is None or relative not in self.raw_sources:
+            return None
+        raw = self.raw_sources[relative]
+        return SourceView(
+            raw,
+            self.canonical_sources.get(relative, raw),
+        )
+
+    def analysis_for_path(self, codebase_path: str, path: str) -> bytes | None:
+        relative = self._relative_path(codebase_path, path)
+        if relative is None or relative not in self.raw_sources:
+            return None
+        return self.canonical_sources.get(relative, b"")
+
+    @staticmethod
+    def _relative_path(codebase_path: str, path: str) -> str | None:
+        root = Path(codebase_path).expanduser().resolve()
+        candidate = Path(path)
+        candidate = candidate if candidate.is_absolute() else root / candidate
+        try:
+            return candidate.resolve().relative_to(root).as_posix()
+        except (OSError, ValueError):
+            return None

--- a/src/metis/engine/source/source_map.py
+++ b/src/metis/engine/source/source_map.py
@@ -10,6 +10,8 @@ import threading
 from collections import OrderedDict, defaultdict
 from typing import Any
 
+from metis.utils import source_lines
+
 from .anchor import (
     CONFIDENCE_DISAMBIGUATED,
     CONFIDENCE_EXACT,
@@ -51,7 +53,7 @@ def _without_consistent_line_numbers(
 ) -> str:
     if not isinstance(start_line, int) or not isinstance(end_line, int):
         return snippet
-    lines = snippet.splitlines()
+    lines = source_lines(snippet)
     expected_numbers = range(start_line, end_line + 1)
     if len(lines) != len(expected_numbers):
         return snippet
@@ -74,11 +76,23 @@ class SourceMap:
     pipeline that needs to attribute a finding to a location.
     """
 
-    def __init__(self, rel_path: str, text: str):
+    def __init__(
+        self,
+        rel_path: str,
+        text: str,
+        source: bytes | None = None,
+        anchor_source: bytes | None = None,
+    ):
         self.rel_path = normalize_path(rel_path)
         self.text = text
-        self.lines: list[str] = text.splitlines()
-        self.line_offsets: list[int] = self._compute_line_offsets(text)
+        self._source = text.encode("utf-8") if source is None else bytes(source)
+        self._anchor_source = (
+            self._source if anchor_source is None else bytes(anchor_source)
+        )
+        if len(self._anchor_source) != len(self._source):
+            raise ValueError("Analysis and anchor sources must have equal byte length")
+        self.lines: list[str] = source_lines(text)
+        self.line_offsets: list[int] = self._compute_line_offsets(self._source)
         # (start_line, end_line, name) for each top-level function
         self._functions: list[tuple[int, int, str]] | None = None
 
@@ -90,13 +104,24 @@ class SourceMap:
     def for_text(cls, rel_path: str, text: str) -> "SourceMap":
         return cls(rel_path, text)
 
+    @classmethod
+    def for_bytes(
+        cls,
+        rel_path: str,
+        source: bytes,
+        *,
+        anchor_source: bytes | None = None,
+    ) -> "SourceMap":
+        return cls(
+            rel_path,
+            source.decode("utf-8", errors="ignore"),
+            source,
+            anchor_source,
+        )
+
     @staticmethod
-    def _compute_line_offsets(text: str) -> list[int]:
-        offsets = [0]
-        for index, byte in enumerate(text.encode("utf-8")):
-            if byte == ord("\n"):
-                offsets.append(index + 1)
-        return offsets
+    def _compute_line_offsets(source: bytes) -> list[int]:
+        return [0, *(match.end() for match in re.finditer(b"\n", source))]
 
     @property
     def line_count(self) -> int:
@@ -114,15 +139,18 @@ class SourceMap:
 
     def line_end_byte(self, line: int) -> int:
         if line < len(self.line_offsets):
-            return self.line_offsets[line] - 1
-        return len(self.text.encode("utf-8"))
+            end = self.line_offsets[line] - 1
+            return end - 1 if self._source[end - 1 : end] == b"\r" else end
+        return len(self._source)
 
     def byte_slice(self, start_byte: int, end_byte: int) -> str:
         """Return text for a UTF-8 byte span such as a tree-sitter node range."""
-        encoded = self.text.encode("utf-8")
-        start = max(0, min(int(start_byte), len(encoded)))
-        end = max(start, min(int(end_byte), len(encoded)))
-        return encoded[start:end].decode("utf-8")
+        start = max(0, min(int(start_byte), len(self._source)))
+        end = max(start, min(int(end_byte), len(self._source)))
+        return self._source[start:end].decode("utf-8", errors="ignore")
+
+    def _anchor_slice(self, start_byte: int, end_byte: int) -> str:
+        return self._anchor_source[start_byte:end_byte].decode("utf-8", errors="ignore")
 
     def numbered_slice(
         self, start_line: int, end_line: int, *, max_lines: int | None = None
@@ -162,7 +190,7 @@ class SourceMap:
         if len(rendered) <= max_chars:
             return rendered
 
-        lines = rendered.splitlines()
+        lines = source_lines(rendered)
         selected: list[str] = []
         rendered_chars = 0
         for line in lines:
@@ -194,7 +222,7 @@ class SourceMap:
 
     @staticmethod
     def number_text(text: str, start_line: int) -> str:
-        lines = text.splitlines()
+        lines = source_lines(text)
         if not lines:
             return ""
         end = start_line + len(lines) - 1
@@ -228,7 +256,7 @@ class SourceMap:
             end_byte=eb,
             symbol=symbol,
             kind=kind,
-            content_hash=content_hash(self.byte_slice(sb, eb)),
+            content_hash=content_hash(self._anchor_slice(sb, eb)),
             confidence=confidence,
         )
 
@@ -255,7 +283,7 @@ class SourceMap:
             end_byte=end_byte,
             symbol=symbol,
             kind=kind,
-            content_hash=content_hash(self.byte_slice(start_byte, end_byte)),
+            content_hash=content_hash(self._anchor_slice(start_byte, end_byte)),
             confidence=confidence,
         )
 
@@ -276,11 +304,13 @@ class SourceMap:
         if not (1 <= start_line <= end_line <= self.line_count):
             return None
         actual = [_norm_line(ln) for ln in self.lines[start_line - 1 : end_line]]
-        wanted = [_norm_line(ln) for ln in snippet.splitlines() if _norm_line(ln)]
+        wanted = [_norm_line(ln) for ln in source_lines(snippet) if _norm_line(ln)]
         if not wanted:
             return None
         joined_actual = " ".join(a for a in actual if a)
         joined_wanted = " ".join(wanted)
+        if not joined_actual:
+            return None
         if joined_wanted in joined_actual or joined_actual in joined_wanted:
             return self.anchor_for_lines(
                 start_line, end_line, confidence=CONFIDENCE_EXACT
@@ -337,7 +367,7 @@ class SourceMap:
         if not snippet or not self.lines:
             return None
 
-        snippet_lines = [ln.rstrip() for ln in snippet.splitlines()]
+        snippet_lines = [ln.rstrip() for ln in source_lines(snippet)]
         while snippet_lines and not snippet_lines[0].strip():
             snippet_lines.pop(0)
         while snippet_lines and not snippet_lines[-1].strip():
@@ -471,13 +501,13 @@ class SourceMap:
                 _node_line,
             )
 
-            tree = get_parser(language).parse(self.text)
+            tree = get_parser(language).parse_bytes(self._source)
         except Exception:
             return []
         if tree is None:
             return []
 
-        source = self.text.encode("utf-8")
+        source = self._source
         out: list[tuple[int, int, str]] = []
         stack = [tree.root_node()]
         while stack:
@@ -511,10 +541,8 @@ class SourceMap:
                 elif ch == "}":
                     depth -= 1
                 i += 1
-            start_byte = len(self.text[: m.start(1)].encode("utf-8"))
-            end_byte = len(self.text[: max(0, i - 1)].encode("utf-8"))
-            start_line = self.byte_to_line(start_byte)
-            end_line = self.byte_to_line(end_byte)
+            start_line = self.text.count("\n", 0, m.start(1)) + 1
+            end_line = self.text.count("\n", 0, max(0, i - 1)) + 1
             out.append((start_line, end_line, name))
         return out
 

--- a/src/metis/engine/stages/configuration.py
+++ b/src/metis/engine/stages/configuration.py
@@ -61,8 +61,8 @@ BUILTIN_STAGE_CONTRACTS: Mapping[StageName, _ResolvedStageContract] = MappingPro
     {
         "initialize": _ResolvedStageContract({}, {}),
         "review": _ResolvedStageContract(
-            {"request": ReviewCommand},
-            {},
+            {"request": ReviewCommand, "codegraph": CodeGraphReference},
+            {"codegraph": CodeGraphReference | None},
             required_execution_inputs=frozenset({"review_request"}),
             required_outputs={
                 "formats": tuple[ResultFormat, ...],
@@ -187,6 +187,25 @@ class ExecutionConfiguration(BaseModel):
                 raise ValueError(
                     f"Execution stage {name!r} depends on unavailable stages: "
                     f"{unavailable}"
+                )
+        initialize = self.stages.initialize
+        if (
+            initialize is not None
+            and "compilation_profile" in initialize.nodes
+            and "codegraph" in initialize.nodes
+            and "compilation_profile" not in initialize.nodes["codegraph"].depends_on
+        ):
+            raise ValueError("Initialize codegraph must depend on compilation_profile")
+        review = self.stages.review
+        if review is not None and "reachability" in review.nodes:
+            source = review.inputs.get("codegraph", "")
+            source_stage, separator, _output = source.partition(".")
+            if not separator or source_stage != "initialize":
+                raise ValueError("Reachability requires a CodeGraph from Initialize")
+            binding = review.nodes["reachability"].inputs.get("codegraph")
+            if binding not in (None, "$inputs.codegraph"):
+                raise ValueError(
+                    "Reachability must consume the Review stage CodeGraph input"
                 )
         for name, stage in configured_stages:
             configured_filenames = [

--- a/src/metis/engine/stages/review/models.py
+++ b/src/metis/engine/stages/review/models.py
@@ -26,6 +26,7 @@ class ReviewRequest(TypedDict):
     relative_file: NotRequired[str | None]
     mode: NotRequired[str]
     original_file: NotRequired[str | None]
+    anchor_source_hash: NotRequired[str]
     threat_model_context: NotRequired[list[dict[str, Any]]]
     debug_callback: NotRequired[Any]
 

--- a/src/metis/engine/stages/service.py
+++ b/src/metis/engine/stages/service.py
@@ -107,13 +107,36 @@ class ExecutionGraphService:
         stage = self.configuration.stages.review
         if stage is None:
             return _unavailable_stage("review")
-        run = run_stage(
-            "review",
-            self._plans["review"],
-            self._context("review", callbacks=callbacks),
-            {"request": command},
+        requires_initialize = "initialize" in stage.depends_on or any(
+            source.startswith("initialize.") for source in stage.inputs.values()
         )
-        return ExecutionResult(run.status, {"review": run.outputs}, run.diagnostics)
+        if not requires_initialize:
+            return self._execute_configured_stage(
+                "review", {}, callbacks=callbacks, initial_inputs={"request": command}
+            )
+        initialized = self.execute_initialize(callbacks=callbacks)
+        if initialized.status is ExecutionStatus.ERROR:
+            return ExecutionResult(
+                initialized.status,
+                {},
+                initialized.diagnostics,
+            )
+        reviewed = self._execute_configured_stage(
+            "review",
+            initialized.outputs,
+            callbacks=callbacks,
+            initial_inputs={"request": command},
+        )
+        return ExecutionResult(
+            (
+                ExecutionStatus.INCONCLUSIVE
+                if initialized.status is ExecutionStatus.INCONCLUSIVE
+                and reviewed.status is ExecutionStatus.OK
+                else reviewed.status
+            ),
+            reviewed.outputs,
+            (*initialized.diagnostics, *reviewed.diagnostics),
+        )
 
     def execute_triage(
         self,
@@ -169,9 +192,13 @@ class ExecutionGraphService:
             if stage_name == "initialize":
                 result = self.execute_initialize(callbacks=callbacks)
             elif stage_name == "review":
-                result = self.execute_review(
-                    cast(ReviewCommand, self.configuration.inputs.review_request),
+                result = self._execute_configured_stage(
+                    stage_name,
+                    outputs,
                     callbacks=callbacks,
+                    initial_inputs={
+                        "request": self.configuration.inputs.review_request
+                    },
                 )
             elif stage_name == "triage":
                 result = self._execute_configured_triage(
@@ -199,6 +226,7 @@ class ExecutionGraphService:
         outputs: Mapping[str, Any],
         *,
         callbacks: Mapping[str, object] | None,
+        initial_inputs: Mapping[str, Any] | None = None,
     ) -> ExecutionResult:
         stage = self.configuration.stages.get(stage_name)
         if stage is None:
@@ -211,7 +239,7 @@ class ExecutionGraphService:
             stage_name,
             self._plans[stage_name],
             self._context(stage_name, callbacks=callbacks),
-            inputs,
+            {**(initial_inputs or {}), **inputs},
         )
         return ExecutionResult(run.status, {stage_name: run.outputs}, run.diagnostics)
 
@@ -224,12 +252,34 @@ class ExecutionGraphService:
         for stage_name in stage_order:
             contract = self._contracts[stage_name]
             stage = cast(StageConfiguration, self.configuration.stages.get(stage_name))
+            initial_inputs = dict(contract.initial_inputs)
+            for name in contract.stage_inputs:
+                source = stage.inputs.get(name)
+                if source is None:
+                    initial_inputs.pop(name, None)
+                elif source.startswith("$inputs."):
+                    value = getattr(
+                        self.configuration.inputs, source.removeprefix("$inputs.")
+                    )
+                    if value is None:
+                        initial_inputs.pop(name, None)
+                    else:
+                        initial_inputs[name] = type(value)
+                else:
+                    source_stage, _, source_output = source.partition(".")
+                    source_plan = self._plans.get(source_stage)
+                    if source_plan is not None and source_output in (
+                        source_plan.output_annotations
+                    ):
+                        initial_inputs[name] = source_plan.output_annotations[
+                            source_output
+                        ]
             self._plans[stage_name] = compile_stage(
                 catalog,
                 stage_name,
                 stage,
                 self.configuration.node_configuration.get(stage_name, {}),
-                contract.initial_inputs,
+                initial_inputs,
                 capabilities,
             )
             plan = self._plans[stage_name]

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -42,16 +42,17 @@ metis_engine:
     stages:
       initialize:
         outputs:
-          - threat_model
+          threat_model: threat_model.threat_model
+          codegraph: codegraph.codegraph
         nodes:
           threat_model:
             capabilities:
               - memory
-      review:
-        depends_on:
-          - initialize
-        nodes:
           codegraph: {}
+      review:
+        inputs:
+          codegraph: initialize.codegraph
+        nodes:
           simple_llm_review:
             capabilities:
               - memory
@@ -65,7 +66,7 @@ metis_engine:
       triage:
         inputs:
           sarif: review.sarif
-          codegraph: review.codegraph
+          codegraph: initialize.codegraph
         nodes:
           triage:
             capabilities:

--- a/src/metis/plugins/c_family/codegraph.py
+++ b/src/metis/plugins/c_family/codegraph.py
@@ -64,6 +64,10 @@ class ParsedFileGraph:
 
 
 class CFamilyCodeGraphProvider:
+    __metis_cache_identity__ = (
+        "metis.plugins.c_family.codegraph:CFamilyCodeGraphProvider:3"
+    )
+
     def __init__(self, context: CodeGraphProviderContext) -> None:
         self._extractor = CFamilyTreeSitterExtractor(context)
 
@@ -184,7 +188,12 @@ class CFamilyTreeSitterExtractor(CFamilyAstMixin):
             )
 
         try:
-            parsed = runtime.parse_file(codebase_path, rel_path)
+            source = (
+                self._context.source_for_path(file_path)
+                if self._context.source_for_path is not None
+                else None
+            )
+            parsed = runtime.parse_file(codebase_path, rel_path, source=source)
         except Exception as exc:
             return ParsedFileGraph(errors=[f"{rel_path}: {type(exc).__name__}: {exc}"])
 

--- a/src/metis/plugins/c_family/runtime.py
+++ b/src/metis/plugins/c_family/runtime.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from metis.utils import resolve_path_within_root
 
-
 _IDENTIFIER_CALL = re.compile(rb"\b[A-Za-z_][A-Za-z0-9_]*[ \t\r\n]*\(")
 _IDENTIFIER = re.compile(rb"[A-Za-z_][A-Za-z0-9_]*")
 _Span = tuple[int, int]
@@ -76,18 +75,24 @@ class TreeSitterRuntime:
     def init_error(self) -> str:
         return self._init_error
 
-    def parse_file(self, codebase_path: str, rel_path: str) -> ParsedUnit:
+    def parse_file(
+        self,
+        codebase_path: str,
+        rel_path: str,
+        *,
+        source: bytes | None = None,
+    ) -> ParsedUnit:
         if not self.is_available:
             raise RuntimeError(
                 f"Tree-sitter parser unavailable for '{self.language_name}': {self._init_error or 'unknown error'}"
             )
         from tree_sitter_language_pack import get_parser
 
-        full = resolve_path_within_root(codebase_path, rel_path)
-        if not full.is_file():
-            raise FileNotFoundError(str(full))
-
-        source = full.read_bytes()
+        if source is None:
+            full = resolve_path_within_root(codebase_path, rel_path)
+            if not full.is_file():
+                raise FileNotFoundError(str(full))
+            source = full.read_bytes()
         parser = get_parser(self.language_name)
         diagnostic_tree = parser.parse_bytes(source)
         parse_source, tree, macro_function_masks = (
@@ -95,6 +100,12 @@ class TreeSitterRuntime:
             if self.language_name == "c"
             else (source, diagnostic_tree, ())
         )
+        if self.language_name == "c":
+            parse_source, tree = _recover_declaration_annotations(
+                parser,
+                parse_source,
+                tree,
+            )
         return ParsedUnit(
             parse_source=parse_source,
             tree=tree,
@@ -106,6 +117,90 @@ class TreeSitterRuntime:
                 else ()
             ),
         )
+
+
+def _recover_declaration_annotations(
+    parser: Any,
+    source: bytes,
+    original_tree: Any,
+) -> tuple[bytes, Any]:
+    if not original_tree.root_node().has_error():
+        return source, original_tree
+    spans = _declaration_annotation_spans(original_tree, source)
+    if not spans:
+        return source, original_tree
+
+    parse_source = bytearray(source)
+    for start, end in spans:
+        _mask_non_newlines(parse_source, source, start, end)
+    recovered_source = bytes(parse_source)
+    recovered_tree = parser.parse_bytes(recovered_source)
+    # Only retain masks in a valid declaration prefix, never in signatures or
+    # expressions swallowed by the original error node.
+    root = recovered_tree.root_node()
+    nodes = iter(root.child(index) for index in range(root.child_count()))
+    node = next(nodes, None)
+    for start, end in spans:
+        while node is not None and node.end_byte() <= start:
+            node = next(nodes, None)
+        declarator = (
+            node.child_by_field_name("declarator") if node is not None else None
+        )
+        if (
+            node is not None
+            and node.kind() == "declaration"
+            and not node.has_error()
+            and declarator is not None
+            and end <= declarator.start_byte()
+        ):
+            continue
+        parse_source[start:end] = source[start:end]
+    if parse_source == source:
+        return source, original_tree
+    if parse_source != recovered_source:
+        recovered_source = bytes(parse_source)
+        recovered_tree = parser.parse_bytes(recovered_source)
+    original_functions = _function_anchors(original_tree, source)
+    recovered_functions = _function_anchors(recovered_tree, recovered_source)
+    if original_functions < recovered_functions:
+        return recovered_source, recovered_tree
+    return source, original_tree
+
+
+def _declaration_annotation_spans(
+    tree: Any,
+    source: bytes,
+) -> tuple[_Span, ...]:
+    lexical_source = _mask_c_comments_and_literals(source)
+    spans: list[_Span] = []
+    root = tree.root_node()
+    for index in range(root.child_count()):
+        node = root.child(index)
+        if (
+            node is None
+            or not node.has_error()
+            or node.kind() not in {"declaration", "function_definition", "ERROR"}
+        ):
+            continue
+        start, end = node.start_byte(), node.end_byte()
+        brace_depth = 0
+        scanned_until = start
+        for match in _IDENTIFIER_CALL.finditer(lexical_source, start, end):
+            # A top-level ERROR can also contain subsequent function bodies.
+            brace_depth += lexical_source.count(b"{", scanned_until, match.start())
+            brace_depth -= lexical_source.count(b"}", scanned_until, match.start())
+            scanned_until = match.start()
+            if brace_depth:
+                continue
+            open_parenthesis = lexical_source.find(b"(", match.start(), match.end())
+            invocation = _scan_invocation(lexical_source, open_parenthesis)
+            if invocation is None or invocation[0] > end:
+                continue
+            invocation_end = invocation[0]
+            following = _skip_whitespace(lexical_source, invocation_end)
+            if _IDENTIFIER.match(lexical_source, following, end) is not None:
+                spans.append((match.start(), invocation_end))
+    return tuple(spans)
 
 
 def _recover_macro_function_wrappers(
@@ -333,6 +428,19 @@ def _mask_c_comments_and_literals(source: bytes) -> bytes:
             _mask_non_newlines(masked, source, index, end)
             index = end
             continue
+        if source.startswith(b'R"', index):
+            delimiter_start = index + 2
+            opening = source.find(
+                b"(", delimiter_start, min(len(source), delimiter_start + 17)
+            )
+            if opening >= 0:
+                delimiter = source[delimiter_start:opening]
+                closing = source.find(b")" + delimiter + b'"', opening + 1)
+                if closing >= 0:
+                    end = closing + len(delimiter) + 2
+                    _mask_non_newlines(masked, source, index, end)
+                    index = end
+                    continue
         if source[index] in {ord('"'), ord("'")}:
             quote = source[index]
             end = index + 1

--- a/src/metis/utils.py
+++ b/src/metis/utils.py
@@ -7,6 +7,7 @@ import math
 import os
 from collections.abc import Callable
 from functools import lru_cache
+from io import StringIO
 from pathlib import Path
 
 import tiktoken
@@ -138,6 +139,16 @@ def count_tokens(text: str, model: str | None = None) -> int:
     return tiktoken_token_count(text, model)
 
 
+def source_lines(text: str, *, keepends: bool = False) -> list[str]:
+    """Split on LF/CRLF without treating source characters as extra line breaks."""
+    lines = list(StringIO(text))
+    return (
+        lines
+        if keepends
+        else [line.removesuffix("\r\n").removesuffix("\n") for line in lines]
+    )
+
+
 def split_snippet(
     snippet: str,
     max_tokens: int,
@@ -147,7 +158,7 @@ def split_snippet(
     if max_tokens <= 0:
         raise ValueError("max_tokens must be positive")
     counter = token_counter or count_tokens
-    lines = snippet.splitlines(keepends=True)
+    lines = source_lines(snippet, keepends=True)
     parts: list[tuple[str, int]] = []
     for line_number, line in enumerate(lines, start=1):
         parts.extend(

--- a/tests/test_compilation_profile.py
+++ b/tests/test_compilation_profile.py
@@ -1,0 +1,761 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from metis.engine import MetisEngine
+from metis.engine.codegraph import CodeGraphReference
+from metis.engine.concurrency import JobScheduler
+from metis.engine.nodes.codegraph import CodeGraphService
+from metis.engine.nodes.codegraph.progress import CODEGRAPH_REUSED
+from metis.engine.nodes.compilation_profile import service as compilation_profile
+from metis.engine.nodes.compilation_profile.database import CompilationUnit
+from metis.engine.nodes.compilation_profile.database import load_compilation_database
+from metis.engine.nodes.simple_llm_review.service import SimpleLlmReviewService
+from metis.engine.repository import EngineRepository
+from metis.engine.source import SourceMap
+from metis.plugins.c_family.codegraph import CFamilyCodeGraphProvider
+from metis.sarif.writer import generate_sarif
+
+
+def _compiler() -> str:
+    if os.name == "nt":
+        pytest.skip("GNU-compatible preprocessing test")
+    compiler = next(
+        (path for name in ("gcc", "clang", "cc") if (path := shutil.which(name))),
+        None,
+    )
+    if compiler is None:
+        pytest.skip("No GCC-compatible compiler is installed")
+    return compiler
+
+
+def _entry(
+    directory: Path,
+    source: Path | str,
+    *arguments: str,
+    compiler: str | None = None,
+    command: bool = False,
+) -> dict[str, object]:
+    argv = [compiler or _compiler(), *arguments, "-c", str(source)]
+    return {
+        "directory": str(directory),
+        "file": str(source),
+        ("command" if command else "arguments"): shlex.join(argv) if command else argv,
+    }
+
+
+def _build_profile(
+    root: Path,
+    node_jobs,
+    entries: list[dict[str, object]],
+    *,
+    timeout: int = 30,
+):
+    path = root / "compile_commands.json"
+    path.write_text(json.dumps(entries))
+    database = load_compilation_database(
+        codebase_path=str(root),
+        compile_commands_path=path.name,
+    )
+    return compilation_profile.build_profiled_source(
+        codebase_path=str(root),
+        database=database,
+        timeout_seconds=timeout,
+        jobs=node_jobs,
+    )
+
+
+def _graph(
+    root: Path,
+    files: list[Path],
+    artifact=None,
+    *,
+    progress_callback=None,
+):
+    repository = EngineRepository(
+        SimpleNamespace(codebase_path=str(root)), SimpleNamespace()
+    )
+    repository.get_code_files = lambda **_kwargs: [str(path) for path in files]
+    repository.get_codegraph_registration = lambda _path: "c"
+    repository.get_language_name_for_path = lambda path: (
+        "cpp" if Path(path).suffix in {".cc", ".cpp", ".cxx", ".hpp"} else "c"
+    )
+    repository.has_language_file_role = lambda path, role: (
+        role == ("header" if Path(path).suffix in {".h", ".hpp"} else "source")
+    )
+    if artifact is not None:
+        repository.install_profiled_source(artifact)
+    service = CodeGraphService(
+        SimpleNamespace(codebase_path=str(root)),
+        repository,
+        {"c": CFamilyCodeGraphProvider},
+    )
+    reference = service.materialize(progress_callback=progress_callback)
+    return repository, service.load(reference), reference
+
+
+def _node(graph, name: str):
+    matches = [node for node in graph.nodes.values() if node.name == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+@pytest.mark.parametrize("command", (False, True), ids=("arguments", "command"))
+def test_real_database_profiles_read_only_project_and_drives_codegraph(
+    tmp_path: Path,
+    node_jobs,
+    command: bool,
+) -> None:
+    root = tmp_path / "project with spaces"
+    build = root / "build dir"
+    sources = root / "source dir"
+    generated = root / "generated headers"
+    for directory in (build, sources, generated):
+        directory.mkdir(parents=True)
+    header = generated / "config.h"
+    header.write_text("#define VALUE 7\n")
+    source = sources / "máin file.c"
+    source.write_bytes(
+        b'const char *line_text = "#line 100"; /* #line 200 \xff\f */\r\n'
+        b"// #line 300\r\n"
+        b'#include "config.h"\r\n'
+        b"#define WRAP(value) \\\r\n  value\r\n"
+        b"#if FEATURE\r\n"
+        b"void target(void) {}\r\n"
+        b"void active(void) { WRAP(target()); VALUE; }\r\n"
+        b"#else\r\nvoid inactive(void) {}\r\n#endif"
+    )
+    arguments = (
+        "-DFEATURE=1",
+        "-I",
+        "../generated headers",
+        "-g",
+        "-Werror",
+        "-MD",
+        "--dependencies",
+        "--user-dependencies",
+        "--write-dependencies",
+        "--write-user-dependencies",
+        "--print-missing-file-dependencies",
+        "--no-line-commands",
+        "--dump=M",
+        "-Wp,-MMD,forwarded.d",
+        "--output=discarded.o",
+        "-MF",
+        "deps/main.d",
+        "-fdirectives-only",
+        "-save-stats=cwd",
+        "-fdeps-file=deps.json",
+        "-dependency-file",
+        str(build / "dependencies"),
+        "-serialize-diagnostics",
+        str(build / "diagnostics"),
+        "-serialize-diagnostics=diagnostics-attached",
+        "-o",
+        "objects/main.o",
+    )
+    entry = _entry(build, "../source dir/máin file.c", *arguments, command=command)
+    entry["directory"] = "build dir"
+    artifact = _build_profile(root, node_jobs, [entry])
+    raw = source.read_bytes()
+    canonical = artifact.canonical_sources["source dir/máin file.c"]
+
+    assert len(canonical) == len(raw)
+    assert canonical.count(b"\n") == raw.count(b"\n")
+    assert canonical.index(b"void active") == raw.index(b"void active")
+    assert b"  value\r\n" in canonical
+    assert b"WRAP(target())" in canonical
+    assert b"void inactive" not in canonical
+    assert "generated headers/config.h" in artifact.canonical_sources
+    assert not any(build.rglob("*"))
+
+    _repository, graph, _reference = _graph(root, [source, header], artifact)
+    active = _node(graph, "active")
+    assert active.resolved_calls == [_node(graph, "target").unique_name]
+    assert not any(node.name == "inactive" for node in graph.nodes.values())
+    assert raw[active.start_byte : active.end_byte].startswith(b"void active")
+    source_map = SourceMap.for_bytes(active.file_path, canonical, anchor_source=raw)
+    anchor = source_map.resolve_issue(
+        snippet="WRAP(target())", start_line=10, end_line=10
+    )
+    assert (anchor.start_line, anchor.end_line) == (8, 8)
+    assert anchor.start_byte == raw.index(b"void active")
+    assert anchor.symbol == f"{active.file_path}::active"
+    sarif = generate_sarif(
+        {
+            "reviews": [
+                {
+                    "file": active.file_path,
+                    "file_path": str(source),
+                    "reviews": [{"issue": "Active call", "anchor": anchor.to_dict()}],
+                }
+            ]
+        }
+    )
+    region = sarif["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
+        "region"
+    ]
+    assert (region["startLine"], region["endLine"]) == (8, 8)
+
+
+def test_compiler_option_values_are_not_treated_as_flags(tmp_path, node_jobs):
+    includes = tmp_path / "-output-headers"
+    includes.mkdir()
+    (includes / "config.h").write_text("#define FEATURE 1\n")
+    (tmp_path / "-options.h").write_text("#define FORCED 1\n")
+    source = tmp_path / "source.c"
+    source.write_text(
+        '#include "config.h"\n'
+        "#if FEATURE && FORCED\nvoid active(void) {}\n"
+        "#else\nvoid inactive(void) {}\n#endif\n"
+    )
+    artifact = _build_profile(
+        tmp_path,
+        node_jobs,
+        [_entry(tmp_path, source, "-I", includes.name, "-include", "-options.h")],
+    )
+    assert b"void active" in artifact.canonical_sources[source.name]
+    assert b"void inactive" not in artifact.canonical_sources[source.name]
+
+
+def test_precompiled_header_mode_is_rejected_before_preprocessing(
+    tmp_path, node_jobs, monkeypatch
+):
+    compiler = _compiler()
+    header = tmp_path / "config.h"
+    header.write_text("#define FEATURE 1\nint helper(void) { return 7; }\n")
+    source = tmp_path / "source.c"
+    source.write_text("#if FEATURE\nint caller(void) { return helper(); }\n#endif\n")
+    subprocess.run(
+        [compiler, "-x", "c-header", str(header), "-o", str(header) + ".gch"],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    preprocess = Mock(side_effect=AssertionError("Unsupported compiler mode executed"))
+    monkeypatch.setattr(compilation_profile.subprocess, "run", preprocess)
+
+    with pytest.raises(ValueError, match="unsupported argument '-fpch-preprocess'"):
+        _build_profile(
+            tmp_path,
+            node_jobs,
+            [
+                _entry(
+                    tmp_path,
+                    source,
+                    "-include",
+                    str(header),
+                    "-fpch-preprocess",
+                    compiler=compiler,
+                )
+            ],
+        )
+    preprocess.assert_not_called()
+
+
+@pytest.mark.parametrize("location", ("unit", "header", "external_header"))
+@pytest.mark.parametrize(
+    "source_bytes",
+    (b"void active(void) {}\r", b"/* first\rsecond */\nvoid active(void) {}\n"),
+    ids=("cr_line_ending", "embedded_cr"),
+)
+def test_profile_rejects_ambiguous_line_endings(
+    tmp_path, node_jobs, location, source_bytes
+):
+    root = tmp_path / "project"
+    root.mkdir()
+    source = root / "sample.c"
+    source.write_text('#include "header.h"\n')
+    directory = tmp_path if location == "external_header" else root
+    invalid = source if location == "unit" else directory / "header.h"
+    invalid.write_bytes(source_bytes)
+
+    with pytest.raises(RuntimeError, match="LF or CRLF") as error:
+        _build_profile(root, node_jobs, [_entry(root, source, "-I", str(directory))])
+    assert invalid.name in str(error.value)
+
+
+def test_fully_inactive_source_skips_llm_review(tmp_path, node_jobs):
+    source = tmp_path / "sample.c"
+    source.write_bytes(b"#if 0\nvoid inactive(void) {}\n#endif\n")
+    artifact = _build_profile(tmp_path, node_jobs, [_entry(tmp_path, source)])
+    assert not artifact.canonical_sources[source.name].strip()
+    repository, codegraph, _ = _graph(tmp_path, [source], artifact)
+    assert not codegraph.nodes
+    repository.get_plugin_for_path = lambda _: SimpleNamespace(get_prompts=dict)
+    graph = Mock()
+    graph.review.return_value = None
+    service = SimpleLlmReviewService(SimpleNamespace(), repository, lambda *_: graph)
+
+    assert service._review_file_standard(str(source)) is None
+    graph.review.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "arguments, message",
+    (
+        (("-I",), "requires a value"),
+        (("-include",), "requires a value"),
+        (("-MF",), "requires a value"),
+        (("--output",), "requires a value"),
+        (("-I", "@flags.rsp"), "unsupported argument"),
+        (("-o", "@flags.rsp"), "unsupported argument"),
+    ),
+)
+def test_compiler_option_values_are_validated(tmp_path, arguments, message):
+    unit = CompilationUnit("test", tmp_path, tmp_path / "source.c", ("cc", *arguments))
+    with pytest.raises(ValueError, match=message):
+        compilation_profile._sanitized_argv(unit)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (b"{", b"[]", b"[{}]"),
+)
+def test_invalid_compilation_databases_fail_closed(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    database = tmp_path / "compile_commands.json"
+    database.write_bytes(payload)
+
+    with pytest.raises(ValueError, match="[Cc]ompilation database"):
+        load_compilation_database(
+            codebase_path=str(tmp_path),
+            compile_commands_path=database.name,
+        )
+
+
+def test_compiler_selection_and_failures_are_reported(
+    tmp_path: Path,
+    node_jobs,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.c"
+    source.write_text("void active(void) {}\n")
+    missing = _entry(tmp_path, source, compiler="missing-compiler")
+    with pytest.raises(FileNotFoundError, match="not available on PATH"):
+        _build_profile(tmp_path, node_jobs, [missing])
+
+    broken = tmp_path / "broken.c"
+    broken.write_text('#include "missing-header.h"\n')
+    with pytest.raises(RuntimeError, match="missing-header.h"):
+        _build_profile(tmp_path, node_jobs, [_entry(tmp_path, broken)])
+    with pytest.raises(FileNotFoundError, match=r"source does not exist: .*missing\.c"):
+        _build_profile(tmp_path, node_jobs, [_entry(tmp_path, tmp_path / "missing.c")])
+
+    with monkeypatch.context() as context:
+        context.setattr(
+            compilation_profile.subprocess,
+            "run",
+            lambda *args, **kwargs: compilation_profile.subprocess.CompletedProcess(
+                args[0],
+                1,
+                stdout=b"",
+                stderr=b"header error: " + b"x" * 6000 + b"omitted-tail",
+            ),
+        )
+        with pytest.raises(RuntimeError, match="header error") as error:
+            _build_profile(tmp_path, node_jobs, [_entry(tmp_path, source)])
+        assert "diagnostics truncated" in str(error.value)
+        assert "omitted-tail" not in str(error.value)
+        assert len(str(error.value)) < 4300
+
+    def time_out(*args, **kwargs):
+        assert kwargs["timeout"] == 7
+        raise compilation_profile.subprocess.TimeoutExpired(args[0], 1)
+
+    monkeypatch.setattr(compilation_profile.subprocess, "run", time_out)
+    with pytest.raises(RuntimeError, match="TimeoutExpired"):
+        _build_profile(tmp_path, node_jobs, [_entry(tmp_path, source)], timeout=7)
+
+
+@pytest.mark.parametrize(
+    "directive",
+    (
+        "#line 100",
+        "#define LINE 100\n#line LINE",
+        "#/**/line 100",
+        "#li\\\nne 100",
+        '# 100 "generated.c"',
+        "%:line 100",
+        "??=line 100",
+        "#li??/\nne 100",
+        "#\fline 100",
+        "#\vline 100",
+    ),
+)
+def test_source_line_directive_spellings_are_rejected(
+    tmp_path: Path,
+    node_jobs,
+    directive: str,
+) -> None:
+    source = tmp_path / "source.c"
+    source.write_text(f"{directive}\nvoid active(void) {{}}\n")
+
+    with pytest.raises(RuntimeError, match="do not support source #line"):
+        _build_profile(tmp_path, node_jobs, [_entry(tmp_path, source)])
+
+
+def test_external_line_directive_cannot_add_project_files(
+    tmp_path: Path,
+    node_jobs,
+) -> None:
+    root = tmp_path / "project"
+    sdk = tmp_path / "sdk"
+    root.mkdir()
+    sdk.mkdir()
+    victim = root / "victim.h"
+    victim.write_text("void victim(void) {}\n")
+    header = sdk / "external.h"
+    clean = sdk / "clean.h"
+    clean.write_text("#define CLEAN 1\n")
+    header.write_text("#define VALUE 1\n")
+    source = root / "source.c"
+    source.write_text('#include "external.h"\nvoid active(void) {}\n')
+    entry = _entry(root, source, "-I", str(sdk))
+
+    _build_profile(root, node_jobs, [entry])
+    for directive in (
+        f'#line 1 "{victim}"',
+        f'# 1 "{victim}" 1',
+        f'# 1 "{victim}" 3',
+        f'# 1 "{clean}" 1\n# 1 "{victim}" 1',
+    ):
+        header.write_text(f"{directive}\nvoid injected(void) {{}}\n")
+        with pytest.raises(RuntimeError, match="#line directives"):
+            _build_profile(root, node_jobs, [entry])
+
+
+def test_cpp_raw_strings_do_not_hide_or_create_line_directives(
+    tmp_path: Path,
+    node_jobs,
+) -> None:
+    source = tmp_path / "source.cpp"
+    source.write_text(
+        'const char *text = R"TAG(\n" text\n#line 5\n)TAG";\nvoid active() {}\n'
+    )
+    _build_profile(tmp_path, node_jobs, [_entry(tmp_path, source)])
+
+    source.write_text(
+        'const char *text = R"TAG(")TAG";\n'
+        '#line 100 "generated.cpp"\nvoid active() {}\n'
+    )
+    with pytest.raises(RuntimeError, match="do not support source #line"):
+        _build_profile(tmp_path, node_jobs, [_entry(tmp_path, source)])
+
+
+@pytest.mark.parametrize(
+    "argument",
+    (
+        "@flags.rsp",
+        "--",
+        "-save-temps=obj",
+        "-ftime-trace",
+        "-Xclang",
+        "-Xpreprocessor",
+        "-Wp,-MD,deps.d,-DFEATURE=1",
+        "-Wp,-unknown",
+    ),
+)
+def test_opaque_or_side_effecting_arguments_are_rejected(
+    tmp_path: Path,
+    node_jobs,
+    argument: str,
+) -> None:
+    source = tmp_path / "source.c"
+    source.write_text("void active(void) {}\n")
+
+    with pytest.raises(ValueError, match="unsupported argument"):
+        _build_profile(tmp_path, node_jobs, [_entry(tmp_path, source, argument)])
+
+
+def test_multi_profile_headers_are_ambiguous_and_deterministic(
+    tmp_path: Path,
+    node_jobs,
+) -> None:
+    header = tmp_path / "variant.h"
+    header.write_text(
+        "#if MODE\nstatic void enabled(void) {}\n"
+        "#else\nstatic void disabled(void) {}\n#endif\n"
+        "static int sized(void) { return SIZE; }\n",
+    )
+    entries = []
+    for mode, size in ((0, 4), (1, 8)):
+        source = tmp_path / f"source_{mode}.c"
+        source.write_text('#include "variant.h"\n')
+        entries.append(
+            _entry(
+                tmp_path,
+                source,
+                f"-DMODE={mode}",
+                f"-DSIZE={size}",
+                "-I",
+                str(tmp_path),
+            )
+        )
+
+    threaded = _build_profile(tmp_path, node_jobs, entries)
+    scheduler = JobScheduler(1)
+    try:
+        serial = _build_profile(tmp_path, scheduler.limit(1), entries)
+    finally:
+        scheduler.close()
+    assert threaded.reference.fingerprint == serial.reference.fingerprint
+    assert set(threaded.raw_sources) - set(threaded.canonical_sources) == {"variant.h"}
+    assert "variant.h" not in threaded.canonical_sources
+    assert "variant.h" in threaded.raw_sources
+    repository, graph, _reference = _graph(tmp_path, [header], threaded)
+    assert not graph.nodes
+    view = repository.source_view_for_path(str(header))
+    assert view is not None and view.canonical == header.read_bytes()
+
+    header.write_text(header.read_text() + "/* source drift */\n")
+    changed = _build_profile(tmp_path, node_jobs, entries)
+    assert changed.reference.compile_commands_sha256 == (
+        threaded.reference.compile_commands_sha256
+    )
+    assert changed.reference.fingerprint != threaded.reference.fingerprint
+
+
+def test_repeated_profile_views_expand_once_and_converge(
+    tmp_path: Path,
+    node_jobs,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.c"
+    source.write_bytes(b"static int value = \\\n    1;\n")
+
+    def preprocess(unit, **_kwargs):
+        active = frozenset({1, 2} if "-DMODE=2" in unit.argv else {1})
+        return compilation_profile._ProfiledUnit(
+            unit.profile_id,
+            frozenset({source.name}),
+            {source.name: active},
+            frozenset(),
+        )
+
+    expand = Mock(wraps=compilation_profile._include_line_continuations)
+    monkeypatch.setattr(compilation_profile, "_preprocess", preprocess)
+    monkeypatch.setattr(compilation_profile, "_include_line_continuations", expand)
+    artifact = _build_profile(
+        tmp_path,
+        node_jobs,
+        [_entry(tmp_path, source, f"-DMODE={mode}") for mode in range(3)],
+    )
+
+    assert expand.call_count == 2
+    assert artifact.reference.source_views == 3
+    assert artifact.reference.active_line_count == 2
+    assert artifact.reference.ambiguous_files == 0
+    assert artifact.canonical_sources[source.name] == source.read_bytes()
+
+
+def test_inactive_line_mask_matches_bytewise_reference() -> None:
+    random_source = random.Random(19)
+    sources = [b"", bytes(range(256)), b"first\r\nsecond\rlast\n"]
+    sources.extend(
+        random_source.randbytes(random_source.randrange(2000)) for _ in range(200)
+    )
+    for source in sources:
+        active = {
+            line
+            for line in range(source.count(b"\n") + 3)
+            if random_source.randrange(2)
+        }
+        expected = bytearray(source)
+        line = 1
+        for index, value in enumerate(source):
+            if value == 10:
+                line += 1
+            elif value != 13 and line not in active:
+                expected[index] = 32
+        assert compilation_profile._mask_inactive_lines(source, active) == expected
+
+
+def test_profile_fingerprint_distinguishes_ambiguous_from_inactive_source() -> None:
+    raw = {"variant.h": b"#if FEATURE\nvoid active(void);\n#endif\n"}
+
+    assert compilation_profile._fingerprint(raw, {}) != (
+        compilation_profile._fingerprint(raw, {"variant.h": b""})
+    )
+
+
+def test_profile_install_invalidates_raw_graph_cache_and_reuses_profiled_graph(
+    tmp_path: Path,
+    node_jobs,
+) -> None:
+    source = tmp_path / "source.c"
+    source.write_text(
+        "#if FEATURE\nvoid active(void) {}\n#else\nvoid inactive(void) {}\n#endif\n",
+    )
+    unprofiled = tmp_path / "unprofiled.c"
+    unprofiled.write_text("void unprofiled(void) {}\n")
+    artifact = _build_profile(
+        tmp_path,
+        node_jobs,
+        [_entry(tmp_path, source, "-DFEATURE=1")],
+    )
+    _raw_repository, raw_graph, raw_reference = _graph(tmp_path, [source, unprofiled])
+    repository, profiled_graph, profiled_reference = _graph(
+        tmp_path,
+        [source, unprofiled],
+        artifact,
+    )
+
+    assert "source.c::inactive" in raw_graph.nodes
+    assert "unprofiled.c::unprofiled" in raw_graph.nodes
+    assert any(node.name == "active" for node in profiled_graph.nodes.values())
+    assert not any(node.name == "inactive" for node in profiled_graph.nodes.values())
+    assert not any(node.name == "unprofiled" for node in profiled_graph.nodes.values())
+    assert repository.analysis_source_for_path(str(unprofiled)) == b""
+    assert raw_reference.fingerprint != profiled_reference.fingerprint
+    different = _build_profile(
+        tmp_path,
+        node_jobs,
+        [_entry(tmp_path, source, "-DFEATURE=0")],
+    )
+    equivalent = _build_profile(
+        tmp_path,
+        node_jobs,
+        [_entry(tmp_path, source, "-DFEATURE=1", "-g")],
+    )
+    assert different.reference.fingerprint != artifact.reference.fingerprint
+    assert equivalent.reference.fingerprint == artifact.reference.fingerprint
+    unprofiled.write_text("void changed_outside_the_build(void) {}\n")
+    events: list[dict[str, object]] = []
+    _repository, persisted, reused_reference = _graph(
+        tmp_path,
+        [source, unprofiled],
+        equivalent,
+        progress_callback=events.append,
+    )
+    assert reused_reference == profiled_reference
+    assert persisted.nodes.keys() == profiled_graph.nodes.keys()
+    assert [event["event"] for event in events] == [CODEGRAPH_REUSED]
+
+    _, _, narrower = _graph(tmp_path, [source], equivalent)
+    assert narrower.fingerprint != profiled_reference.fingerprint
+
+    expanded = _build_profile(
+        tmp_path,
+        node_jobs,
+        [_entry(tmp_path, source, "-DFEATURE=1"), _entry(tmp_path, unprofiled)],
+    )
+    _, expanded_graph, expanded_reference = _graph(
+        tmp_path, [source, unprofiled], expanded
+    )
+    assert expanded_reference.fingerprint != profiled_reference.fingerprint
+    assert "unprofiled.c::changed_outside_the_build" in expanded_graph.nodes
+
+    source.write_text(source.read_text().replace("inactive", "changed_"))
+    with pytest.raises(RuntimeError, match="changed after initialization"):
+        repository.source_view_for_path(str(source))
+    with pytest.raises(RuntimeError, match="changed after initialization"):
+        _graph(tmp_path, [source, unprofiled], equivalent)
+
+
+def test_initialize_reuses_stored_graph_until_source_changes(
+    tmp_path: Path,
+    dummy_backend,
+    dummy_llm,
+    dummy_embedding_provider,
+    capability_settings,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "source.c"
+    source.write_text("void target(void) {}\nvoid active(void) { target(); }\n")
+    assembly = tmp_path / "startup.S"
+    assembly.write_text("nop\n")
+    database = tmp_path / "compile_commands.json"
+    ignored = _entry(tmp_path, assembly, compiler="missing-compiler")
+    ignored["directory"] = str(tmp_path / "missing-build-directory")
+    database.write_text(json.dumps([_entry(tmp_path, source), ignored]))
+    options = {
+        "codebase_path": str(tmp_path),
+        "vector_backend": dummy_backend,
+        "llm_provider": dummy_llm,
+        "embedding_provider": dummy_embedding_provider,
+        "max_workers": 2,
+        "max_token_length": 2048,
+        "llama_query_model": "gpt-test",
+        "similarity_top_k": 3,
+        "capability_settings": capability_settings,
+        "execution_config": {
+            "stages": {
+                "initialize": {
+                    "outputs": {
+                        "profiled_source": "compilation_profile.profiled_source",
+                        "codegraph": "codegraph.codegraph",
+                    },
+                    "nodes": {
+                        "compilation_profile": {},
+                        "codegraph": {"depends_on": ["compilation_profile"]},
+                    },
+                }
+            },
+            "node_configuration": {
+                "initialize": {
+                    "compilation_profile": {
+                        "compile_commands_path": database.name,
+                    }
+                }
+            },
+        },
+    }
+    engine = MetisEngine(**options)
+    try:
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                CFamilyCodeGraphProvider,
+                "__metis_cache_identity__",
+                "metis.plugins.c_family.codegraph:CFamilyCodeGraphProvider:2",
+            )
+            legacy = engine.init_codebase()
+        initialized = engine.init_codebase()
+        assert (
+            legacy["codegraph"]["fingerprint"]
+            != initialized["codegraph"]["fingerprint"]
+        )
+        assert (tmp_path / ".metis" / "codegraph.sqlite3").is_file()
+        with monkeypatch.context() as patch:
+            rebuild = Mock(side_effect=AssertionError("Unchanged graph was rebuilt"))
+            patch.setattr(CFamilyCodeGraphProvider, "build_graph", rebuild)
+            repeated = engine.init_codebase()
+            fresh = MetisEngine(**options)
+            try:
+                restored = fresh.init_codebase()
+                reference = CodeGraphReference.model_validate(restored["codegraph"])
+                loaded = fresh.execution._codegraphs.load(reference)
+                assert _node(loaded, "active").resolved_calls == [
+                    _node(loaded, "target").unique_name
+                ]
+            finally:
+                fresh.close()
+            rebuild.assert_not_called()
+        source.write_text("void changed(void) {}\n")
+        changed = engine.init_codebase()
+    finally:
+        engine.close()
+
+    assert initialized["profiled_source"]["profiled_files"] == 1
+    assert initialized["profiled_source"]["translation_units"] == 1
+    assert repeated == initialized
+    assert restored == initialized
+    assert initialized["codegraph"]["fingerprint"]
+    assert (
+        changed["codegraph"]["fingerprint"] != initialized["codegraph"]["fingerprint"]
+    )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -80,11 +80,16 @@ def test_packaged_execution_graph_omits_index_initialization():
     triage = execution["stages"]["triage"]
     assert "index" not in initialize["nodes"]
     assert "index" not in initialize["outputs"]
+    assert initialize["outputs"]["codegraph"] == "codegraph.codegraph"
+    assert "codegraph" in initialize["nodes"]
     assert "outputs" not in review
+    assert review["inputs"]["codegraph"] == "initialize.codegraph"
+    assert "codegraph" not in review["nodes"]
     assert "inputs" not in review["nodes"]["simple_llm_review"]
     assert "inputs" not in review["nodes"]["finding_dedup"]
     assert "inputs" not in review["nodes"]["result"]
     assert "outputs" not in triage
+    assert triage["inputs"]["codegraph"] == "initialize.codegraph"
     assert set(triage["nodes"]) == {"triage", "result"}
     assert "inputs" not in triage["nodes"]["triage"]
     assert "inputs" not in triage["nodes"]["result"]

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -389,15 +389,19 @@ def test_explicit_review_producers_run_independently(engine, monkeypatch):
         {
             "inputs": {"review_request": {"mode": "code"}},
             "stages": {
+                "initialize": {
+                    "outputs": {"codegraph": "codegraph.codegraph"},
+                    "nodes": {"codegraph": {}},
+                },
                 "review": {
+                    "inputs": {"codegraph": "initialize.codegraph"},
                     "nodes": {
-                        "codegraph": {},
                         "simple_llm_review": {},
                         "reachability": {},
                         "finding_dedup": {},
                         "result": {},
-                    }
-                }
+                    },
+                },
             },
         }
     )

--- a/tests/test_engine_review.py
+++ b/tests/test_engine_review.py
@@ -12,6 +12,7 @@ import pytest
 from metis.cli.review_checkpoints import review_checkpoint_callbacks
 from metis.engine import MetisEngine
 from metis.engine.codegraph import CodeGraph
+from metis.engine.codegraph import FunctionNode
 from metis.engine.execution.contracts import NodeCallbacks
 from metis.engine.llm_runner import JsonPromptRequest
 from metis.engine.llm_runner import ModelProviderConfigurationError
@@ -20,9 +21,12 @@ from metis.engine.nodes.reachability.domain import ReachabilityAnalysis
 from metis.engine.nodes.reachability.review import ReachabilityReviewService
 from metis.engine.nodes.simple_llm_review.service import SimpleLlmReviewService
 from metis.engine.nodes.simple_llm_review.service import TraditionalReviewOutcome
+from metis.engine.source import ProfiledSourceArtifact
+from metis.engine.source import ProfiledSourceReference
+from metis.engine.source import SourceMap
 from metis.engine.stages.review.checkpoints import ReviewCheckpointSession
-from metis.engine.stages.review.models import ReviewCommand
 from metis.engine.stages.review.models import ReviewCheckpointRecord
+from metis.engine.stages.review.models import ReviewCommand
 from metis.engine.stages.review.models import ReviewRun
 from metis.engine.stages.review.models import ReviewStatus
 from metis.engine.stages.review.models import StandardReviewResult
@@ -35,6 +39,12 @@ def _simple_llm_review(engine: MetisEngine) -> SimpleLlmReviewService:
         engine.repository,
         lambda index, model: engine._get_review_graph(index, model),
     )
+
+
+def _covered_graph(path: str) -> CodeGraph:
+    graph = CodeGraph()
+    graph.add_node(FunctionNode(f"{path}::entry", path, "entry", 1))
+    return graph
 
 
 def _prompt_json_section(request: JsonPromptRequest, label: str) -> Any:
@@ -122,6 +132,112 @@ def test_simple_review_orders_results_by_selected_file(engine):
         "first.c",
         "second.c",
     ]
+    assert all(
+        "anchor_source_hash" not in call.args[0] for call in graph.review.call_args_list
+    )
+
+
+def test_simple_review_uses_profile_bytes_and_anchors_raw_source(engine) -> None:
+    raw = (
+        b"int marker; /* \xff\f */\n"
+        b"void active(void) {\n    risky();\n    inactive_bug();\n}\n"
+    )
+    canonical = raw.replace(b"    inactive_bug();", b"                   ")
+    assert len(raw) == len(canonical)
+    target = Path(engine.codebase_path) / "profiled.c"
+    target.write_bytes(raw)
+    engine.repository.install_profiled_source(
+        ProfiledSourceArtifact(
+            reference=ProfiledSourceReference(
+                fingerprint="review-profile",
+                compile_commands_path="compile_commands.json",
+                compile_commands_sha256="0" * 64,
+                translation_units=1,
+                source_views=1,
+                profiled_files=1,
+                ambiguous_files=0,
+                active_line_count=3,
+            ),
+            languages=frozenset({"c", "cpp"}),
+            raw_sources={target.name: raw},
+            canonical_sources={target.name: canonical},
+        )
+    )
+    graph = engine._get_review_graph(None, None)
+
+    def model_response(request):
+        body = request.variables["body_text"]
+        assert "risky();" in body
+        assert "3:     risky();" in body
+        assert "inactive_bug();" not in body
+        return request.parse(
+            {
+                "reviews": [
+                    {
+                        "issue": "Active issue",
+                        "code_snippet": "risky();\n\n}",
+                        "start_line": 2,
+                        "end_line": 4,
+                        "reasoning": "Active path reaches risky operation.",
+                        "mitigation": "Validate input first.",
+                        "confidence": 0.9,
+                        "cwe": "CWE-20",
+                        "severity": "HIGH",
+                    }
+                ]
+            }
+        )
+
+    graph._prompt_runner.invoke = Mock(side_effect=model_response)
+    service = _simple_llm_review(engine)
+    checkpoint_session = Mock(has_records=False)
+    checkpoint_session.get.return_value = None
+    run = service.run_files(
+        (str(target),),
+        jobs=engine.execution._jobs,
+        checkpoint_session=checkpoint_session,
+    )
+
+    assert run.status is ReviewStatus.SUCCEEDED
+    assert run.result is not None
+    finding = run.result.reviews[0].reviews[0].model_dump()
+    raw_anchor = SourceMap.for_bytes(target.name, raw).anchor_for_lines(3, 5)
+    canonical_anchor = SourceMap.for_bytes(target.name, canonical).anchor_for_lines(
+        3, 5
+    )
+    assert finding["anchor"] == raw_anchor.to_dict()
+    assert finding["anchor"]["start_byte"] == raw.index(b"    risky();")
+    assert finding["anchor"]["symbol"] == "profiled.c::active"
+    assert finding["anchor"]["content_hash"] != canonical_anchor.content_hash
+    assert json.dumps(checkpoint_session.put.call_args.args[1])
+
+    other = Path(engine.codebase_path) / "other.py"
+    other.write_text("print('unchanged')\n", encoding="utf-8")
+    plugin = engine.repository.get_plugin_for_path(str(target))
+    language_for_path = engine.repository.get_language_name_for_path
+    engine.repository.get_plugin_for_path = lambda _path: plugin
+    engine.repository.get_language_name_for_path = lambda path: (
+        "python" if path == str(other) else language_for_path(path)
+    )
+    other_graph = Mock()
+    other_graph.review.return_value = None
+    service._review_file_standard(str(other), review_graph=other_graph)
+    other_request = other_graph.review.call_args.args[0]
+    assert other_request["snippet"] == "print('unchanged')\n"
+    assert "anchor_source_hash" not in other_request
+
+    review = graph.review
+
+    def change_source(request, **kwargs):
+        target.write_text("void changed(void) {}\n", encoding="utf-8")
+        return review(request, **kwargs)
+
+    graph.review = change_source
+    failed = service.run_files((str(target),), jobs=engine.execution._jobs)
+
+    assert failed.status is ReviewStatus.FAILED
+    assert "Source changed during review" in failed.diagnostics[0].message
+    graph._prompt_runner.invoke.assert_called_once()
 
 
 def test_simple_llm_review_resumes_completed_files(engine, tmp_path):
@@ -347,11 +463,11 @@ def test_reachability_review_falls_back_for_unsupported_files(engine, caplog):
         Mock(),
         fallback,
         {},
+        supports_file=lambda path: path.endswith(".c"),
     )
     c_file = str(Path(engine.codebase_path) / "supported.c")
     python_file = str(Path(engine.codebase_path) / "baseline.py")
     service._repository.get_code_files = Mock(return_value=[c_file, python_file])
-    service.supports_file = Mock(side_effect=lambda path: path.endswith(".c"))
     service.codebase_reviews = Mock(
         return_value=(
             [{"file": "supported.c", "reviews": [{"issue": "reachable"}]}],
@@ -366,7 +482,7 @@ def test_reachability_review_falls_back_for_unsupported_files(engine, caplog):
         run = service.run_review(
             ReviewCommand(mode="code"),
             jobs=engine.execution._jobs,
-            codegraph=CodeGraph(),
+            codegraph=_covered_graph("supported.c"),
             progress_callback=progress_events.append,
         )
 
@@ -421,9 +537,9 @@ def test_reachability_does_not_run_simple_review_for_supported_files(engine):
         Mock(),
         simple,
         {},
+        supports_file=lambda _path: True,
     )
     target = str(Path(engine.codebase_path) / "supported.c")
-    service.supports_file = Mock(return_value=True)
     service.file_review = Mock(
         side_effect=lambda *_args, **_kwargs: (
             events.append("graph")
@@ -436,47 +552,13 @@ def test_reachability_does_not_run_simple_review_for_supported_files(engine):
     run = service.run_review(
         ReviewCommand(mode="file", target=target),
         jobs=engine.execution._jobs,
-        codegraph=CodeGraph(),
+        codegraph=_covered_graph("supported.c"),
     )
 
     assert run.status is ReviewStatus.SUCCEEDED
     assert events == ["graph"]
     simple.run_files.assert_not_called()
     assert "candidate_node_names" not in service.file_review.call_args.kwargs
-
-
-def test_reachability_missing_graph_coverage_is_inconclusive(engine):
-    service = ReachabilityReviewService(
-        engine._config,
-        engine.repository,
-        Mock(),
-        Mock(spec=SimpleLlmReviewService),
-        {},
-    )
-    target = str(Path(engine.codebase_path) / "supported.c")
-    service.supports_file = Mock(return_value=True)
-    service.file_review = Mock(
-        return_value=(
-            {"file": "supported.c", "reviews": []},
-            ReachabilityAnalysis(
-                findings=(),
-                codegraph_failures=(
-                    "codegraph.target_missing:supported.c",
-                    "codegraph.target_missing:supported.c",
-                ),
-            ),
-        )
-    )
-
-    run = service.run_review(
-        ReviewCommand(mode="file", target=target),
-        jobs=engine.execution._jobs,
-        codegraph=CodeGraph(),
-    )
-
-    assert run.status is ReviewStatus.INCONCLUSIVE
-    assert run.diagnostics[0].code == "review.frontier_analysis_partial"
-    assert "1 selected target" in run.diagnostics[0].message
 
 
 def test_reachability_operational_failure_detail_survives_product_boundary(engine):
@@ -486,9 +568,9 @@ def test_reachability_operational_failure_detail_survives_product_boundary(engin
         Mock(),
         Mock(spec=SimpleLlmReviewService),
         {},
+        supports_file=lambda _path: True,
     )
     target = str(Path(engine.codebase_path) / "supported.c")
-    service.supports_file = Mock(return_value=True)
     service.file_review = Mock(
         return_value=(
             {"file": "supported.c", "reviews": []},
@@ -507,7 +589,7 @@ def test_reachability_operational_failure_detail_survives_product_boundary(engin
     run = service.run_review(
         ReviewCommand(mode="file", target=target),
         jobs=engine.execution._jobs,
-        codegraph=CodeGraph(),
+        codegraph=_covered_graph("supported.c"),
     )
 
     assert run.status is ReviewStatus.INCONCLUSIVE
@@ -528,6 +610,7 @@ def test_reachability_review_rejects_symlink_outside_codebase(engine, tmp_path):
         Mock(),
         fallback,
         {},
+        supports_file=lambda _path: False,
     )
 
     run = service.run_review(
@@ -548,11 +631,10 @@ def test_reachability_defers_fallback_to_explicit_simple_review(engine):
         Mock(),
         None,
         {},
+        supports_file=lambda _path: False,
     )
     python_file = str(Path(engine.codebase_path) / "baseline.py")
     service._repository.get_code_files = Mock(return_value=[python_file])
-    service.supports_file = Mock(return_value=False)
-
     run = service.run_review(
         ReviewCommand(mode="code"),
         jobs=engine.execution._jobs,
@@ -572,6 +654,7 @@ def test_reachability_empty_scope_is_inconclusive(engine):
         Mock(),
         Mock(spec=SimpleLlmReviewService),
         {},
+        supports_file=lambda _path: False,
     )
     service._repository.get_code_files = Mock(return_value=[])
 

--- a/tests/test_execution_graph.py
+++ b/tests/test_execution_graph.py
@@ -38,6 +38,7 @@ from metis.engine.stages.review.models import ReviewStatus
 from metis.engine.stages.review.models import StandardReviewResult
 from metis.engine.stages.service import ExecutionGraphService
 from metis.engine.stages.triage.models import TriageRun
+from metis.engine.source import ProfiledSourceReference
 from metis.execution_nodes import CapabilityRequirement
 from metis.execution_nodes import EmptyNodeConfiguration
 from metis.execution_nodes import ExecutionDiagnostic
@@ -79,15 +80,18 @@ def _configuration() -> ExecutionConfiguration:
             },
             "stages": {
                 "initialize": {
-                    "outputs": ["threat_model"],
+                    "outputs": {
+                        "threat_model": "threat_model.threat_model",
+                        "codegraph": "codegraph.codegraph",
+                    },
                     "nodes": {
                         "threat_model": {"capabilities": ["memory"]},
+                        "codegraph": {},
                     },
                 },
                 "review": {
-                    "depends_on": ["initialize"],
+                    "inputs": {"codegraph": "initialize.codegraph"},
                     "nodes": {
-                        "codegraph": {},
                         "simple_llm_review": {"capabilities": ["index", "memory"]},
                         "finding_dedup": {},
                         "result": {
@@ -98,7 +102,7 @@ def _configuration() -> ExecutionConfiguration:
                 "triage": {
                     "inputs": {
                         "sarif": "review.sarif",
-                        "codegraph": "review.codegraph",
+                        "codegraph": "initialize.codegraph",
                     },
                     "nodes": {
                         "triage": {"capabilities": ["memory", "navigation"]},
@@ -137,13 +141,69 @@ def test_builtin_stage_order_is_stable_when_yaml_is_reordered() -> None:
         {
             "inputs": {"review_request": {"mode": "code"}},
             "stages": {
-                "review": {"nodes": {"result": {}}},
-                "initialize": {"nodes": {"init": {}}},
+                "review": {
+                    "inputs": {"codegraph": "initialize.codegraph"},
+                    "nodes": {"result": {}},
+                },
+                "initialize": {
+                    "outputs": {"codegraph": "init.codegraph"},
+                    "nodes": {"init": {}},
+                },
             },
         }
     )
 
     assert configuration.stage_order() == ("initialize", "review")
+
+
+def test_simple_review_does_not_require_codegraph() -> None:
+    raw = _configuration().model_dump(mode="json")
+    raw["stages"] = {"review": raw["stages"]["review"]}
+    raw["stages"]["review"]["inputs"] = {}
+    raw["stages"]["review"]["nodes"]["result"]["formats"] = ["sarif"]
+
+    _service(ExecutionConfiguration.model_validate(raw))
+
+
+def test_reachability_requires_initialized_codegraph() -> None:
+    with pytest.raises(ValueError, match="CodeGraph from Initialize"):
+        ExecutionConfiguration.model_validate(
+            {
+                "inputs": {"review_request": {"mode": "code"}},
+                "stages": {
+                    "review": {
+                        "nodes": {"reachability": {}, "result": {"formats": ["sarif"]}}
+                    }
+                },
+            }
+        )
+
+
+def test_reachability_rejects_review_time_codegraph_binding() -> None:
+    raw = _configuration().model_dump(mode="json")
+    raw["stages"]["review"]["nodes"]["reachability"] = {
+        "inputs": {"codegraph": "producer.codegraph"}
+    }
+
+    with pytest.raises(ValueError, match="Review stage CodeGraph input"):
+        ExecutionConfiguration.model_validate(raw)
+
+
+def test_reachability_accepts_explicit_review_stage_codegraph_binding() -> None:
+    raw = _configuration().model_dump(mode="json")
+    raw["stages"]["review"]["nodes"]["reachability"] = {
+        "inputs": {"codegraph": "$inputs.codegraph"}
+    }
+
+    _service(ExecutionConfiguration.model_validate(raw))
+
+
+def test_profiled_codegraph_requires_profile_dependency() -> None:
+    raw = _configuration().model_dump(mode="json")
+    raw["stages"]["initialize"]["nodes"]["compilation_profile"] = {}
+
+    with pytest.raises(ValueError, match="must depend on compilation_profile"):
+        ExecutionConfiguration.model_validate(raw)
 
 
 def test_finding_dedup_combines_producers_before_result() -> None:
@@ -637,6 +697,7 @@ def _service(
     configuration: ExecutionConfiguration | None = None,
     *,
     entry_points: tuple[Any, ...] = (),
+    extra_registrations: tuple[NodeRegistration, ...] = (),
     review_run: ReviewRun | None = None,
     review_commands: list[ReviewCommand] | None = None,
     triage_options: TriageOptions | None = None,
@@ -683,6 +744,21 @@ def _service(
         return replace(run, remaining=(), processed=run.total)
 
     triage.triage_run.side_effect = triage_run
+    initialized_threat_model = threat_model_node.InitializedThreatModelResult(
+        status="ok",
+        records_written=0,
+        records_deleted=0,
+        authoritative_sources=[],
+    )
+    threat_model_registration = NodeRegistration(
+        "threat_model",
+        "initialize",
+        EmptyNodeConfiguration,
+        {},
+        {"threat_model": threat_model_node.InitializedThreatModelResult},
+        lambda _invocation: NodeResult({"threat_model": initialized_threat_model}),
+        {"memory": CapabilityRequirement.REQUIRED},
+    )
     service = ExecutionGraphService(
         configuration or _configuration(),
         engine_config=engine_config,
@@ -697,7 +773,7 @@ def _service(
         triage_adjudicator=triage,
         triage_options=triage_options or TriageOptions(),
         registrations=(
-            threat_model_node.create_node(engine_config, Mock()),
+            threat_model_registration,
             index_node.registration,
             codegraph_node.registration,
             review_node.create_node(review),
@@ -706,6 +782,7 @@ def _service(
             review_results_node.registration,
             triage_node.create_node(triage_classifier),
             triage_results_node.registration,
+            *extra_registrations,
         ),
         entry_points=entry_points,
     )
@@ -738,18 +815,9 @@ def test_configured_include_triaged_can_be_overridden_per_run() -> None:
     assert [run.total for run in runs] == [1, 0]
 
 
-def test_default_graph_runs_fixed_stages_and_passes_review_sarif(monkeypatch):
+def test_default_graph_runs_fixed_stages_and_passes_review_sarif():
     configuration = ExecutionConfiguration.model_validate(load_execution_config())
     service, calls = _service(configuration)
-    monkeypatch.setattr(
-        "metis.engine.nodes.threat_model.registration.initialize_threat_model_memory",
-        lambda *_args: {
-            "status": "ok",
-            "records_written": 0,
-            "records_deleted": 0,
-            "authoritative_sources": [],
-        },
-    )
 
     result = service.execute_graph()
 
@@ -759,46 +827,112 @@ def test_default_graph_runs_fixed_stages_and_passes_review_sarif(monkeypatch):
     assert result.outputs["triage"]["sarif"] == result.outputs["review"]["sarif"]
 
 
-def test_codegraph_node_seeds_file_review_from_target():
+@pytest.mark.parametrize(
+    "stage_inputs",
+    ({}, {"codegraph": "$inputs.codegraph"}),
+    ids=("omitted", "unset-execution-input"),
+)
+def test_required_external_review_input_must_be_configured(stage_inputs) -> None:
+    raw = _configuration().model_dump(mode="json")
+    raw["stages"]["review"]["inputs"] = stage_inputs
+    raw["stages"]["review"]["nodes"]["requires_graph"] = {}
+    configuration = ExecutionConfiguration.model_validate(raw)
+    requires_graph = NodeRegistration(
+        "requires_graph",
+        "review",
+        EmptyNodeConfiguration,
+        {"codegraph": CodeGraphReference},
+        {},
+        lambda _invocation: NodeResult({}),
+    )
+
+    with pytest.raises(ValueError, match="unbound inputs: codegraph"):
+        _service(configuration, extra_registrations=(requires_graph,))
+
+
+def test_required_review_input_rejects_nullable_stage_output() -> None:
+    raw = _configuration().model_dump(mode="json")
+    raw["stages"]["initialize"]["outputs"]["codegraph"] = "maybe.codegraph"
+    raw["stages"]["initialize"]["nodes"]["maybe"] = {}
+    del raw["stages"]["initialize"]["nodes"]["codegraph"]
+    raw["stages"]["review"]["nodes"]["reachability"] = {}
+    maybe = NodeRegistration(
+        "maybe",
+        "initialize",
+        EmptyNodeConfiguration,
+        {},
+        {"codegraph": CodeGraphReference | None},
+        lambda _invocation: NodeResult({"codegraph": None}),
+    )
+
+    with pytest.raises(ValueError, match="input 'codegraph' is incompatible"):
+        _service(
+            ExecutionConfiguration.model_validate(raw),
+            extra_registrations=(maybe,),
+        )
+
+
+def test_direct_review_skips_unrelated_initialize_stage() -> None:
+    raw = _configuration().model_dump(mode="json")
+    raw["stages"]["review"]["inputs"] = {}
+    configuration = ExecutionConfiguration.model_validate(raw)
+    service, calls = _service(configuration)
+
+    result = service.execute_review(ReviewCommand(mode="code"))
+
+    assert result.status is ExecutionStatus.OK
+    assert calls == ["review"]
+
+
+def test_profiled_codegraph_fails_when_source_graph_is_incomplete():
     codegraphs = Mock()
-    reference = CodeGraphReference(
+    codegraphs.materialize.return_value = CodeGraphReference(
         revision=1,
         fingerprint="fingerprint",
         producer_version="test",
+        failed_files=("source.c",),
     )
-    codegraphs.materialize.return_value = reference
-    context = replace(
-        _node_context(),
-        stage="review",
-        codegraphs=codegraphs,
+    context = replace(_node_context(), stage="initialize", codegraphs=codegraphs)
+    context.repository.profiled_source_fingerprint = "profile"
+    context.repository.source_profile_applies_to_path.side_effect = lambda path: (
+        path.endswith(".c")
+    )
+    profile = ProfiledSourceReference(
+        fingerprint="profile",
+        compile_commands_path="compile_commands.json",
+        compile_commands_sha256="0" * 64,
+        translation_units=1,
+        source_views=1,
+        profiled_files=1,
+        ambiguous_files=0,
+        active_line_count=1,
+    )
+    invocation = NodeInvocation(
+        EmptyNodeConfiguration(), {"profiled_source": profile}, context
     )
 
-    result = codegraph_node.registration.execute(
-        NodeInvocation(
-            EmptyNodeConfiguration(),
-            {"request": ReviewCommand(mode="file", target="src/target.c")},
-            context,
+    with pytest.raises(RuntimeError, match="contains failed files"):
+        codegraph_node.registration.execute(invocation)
+
+    codegraphs.materialize.return_value = (
+        codegraphs.materialize.return_value.model_copy(
+            update={"failed_files": ("module.py",)},
         )
     )
+    result = codegraph_node.registration.execute(invocation)
+    assert result.outputs["codegraph"].failed_files == ("module.py",)
 
-    assert result.outputs == {"codegraph": reference}
-    codegraphs.materialize.assert_called_once()
-    assert codegraphs.materialize.call_args.kwargs["seed_file"] == "src/target.c"
-    assert callable(codegraphs.materialize.call_args.kwargs["progress_callback"])
+    for installed in (None, "different-profile"):
+        context.repository.profiled_source_fingerprint = installed
+        codegraphs.materialize.reset_mock()
+        with pytest.raises(RuntimeError, match="does not match the installed profile"):
+            codegraph_node.registration.execute(invocation)
+        codegraphs.materialize.assert_not_called()
 
 
-def test_inconclusive_review_still_feeds_triage(monkeypatch):
+def test_inconclusive_review_still_feeds_triage():
     service, calls = _service(
         review_run=_review_run(ReviewStatus.INCONCLUSIVE),
-    )
-    monkeypatch.setattr(
-        "metis.engine.nodes.threat_model.registration.initialize_threat_model_memory",
-        lambda *_args: {
-            "status": "ok",
-            "records_written": 0,
-            "records_deleted": 0,
-            "authoritative_sources": [],
-        },
     )
 
     result = service.execute_graph()
@@ -851,18 +985,9 @@ def test_patch_review_publishes_the_canonical_codegraph_reference():
     assert result.outputs["review"]["codegraph"].fingerprint == "test"
 
 
-def test_failed_review_stops_before_triage(monkeypatch):
+def test_failed_review_stops_before_triage():
     service, calls = _service(
         review_run=ReviewRun(ReviewStatus.FAILED, None),
-    )
-    monkeypatch.setattr(
-        "metis.engine.nodes.threat_model.registration.initialize_threat_model_memory",
-        lambda *_args: {
-            "status": "ok",
-            "records_written": 0,
-            "records_deleted": 0,
-            "authoritative_sources": [],
-        },
     )
 
     result = service.execute_graph()
@@ -1639,19 +1764,23 @@ def test_private_registration_must_match_selected_stage():
         {
             "inputs": {"review_request": {"mode": "code"}},
             "stages": {
+                "initialize": {
+                    "outputs": {"codegraph": "codegraph.codegraph"},
+                    "nodes": {"codegraph": {}},
+                },
                 "review": {
+                    "inputs": {"codegraph": "initialize.codegraph"},
                     "nodes": {
-                        "codegraph": {},
                         "private_node": {},
                         "result": {
                             "inputs": {
                                 "reviews": ["private_node"],
-                                "codegraph": "codegraph",
+                                "codegraph": "$inputs.codegraph",
                             },
                             "formats": ["sarif"],
                         },
-                    }
-                }
+                    },
+                },
             },
         }
     )

--- a/tests/test_reachability_incremental_review.py
+++ b/tests/test_reachability_incremental_review.py
@@ -35,6 +35,8 @@ from metis.engine.nodes.reachability.state import NormalExit
 from metis.engine.nodes.reachability.state import ReturnSubject
 from metis.engine.nodes.reachability.state import StateEffect
 from metis.engine.nodes.reachability.state import TrackedObjectSubject
+from metis.engine.source import SourceMap
+from metis.engine.source import SourceView
 from metis.engine.stages.review.checkpoints import ReviewCheckpointSession
 from metis.providers.base import ChatProvider
 
@@ -69,6 +71,8 @@ def _reviewer(tmp_path: Path) -> IncrementalGraphReviewer:
     }
     repository = Mock()
     repository.get_plugin_for_path.return_value = plugin
+    repository.analysis_source_for_path.return_value = None
+    repository.source_view_for_path.return_value = None
     config = SimpleNamespace(
         codebase_path=str(tmp_path),
         plugin_config={"general_prompts": {"security_review_report": "Report."}},
@@ -85,24 +89,26 @@ def test_review_runs_one_discovery_pass_with_deterministic_contracts(
     tmp_path: Path,
     node_jobs,
 ) -> None:
-    (tmp_path / "graph.c").write_text(
-        "void root(void) { sink(); }\nvoid sink(void) {}\n",
-        encoding="utf-8",
-    )
+    raw = b"/* \xff */ void root(void) { /* \f */\n\f  sink();\n  sink();\n}\nvoid sink(void) {}\n"
+    canonical = raw.replace(b"  sink();\n  sink();", b"  sink();\n         ", 1)
+    (tmp_path / "graph.c").write_bytes(raw)
     call = CallSite(
         "sink",
-        1,
+        2,
         0,
-        start_byte=18,
-        end_byte=24,
+        start_byte=raw.index(b"sink()"),
+        end_byte=raw.index(b"sink()") + len(b"sink()"),
         target_ids=("graph.c::sink",),
     )
     root = _function("root", 1, source=True)
+    root.end_line = 4
     root.call_sites = [call]
     root.calls = ["sink"]
-    sink = _function("sink", 2)
+    sink = _function("sink", 5)
     sink.set_tag("control.noreturn", value="_Noreturn", reason="test fact")
     reviewer = _reviewer(tmp_path)
+    reviewer._repository.analysis_source_for_path.return_value = canonical
+    reviewer._repository.source_view_for_path.return_value = SourceView(raw, canonical)
     seen_bodies: list[str] = []
     progress_events: list[dict[str, object]] = []
 
@@ -114,23 +120,43 @@ def test_review_runs_one_discovery_pass_with_deterministic_contracts(
         )
         body = request.variables["body_text"]
         assert isinstance(body, str)
+        assert "2: \f  sink();" in body
+        assert "3:   sink();" not in body
         seen_bodies.append(body)
         evidence_text = body.partition("CODEGRAPH_EVIDENCE (untrusted JSON):\n")[2]
         evidence, _end = json.JSONDecoder().raw_decode(evidence_text)
         contract = evidence["direct_function_contracts"][0]
         assert evidence["function_ids"][contract["function"]] == "::sink"
         assert contract["normal_exit"] == {
-            "line": 2,
+            "line": 5,
             "origin": "observed",
             "status": "impossible",
         }
-        parsed = request.parse({"reviews": []})
+        parsed = request.parse(
+            {
+                "reviews": [
+                    {
+                        "issue": "Reachable sink",
+                        "code_snippet": "void root(void) { /* \f */\n\f  sink();\n\n}",
+                        "start_line": 1,
+                        "end_line": 4,
+                        "reasoning": "Root reaches sink.",
+                        "mitigation": "Validate before calling sink.",
+                        "confidence": 0.9,
+                        "cwe": "CWE-20",
+                        "severity": "HIGH",
+                        "necessary_condition_alternatives": [],
+                    }
+                ]
+            }
+        )
         assert parsed is not None
         return parsed
 
     reviewer._runner.invoke = Mock(side_effect=invoke)
+    graph = _graph(root, sink)
     outcome = reviewer.review(
-        _graph(root, sink),
+        graph,
         jobs=node_jobs,
         options=ReachabilityReviewOptions(
             domain_profiles=(" GPU ",),
@@ -140,6 +166,32 @@ def test_review_runs_one_discovery_pass_with_deterministic_contracts(
     )
 
     assert len(seen_bodies) == 1
+    reviewer._repository.analysis_source_for_path.assert_called_with("graph.c")
+    expected_anchor = SourceMap.for_bytes("graph.c", raw).anchor_for_lines(1, 4)
+    assert outcome.findings[0].primary_anchor == expected_anchor.to_dict()
+    assert (
+        outcome.findings[0].primary_anchor
+        != SourceMap.for_bytes("graph.c", canonical).anchor_for_lines(1, 4).to_dict()
+    )
+    packets, failures = reviewer._build_packets(
+        graph,
+        (root.unique_name,),
+        options=ReachabilityReviewOptions(),
+        memory_service=None,
+    )
+    hidden_active_line = replace(packets[0], shown_lines=frozenset({1, 4}))
+    assert not failures
+    assert (
+        reviewer._review_anchor(
+            hidden_active_line,
+            {
+                "code_snippet": "void root(void) { /* \f */\n\f  sink();\n\n}",
+                "start_line": 1,
+                "end_line": 4,
+            },
+        )
+        is None
+    )
     assert "CONTRACT_MANIFEST" not in seen_bodies[0]
     assert "STATE_REVIEW_CASES" not in seen_bodies[0]
     assert outcome.stats.packet_count == 1

--- a/tests/test_reachability_provider_registry.py
+++ b/tests/test_reachability_provider_registry.py
@@ -61,6 +61,8 @@ def test_codegraph_store_closes_connections(tmp_path, monkeypatch):
 
 def _repository(files, registration_for_path):
     return SimpleNamespace(
+        analysis_source_for_path=lambda _path: None,
+        profiled_source_fingerprint=None,
         get_code_files=lambda **_kwargs: files,
         get_codegraph_registration=registration_for_path,
         get_language_name_for_path=lambda path: (
@@ -531,37 +533,6 @@ def test_concurrent_materialize_serializes_canonical_builds(tmp_path):
 
     assert first_reference == second_reference
     assert builds == ["build"]
-
-
-def test_concurrent_different_file_seeds_keep_both_graphs(tmp_path):
-    for name in ("first.py", "second.py"):
-        (tmp_path / name).write_text(f"def {name[:-3]}(): pass\n", encoding="utf-8")
-
-    def build_graph(**kwargs):
-        graph = CodeGraph()
-        path = os.path.basename(kwargs["files"][0])
-        name = path[:-3]
-        graph.add_node(FunctionNode(f"{path}::{name}", path, name, 1))
-        return CodeGraphResult(graph, kwargs["files"])
-
-    repository = _repository((), lambda _path: "python")
-    repository.is_code_file_selected = lambda path, **_kwargs: (
-        tmp_path / path
-    ).is_file()
-    service = CodeGraphService(
-        SimpleNamespace(codebase_path=str(tmp_path)),
-        repository,
-        {"python": lambda _context: SimpleNamespace(build_graph=build_graph)},
-    )
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        first_future = executor.submit(service.materialize, seed_file="first.py")
-        second_future = executor.submit(service.materialize, seed_file="second.py")
-        first = first_future.result()
-        second = second_future.result()
-
-    assert service.load(first).get_node("first.py::first") is not None
-    assert service.load(second).get_node("second.py::second") is not None
 
 
 def test_concurrent_materialize_shares_an_incomplete_attempt(tmp_path):

--- a/tests/test_reachability_source_context.py
+++ b/tests/test_reachability_source_context.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+from unittest.mock import Mock
 
 import pytest
 
-from metis.engine.codegraph import CallSite, FunctionNode
+from metis.engine.codegraph import CallSite
+from metis.engine.codegraph import FunctionNode
 from metis.engine.nodes.reachability.source_context import (
     _build_file_grouped_node_chunks,
 )
@@ -58,7 +60,8 @@ def test_function_chunks_cover_every_source_line_and_callsite(tmp_path):
     assert {call.line for call in target.call_sites} <= _rendered_lines(chunks)
 
 
-def test_function_chunks_never_cross_files_and_follow_source_order(tmp_path):
+@pytest.mark.parametrize("profiled", (False, True))
+def test_function_chunks_never_cross_files_and_follow_source_order(tmp_path, profiled):
     (tmp_path / "a.c").write_text(
         "void first(void) {}\nvoid second(void) {}\n",
         encoding="utf-8",
@@ -67,12 +70,14 @@ def test_function_chunks_never_cross_files_and_follow_source_order(tmp_path):
     first = FunctionNode("a.c::first", "a.c", "first", 1, end_line=1)
     second = FunctionNode("a.c::second", "a.c", "second", 2, end_line=2)
     third = FunctionNode("b.c::third", "b.c", "third", 1, end_line=1)
+    lookup = Mock(side_effect=lambda path: (tmp_path / path).read_bytes())
 
     chunks = _build_file_grouped_node_chunks(
         str(tmp_path),
         [third, second, first],
         max_tokens=10_000,
         token_counter=_character_count,
+        source_for_path=lookup if profiled else None,
     )
 
     assert [[node.unique_name for node in nodes] for nodes, _text in chunks] == [
@@ -82,6 +87,9 @@ def test_function_chunks_never_cross_files_and_follow_source_order(tmp_path):
     assert all(len({node.file_path for node in nodes}) == 1 for nodes, _text in chunks)
     assert all("Function a.c::" not in text for _nodes, text in chunks)
     assert all("===== FILE:" not in text for _nodes, text in chunks)
+    assert [call.args[0] for call in lookup.call_args_list] == (
+        ["a.c", "b.c"] if profiled else []
+    )
 
 
 def test_function_chunks_reject_unlabelled_line_fragments(tmp_path):

--- a/tests/test_reachability_treesitter.py
+++ b/tests/test_reachability_treesitter.py
@@ -30,11 +30,12 @@ from metis.engine.nodes.reachability.options import ReachabilityReviewOptions
 from metis.engine.nodes.reachability.service import ReachabilityService
 from metis.engine.nodes.reachability.state import ParameterSubject
 from metis.engine.nodes.reachability.state import augment_function_contracts
+from metis.plugins.base import ConfigBackedLanguagePlugin
 from metis.plugins.c_family.ast import CFamilyAstMixin
 from metis.plugins.c_family.codegraph import CFamilyCodeGraphProvider
 from metis.plugins.c_family.codegraph import CFamilyTreeSitterExtractor
+from metis.plugins.c_family.runtime import TreeSitterRuntime
 from metis.plugins.c_family.semantics import CFamilyCodeGraphSemantics
-from metis.plugins.base import ConfigBackedLanguagePlugin
 
 
 class _Point:
@@ -100,6 +101,8 @@ class _Node:
 def _codegraph_service(codebase_path, *, files=(), annotation_settings=None):
     plugin = ConfigBackedLanguagePlugin(plugin_config={"plugins": {}}, name="c")
     repository = SimpleNamespace(
+        analysis_source_for_path=lambda _path: None,
+        profiled_source_fingerprint=None,
         get_code_files=lambda **_kwargs: list(files),
         is_code_file_selected=lambda path, **_kwargs: (
             Path(codebase_path) / path
@@ -355,6 +358,100 @@ def test_c_codegraph_recovers_generic_macro_wrapped_function_definitions(tmp_pat
     assert [diagnostic.code for diagnostic in result.diagnostics] == [
         "codegraph.partial_parse"
     ]
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        "before();",
+        "if (ready()) before();",
+        "while (ready()) before();",
+        "for (; ready(); ) before();",
+    ),
+)
+def test_c_codegraph_recovers_after_declaration_annotation_macro(tmp_path, body):
+    source = tmp_path / "annotation.c"
+    source.write_text(
+        "static void before(void) {}\n"
+        "static int ready(void) { return 1; }\n"
+        "static __ALIGNED(4) uint8_t buffer[4];\n"
+        f"static void after(void) {{ {body} }}\n"
+        "static __ALIGNED(8) uint8_t second[8];\n"
+        "static void last(void) { after(); }\n",
+        encoding="utf-8",
+    )
+    original = source.read_bytes()
+    runtime = TreeSitterRuntime("c")
+
+    parsed = runtime.parse_file(str(tmp_path), source.name)
+
+    assert len(parsed.parse_source) == len(original)
+    assert parsed.parse_source.index(b"before") == original.index(b"before")
+    assert parsed.parse_source.index(b"after") == original.index(b"after")
+    annotation = slice(original.index(b"__ALIGNED"), original.index(b"uint8_t"))
+    assert parsed.parse_source[annotation].strip() == b""
+    function = slice(
+        original.index(b"static void after"), original.index(b"static __ALIGNED(8)")
+    )
+    assert parsed.parse_source[function] == original[function]
+
+    service = _codegraph_service(str(tmp_path), files=(str(source),))
+    graph = service.load(service.materialize())
+    assert graph.get_node("annotation.c::before") is not None
+    after = graph.get_node("annotation.c::after")
+    assert after is not None
+    assert after.start_byte == original.index(b"static void after")
+    expected_calls = {"annotation.c::before"}
+    if "ready()" in body:
+        expected_calls.add("annotation.c::ready")
+    if body.startswith("if"):
+        assert next(
+            call for call in after.call_sites if call.symbol == "before"
+        ).conditions
+    elif body.startswith(("while", "for")):
+        assert len(after.loops) == 1
+        assert after.loops[0].condition.text == "ready()"
+    assert set(after.resolved_calls) == expected_calls
+    assert graph.get_node("annotation.c::last").resolved_calls == [
+        "annotation.c::after"
+    ]
+
+
+@pytest.mark.parametrize(
+    "signature",
+    (
+        "(__typeof__(1) value)",
+        "(_Atomic(int) value)",
+        "(int value) __attribute__((noinline))",
+    ),
+)
+def test_declaration_recovery_preserves_signatures_and_graph_facts(tmp_path, signature):
+    source = tmp_path / "annotation.c"
+    original = (
+        "#define ALIGN(n) __attribute__((aligned(n)))\n"
+        "static void before(void) {}\n"
+        "static ALIGN(4) unsigned char buffer[4];\n"
+        f"void target{signature} {{ before(); }}\n"
+        "void after(void) { target(0); }\n"
+    ).encode()
+    source.write_bytes(original)
+    annotation = b"ALIGN(4)"
+    expected = original.replace(annotation, b" " * len(annotation))
+
+    parsed = TreeSitterRuntime("c").parse_file(str(tmp_path), source.name)
+    assert parsed.parse_source == expected
+    service = _codegraph_service(str(tmp_path), files=(str(source),))
+    recovered = service.load(service.materialize())
+    assert recovered.get_node("annotation.c::target").resolved_calls == [
+        "annotation.c::before"
+    ]
+    assert recovered.get_node("annotation.c::after").resolved_calls == [
+        "annotation.c::target"
+    ]
+
+    source.write_bytes(expected)
+    control = service.load(service.materialize())
+    assert recovered.nodes == control.nodes
 
 
 def test_c_codegraph_resolves_wrapper_annotations_across_files(tmp_path):
@@ -1111,6 +1208,8 @@ def test_codegraph_service_preserves_provider_resolution_without_cross_links(tmp
     python_graph = _graph(_fn("module.py::open", 1))
     progress_events = []
     repository = SimpleNamespace(
+        analysis_source_for_path=lambda _path: None,
+        profiled_source_fingerprint=None,
         get_code_files=lambda **_kwargs: ["caller.c", "module.py"],
         get_codegraph_registration=lambda path: (
             "c_family" if path.endswith(".c") else "python"

--- a/tests/test_source_map.py
+++ b/tests/test_source_map.py
@@ -1,22 +1,21 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from concurrent.futures import ThreadPoolExecutor
 import gc
 import sys
 import textwrap
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from metis.engine.source import CodeAnchor, SourceMap, SourceRepository
-from metis.engine.source.anchor import (
-    CONFIDENCE_DISAMBIGUATED,
-    CONFIDENCE_EXACT,
-    CONFIDENCE_FUZZY,
-    CONFIDENCE_UNRESOLVED,
-    content_hash,
-)
-
+from metis.engine.source import CodeAnchor
+from metis.engine.source import SourceMap
+from metis.engine.source import SourceRepository
+from metis.engine.source.anchor import CONFIDENCE_DISAMBIGUATED
+from metis.engine.source.anchor import CONFIDENCE_EXACT
+from metis.engine.source.anchor import CONFIDENCE_FUZZY
+from metis.engine.source.anchor import CONFIDENCE_UNRESOLVED
+from metis.engine.source.anchor import content_hash
 
 C_FIXTURE = textwrap.dedent(
     """\
@@ -90,6 +89,9 @@ def test_numbered_slice_max_lines(smap):
 def test_number_text_static():
     out = SourceMap.number_text("a\nb\nc", start_line=10)
     assert out.splitlines() == ["10: a", "11: b", "12: c"]
+    assert SourceMap.number_text("a\finside\r\nb\vinside\n", 1) == (
+        "1: a\finside\n2: b\vinside"
+    )
 
 
 def test_byte_line_round_trip(smap):
@@ -162,6 +164,8 @@ def test_verify_lines_mismatch(smap):
     assert smap.verify_lines(3, 3, "memcpy(tmp, buf, len);") is None
     assert smap.verify_lines(0, 0, "x") is None
     assert smap.verify_lines(1, 9999, "x") is None
+    blank = SourceMap.for_text("source.c", "             \n")
+    assert blank.verify_lines(1, 1, "inactive_bug();") is None
 
 
 def test_enclosing_symbol(smap):
@@ -254,6 +258,44 @@ def test_repository_caches_by_mtime(tmp_path):
     m2 = repo.get(str(tmp_path), "f.c")
     assert m1 is m2
     assert repo.get(str(tmp_path), "missing.c") is None
+
+
+def test_source_map_preserves_crlf_byte_offsets() -> None:
+    source_map = SourceMap.for_bytes("crlf.c", b"a\r\nb\r\n")
+
+    assert source_map.line_to_byte(2) == 3
+    anchor = source_map.anchor_for_lines(1, 1)
+    assert (anchor.end_byte, anchor.end_col) == (1, 1)
+    assert source_map.byte_slice(anchor.start_byte, anchor.end_byte) == "a"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [b"", b"\n", b"\r", b"a\r\nb\n", "αé\n尾".encode(), bytes(range(256))],
+)
+def test_source_map_offsets_match_byte_newlines(source: bytes) -> None:
+    source_map = SourceMap.for_bytes("source.txt", source)
+
+    assert source_map.line_count == source.count(b"\n") + bool(
+        source and not source.endswith(b"\n")
+    )
+    assert source_map.line_offsets == [
+        0,
+        *(index + 1 for index, byte in enumerate(source) if byte == 10),
+    ]
+
+
+@pytest.mark.parametrize("fallback", (False, True))
+def test_symbol_disambiguation_keeps_invalid_utf8_byte_positions(monkeypatch, fallback):
+    raw = b"/* " + b"\xff" * 64 + b" */\n"
+    raw += b"void first(void) { operation(); }\nvoid second(void) { operation(); }\n"
+    source_map = SourceMap.for_bytes("source.c", raw)
+    if fallback:
+        monkeypatch.setattr(source_map, "_spans_from_tree", lambda: [])
+    anchor = source_map.resolve_issue(snippet="operation();", context_text="second")
+    assert (anchor.start_line, anchor.end_line) == (3, 3)
+    assert anchor.start_byte == raw.index(b"void second")
+    assert anchor.symbol == "source.c::second"
 
 
 def test_repository_lru_eviction(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,7 +168,7 @@ def test_split_snippet_default_counter():
 
 
 def test_split_snippet_splits_one_overlong_line_without_data_loss():
-    text = "abcdefghijkl\nok\n"
+    text = "abc\fdef\u2028ghijkl\nok\n"
     chunks = split_snippet(text, max_tokens=4, token_counter=len)
 
     assert "".join(chunk for chunk, _start in chunks) == text


### PR DESCRIPTION
- Added optional C/C++ build profiling from compile_commands.json, using the recorded compiler to identify active files and conditional branches.
 - Moved CodeGraph construction into Initialize. Reachability consumes the prepared graph; ordinary Tree-sitter analysis still works without compilation profiling.
 - Preserved original source locations for findings and tightened annotation recovery and compiler-option validation.
 - Improved persisted-graph reuse, added regression tests for mapping, parsing and cache behavior, and updated the documentation.