### PR TITLE
fix(core): harden indexing, execution and persistence

### DIFF
--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+from copy import copy
 from datetime import datetime
 import logging
 from pathlib import Path
+import shlex
 from typing import Any
 from typing import cast
 
@@ -299,6 +301,7 @@ def _execute_command(engine, cmd, cmd_args, args):
     spec = COMMANDS[cmd]
     if cmd == "exit":
         return EXIT_REQUESTED
+    args = copy(args)
     runtime = CommandRuntime(command=cmd, command_args=list(cmd_args))
 
     if spec.prepares_output_file:
@@ -343,7 +346,7 @@ def run_interactive_loop(engine, args, vector_backend):
             user_input = prompt("> ", completer=completer, history=history).strip()
             if not user_input:
                 continue
-            parts = user_input.split()
+            parts = shlex.split(user_input)
             cmd, cmd_args = parts[0], parts[1:]
 
             if PG_SUPPORTED and isinstance(vector_backend, PGVectorStoreImpl):

--- a/src/metis/cli/exporters.py
+++ b/src/metis/cli/exporters.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Tuple
 
+from metis.json_io import write_json_atomic
 from metis.sarif.writer import generate_sarif
 
 
@@ -35,8 +36,7 @@ def export_sarif(
         sarif_payload if sarif_payload is not None else generate_sarif(report_data)
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as f:
-        json.dump(payload, f, indent=4)
+    write_json_atomic(output_path, payload, indent=4)
     return output_path, payload
 
 

--- a/src/metis/cli/report_template.html
+++ b/src/metis/cli/report_template.html
@@ -15,7 +15,6 @@
         body.light-theme .meta { color: #4b5565; }
         body.light-theme .chart-card { background: #ffffff; border-color: #d0d5e0; box-shadow: 0 12px 30px -18px rgba(15, 23, 42, 0.15); }
         body.light-theme .chart-card.selected { border-color: #2563eb; box-shadow: 0 18px 38px -18px rgba(37, 99, 235, 0.35); }
-        body.light-theme .chart-card.selected { border-color: #2563eb; box-shadow: 0 18px 38px -18px rgba(37, 99, 235, 0.35); }
         body.light-theme .chart-card h2 { color: #111827; }
         body.light-theme .chart-card .echart { cursor: pointer; }
         body.light-theme .chart-button { color: #1e293b; border-color: rgba(148, 163, 184, 0.4); background: rgba(148, 163, 184, 0.18); }
@@ -45,7 +44,6 @@
         .charts.maximized-active { grid-template-columns: 1fr; }
         .charts.maximized-active .chart-card:not(.maximized) { display: none; }
         .chart-card { position: relative; background: #0d1a33; border: 1px solid #1f2c4d; border-radius: 12px; padding: 1rem 1.25rem 1.5rem; box-shadow: 0 10px 30px -15px rgba(15, 23, 42, 0.8); min-height: 320px; display: flex; flex-direction: column; transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease; }
-        .chart-card.selected { border-color: #3b82f6; box-shadow: 0 20px 45px -18px rgba(59, 130, 246, 0.45); }
         .chart-card.selected { border-color: #3b82f6; box-shadow: 0 20px 45px -18px rgba(59, 130, 246, 0.45); }
         .chart-card h2 { font-size: 1.05rem; margin-bottom: 0.75rem; color: #f4f5f7; display: flex; justify-content: space-between; align-items: center; gap: 0.75rem; }
         .chart-actions { display: inline-flex; gap: 0.5rem; }
@@ -683,7 +681,7 @@
                 backgroundColor: 'transparent',
                 tooltip: {
                     trigger: 'item',
-                    formatter: params => `${params.name}: ${params.value}`
+                    formatter: params => `${echarts.format.encodeHTML(params.name)}: ${params.value}`
                 },
                 legend: {
                     orient: 'vertical',
@@ -768,12 +766,12 @@
                         const severityLines = Object.entries(counts)
                             .filter(([, value]) => value > 0)
                             .sort((a, b) => (severityRank[b[0]] || 0) - (severityRank[a[0]] || 0))
-                            .map(([severity, value]) => `${severity}: ${value}`);
+                            .map(([severity, value]) => `${echarts.format.encodeHTML(severity)}: ${value}`);
                         const path = data.isFile ? data.fullPath : data.fullPath || data.name;
                         const severity = data.severity || 'Unknown';
                         const details = [
-                            `<strong>${path}</strong>`,
-                            `Severity: ${severity}`,
+                            `<strong>${echarts.format.encodeHTML(path)}</strong>`,
+                            `Severity: ${echarts.format.encodeHTML(severity)}`,
                             `Total issues: ${total}`
                         ];
                         if (severityLines.length) {

--- a/src/metis/cli/review_checkpoints.py
+++ b/src/metis/cli/review_checkpoints.py
@@ -66,8 +66,9 @@ def _sqlite_records(path: Path) -> dict[str, dict[str, object]] | None:
                 if not isinstance(record, dict):
                     continue
                 records[str(key)] = record
-    except (OSError, sqlite3.Error):
-        _discard_checkpoint(path)
+    except (OSError, sqlite3.Error) as exc:
+        if _should_discard_on(exc):
+            _discard_checkpoint(path)
         return None
     return records or None
 

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -108,7 +108,7 @@ def load_runtime_config(config_path=None, enable_psql=False):
         "review_code_exclude_paths", []
     )
     runtime["capability_settings"] = _capability_runtime_settings(engine_cfg)
-    memory_cfg = cfg.get("memory") or {}
+    memory_cfg = cfg.get("memory")
     runtime["memory"] = _memory_config(memory_cfg)
     runtime["threat_model_config"] = _threat_model_config(
         engine_cfg.get("threat_model")
@@ -155,11 +155,9 @@ def load_runtime_config(config_path=None, enable_psql=False):
     llm_provider_config["max_retries"] = runtime["llm_max_retries"]
     runtime["llm_provider"] = llm_provider_config
 
-    embedding_provider_raw_config = dict(cfg.get("embedding_provider") or {})
-    if not embedding_provider_raw_config:
-        runtime["embedding_provider_raw_config"] = None
-    else:
-        runtime["embedding_provider_raw_config"] = embedding_provider_raw_config
+    runtime["embedding_provider_raw_config"] = (
+        dict(cfg.get("embedding_provider") or {}) or None
+    )
 
     return runtime
 
@@ -240,8 +238,10 @@ def _capability_runtime_settings(
     engine = _required_mapping(engine_config, section="metis_engine")
     model = _load_engine_mapping("model_tools", None)
     configured_model = engine.get("model_tools")
-    if isinstance(configured_model, dict):
-        model.update(configured_model)
+    if configured_model is not None:
+        model.update(
+            _required_mapping(configured_model, section="metis_engine.model_tools")
+        )
     capabilities = _load_engine_mapping("capabilities", engine.get("capabilities"))
     configurations: dict[str, dict[str, Any]] = {}
     for name, value in capabilities.items():
@@ -274,15 +274,15 @@ def pgvector_use_halfvec_setting(value: object, embed_dim: object) -> bool:
     if isinstance(value, (int, float)) and value in (0, 1):
         return bool(value)
     if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"true", "yes", "on", "1"}:
+        value = value.strip().lower()
+        if value in {"true", "yes", "on", "1"}:
             return True
-        if normalized in {"false", "no", "off", "0"}:
+        if value in {"false", "no", "off", "0"}:
             return False
-        if normalized != "auto":
-            raise ValueError(
-                "metis_engine.pgvector_use_halfvec must be true, false, or auto."
-            )
+    if value is not None and value != "auto":
+        raise ValueError(
+            "metis_engine.pgvector_use_halfvec must be true, false, or auto."
+        )
     try:
         parsed_embed_dim = int(cast(Any, embed_dim))
     except (TypeError, ValueError):

--- a/src/metis/engine/capabilities/indexing.py
+++ b/src/metis/engine/capabilities/indexing.py
@@ -217,6 +217,6 @@ class IndexingService:
                         nodes = doc_splitter.get_nodes_from_documents([doc])
                     target_index.insert_nodes(nodes)
                 else:
-                    target_index.refresh_ref_docs([doc])
+                    target_index.update_ref_doc(doc)
                 target_index.docstore.set_document_hash(doc.id_, doc.hash)
         logger.info("Index update complete based on the provided patch diff.")

--- a/src/metis/engine/concurrency.py
+++ b/src/metis/engine/concurrency.py
@@ -220,9 +220,7 @@ class JobScheduler:
         future: Future[Any],
     ) -> None:
         with self._condition:
-            job = run.active.pop(future, None)
-            if job is None:
-                return
+            job = run.active.pop(future)
             self._active_workers -= 1
             run.completed.append((job, future))
             self._condition.notify_all()

--- a/src/metis/engine/execution/compiler.py
+++ b/src/metis/engine/execution/compiler.py
@@ -147,6 +147,7 @@ def compile_stage(
                         input_name,
                         initial_inputs[stage_input],
                         registration.inputs[input_name],
+                        collection=collection,
                     )
                     continue
                 producer_name, _, _output_name = source.partition(".")
@@ -314,9 +315,15 @@ def _validate_input_annotation(
     input_name: str,
     source: Any,
     target: Any,
+    *,
+    collection: bool = False,
 ) -> None:
-    target_origin = get_origin(target)
-    if target_origin is tuple:
+    if collection:
+        if get_origin(target) is not tuple:
+            raise ValueError(
+                f"Execution node {stage_name}.{node_name} input {input_name!r} "
+                "does not accept multiple sources"
+            )
         target = get_args(target)[0]
     if not _annotations_compatible(source, target):
         raise ValueError(

--- a/src/metis/engine/execution/runner.py
+++ b/src/metis/engine/execution/runner.py
@@ -404,6 +404,8 @@ def _validate_outputs(
 
 
 def _validate_value(annotation: Any, value: object) -> object:
+    if annotation is Any:
+        return value
     if get_origin(annotation) is None and isinstance(annotation, type):
         if not isinstance(value, annotation):
             raise ValueError(

--- a/src/metis/engine/external_stages/runner.py
+++ b/src/metis/engine/external_stages/runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from dataclasses import dataclass
 from string import Formatter
 from typing import Mapping
@@ -81,9 +82,12 @@ class ExternalStageRunner:
                 proc.communicate(),
                 timeout=stage.timeout_seconds,
             )
-        except TimeoutError as exc:
-            proc.kill()
+        except (TimeoutError, asyncio.CancelledError) as exc:
+            with suppress(ProcessLookupError):
+                proc.kill()
             stdout_bytes, stderr_bytes = await proc.communicate()
+            if isinstance(exc, asyncio.CancelledError):
+                raise
             result = ExternalStageProcessResult(
                 argv=argv,
                 returncode=proc.returncode if proc.returncode is not None else -1,

--- a/src/metis/engine/external_stages/schemas.py
+++ b/src/metis/engine/external_stages/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, constr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, constr
 
 from metis.engine.stages.triage.models import TriageDecisionModel
 
@@ -57,39 +57,9 @@ class ValidationRequestModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class ExternalValidationDecisionModel(BaseModel):
+class ExternalValidationDecisionModel(TriageDecisionModel):
     run_index: int = Field(ge=0)
     result_index: int = Field(ge=0)
-    status: Literal["valid", "invalid", "inconclusive"]
-    reason: constr(strip_whitespace=True, min_length=1)
-    evidence: list[constr(strip_whitespace=True, min_length=1)] = Field(
-        default_factory=list
-    )
-    resolution_chain: list[constr(strip_whitespace=True, min_length=1)] = Field(
-        default_factory=list
-    )
-    unresolved_hops: list[constr(strip_whitespace=True, min_length=1)] = Field(
-        default_factory=list
-    )
-
-    model_config = ConfigDict(extra="forbid")
-
-    @field_validator("unresolved_hops", mode="after")
-    @classmethod
-    def _validate_decision_shape(cls, value, info):
-        payload = dict(info.data)
-        payload["unresolved_hops"] = value
-        if "status" in payload and "reason" in payload:
-            TriageDecisionModel.model_validate(
-                {
-                    "status": payload.get("status"),
-                    "reason": payload.get("reason"),
-                    "evidence": payload.get("evidence") or [],
-                    "resolution_chain": payload.get("resolution_chain") or [],
-                    "unresolved_hops": payload.get("unresolved_hops") or [],
-                }
-            )
-        return value
 
     def triage_decision_metadata(self) -> dict[str, Any]:
         return {

--- a/src/metis/engine/external_stages/service.py
+++ b/src/metis/engine/external_stages/service.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
@@ -338,9 +339,9 @@ def _run_stage_and_log(
         result = runner.run_sync(stage, bindings=bindings)
     except ExternalStageExecutionError as exc:
         if exc.result is not None:
-            _write_process_log(log_path, exc.result)
+            _write_json(log_path, asdict(exc.result))
         raise
-    _write_process_log(log_path, result)
+    _write_json(log_path, asdict(result))
     return result
 
 
@@ -362,18 +363,6 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
-
-
-def _write_process_log(path: Path, result: ExternalStageProcessResult) -> None:
-    _write_json(
-        path,
-        {
-            "argv": list(result.argv),
-            "returncode": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-        },
-    )
 
 
 def _require_file(path: Path, label: str) -> None:

--- a/src/metis/engine/source/anchor.py
+++ b/src/metis/engine/source/anchor.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import asdict, dataclass, fields
 
 KIND_FUNCTION = "function"
 KIND_STATEMENT = "statement"
@@ -54,15 +54,8 @@ class CodeAnchor:
     content_hash: str = ""
     confidence: str = CONFIDENCE_EXACT
 
-    _FIELD_NAMES: frozenset[str] = field(
-        default=frozenset(), init=False, repr=False, compare=False
-    )
-
     def __post_init__(self):
         object.__setattr__(self, "file_path", normalize_path(self.file_path))
-        object.__setattr__(
-            self, "_FIELD_NAMES", frozenset(f.name for f in fields(self) if f.init)
-        )
 
     def display_id(self) -> str:
         sym = self.symbol or ""
@@ -73,9 +66,7 @@ class CodeAnchor:
         return f"{self.file_path}#{sym}~{self.content_hash}"
 
     def to_dict(self) -> dict:
-        d = asdict(self)
-        d.pop("_FIELD_NAMES", None)
-        return d
+        return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict | None) -> "CodeAnchor | None":

--- a/src/metis/engine/source/source_map.py
+++ b/src/metis/engine/source/source_map.py
@@ -548,14 +548,16 @@ class SourceMap:
 
 
 class SourceRepository:
-    """Process-wide LRU cache of :class:`SourceMap` keyed by (path, mtime, size)."""
+    """Process-wide LRU cache of source maps and their repository-relative paths."""
 
     _instance: "SourceRepository | None" = None
     _instance_lock = threading.Lock()
 
     def __init__(self, capacity: int = 256):
         self._capacity = capacity
-        self._cache: "OrderedDict[tuple[str, float, int], SourceMap]" = OrderedDict()
+        self._cache: "OrderedDict[tuple[str, str, float, int], SourceMap]" = (
+            OrderedDict()
+        )
         self._lock = threading.Lock()
 
     @classmethod
@@ -579,18 +581,18 @@ class SourceRepository:
             st = os.stat(full)
         except OSError:
             return None
-        key = (os.path.abspath(full), st.st_mtime, st.st_size)
+        key = (os.path.abspath(full), normalize_path(rel), st.st_mtime, st.st_size)
         with self._lock:
             smap = self._cache.get(key)
             if smap is not None:
                 self._cache.move_to_end(key)
                 return smap
         try:
-            with open(full, "r", encoding="utf-8", errors="ignore") as f:
-                text = f.read()
+            with open(full, "rb") as f:
+                source = f.read()
         except OSError:
             return None
-        smap = SourceMap(rel, text)
+        smap = SourceMap.for_bytes(rel, source)
         with self._lock:
             self._cache[key] = smap
             self._cache.move_to_end(key)

--- a/src/metis/memory/configuration.py
+++ b/src/metis/memory/configuration.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import model_validator
@@ -18,12 +20,20 @@ class MemoryCapabilityConfiguration(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def normalize_store(cls, value: object) -> dict[str, str]:
-        configured = value if isinstance(value, dict) else {}
-        spec = parse_memory_store_spec(
-            str(configured.get("location") or cls.model_fields["location"].default),
-            backend=str(
-                configured.get("backend") or cls.model_fields["backend"].default
-            ),
-        )
-        return {"backend": spec.backend, "location": spec.location}
+    def normalize_store(cls, value: object) -> object:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            return value
+        configured = value.copy()
+        for name in ("backend", "location"):
+            if configured.get(name) is None or configured[name] == "":
+                configured[name] = cls.model_fields[name].default
+        if isinstance(configured["backend"], str) and isinstance(
+            configured["location"], (str, Path)
+        ):
+            spec = parse_memory_store_spec(
+                configured["location"], backend=configured["backend"]
+            )
+            configured.update(backend=spec.backend, location=spec.location)
+        return configured

--- a/src/metis/memory/sqlite_store.py
+++ b/src/metis/memory/sqlite_store.py
@@ -297,7 +297,7 @@ def _fts_query(query: str) -> str:
 
 
 def _query_terms(query: str) -> list[str]:
-    return [term.lower() for term in re.findall(r"[A-Za-z0-9_]+", query)]
+    return [term.lower() for term in re.findall(r"\w+", query)]
 
 
 def _parse_datetime(value: str) -> datetime:

--- a/src/metis/plugins/aarch64_assembly_plugin.py
+++ b/src/metis/plugins/aarch64_assembly_plugin.py
@@ -1,54 +1,10 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from llama_index.core.node_parser import CodeSplitter, SentenceSplitter
+from llama_index.core.node_parser import SentenceSplitter
 
 from metis.plugins.base import ConfigBackedLanguagePlugin
-
-
-class _AsmNodeAdapter:
-    def __init__(self, node):
-        self._node = node
-
-    @property
-    def children(self):
-        return [
-            _AsmNodeAdapter(self._node.child(index))
-            for index in range(self._node.child_count())
-        ]
-
-    @property
-    def type(self):
-        return self._node.kind()
-
-    @property
-    def start_byte(self):
-        return self._node.start_byte()
-
-    @property
-    def end_byte(self):
-        return self._node.end_byte()
-
-
-class _AsmTreeAdapter:
-    def __init__(self, tree):
-        self._tree = tree
-
-    @property
-    def root_node(self):
-        return _AsmNodeAdapter(self._tree.root_node())
-
-
-class _AsmParserAdapter:
-    """Adapt py-tree-sitter style parsers to the interface CodeSplitter expects."""
-
-    def __init__(self, parser):
-        self._parser = parser
-
-    def parse(self, source):
-        if isinstance(source, bytes):
-            source = source.decode("utf-8", errors="ignore")
-        return _AsmTreeAdapter(self._parser.parse(source))
+from metis.plugins.base import build_code_splitter
 
 
 class AArch64AssemblyPlugin(ConfigBackedLanguagePlugin):
@@ -63,14 +19,13 @@ class AArch64AssemblyPlugin(ConfigBackedLanguagePlugin):
         max_chars = splitting_cfg.get("max_chars") or 2500
 
         try:
-            from tree_sitter_language_pack import get_parser
-
-            return CodeSplitter(
-                language="asm",
-                chunk_lines=chunk_lines,
-                chunk_lines_overlap=chunk_lines_overlap,
-                max_chars=max_chars,
-                parser=_AsmParserAdapter(get_parser("asm")),
+            return build_code_splitter(
+                "asm",
+                {
+                    "chunk_lines": chunk_lines,
+                    "chunk_lines_overlap": chunk_lines_overlap,
+                    "max_chars": max_chars,
+                },
             )
         except Exception:
             return SentenceSplitter(

--- a/src/metis/providers/config.py
+++ b/src/metis/providers/config.py
@@ -52,7 +52,7 @@ def build_provider_config(
     if api_key:
         config["api_key"] = api_key
 
-    return _compact_provider_config(config)
+    return config
 
 
 def _provider_config_spec(
@@ -172,14 +172,6 @@ def _optional_condition_matches(
         return False
     key, expected_value = optional_when
     return provider_config.get(key) == expected_value
-
-
-def _compact_provider_config(config: Mapping[str, object]) -> dict[str, object]:
-    return {
-        key: value
-        for key, value in config.items()
-        if value is not None and value != "" and value != {}
-    }
 
 
 def _is_missing(value: object) -> bool:

--- a/src/metis/providers/embedding_adapter.py
+++ b/src/metis/providers/embedding_adapter.py
@@ -33,10 +33,10 @@ class LangChainEmbeddingAdapter(BaseEmbedding):
         return await self._client.aembed_query(query)
 
     def _get_text_embedding(self, text: str) -> Embedding:
-        return self._client.embed_query(text)
+        return self._client.embed_documents([text])[0]
 
     async def _aget_text_embedding(self, text: str) -> Embedding:
-        return await self._client.aembed_query(text)
+        return (await self._client.aembed_documents([text]))[0]
 
     def _get_text_embeddings(self, texts: list[str]) -> list[Embedding]:
         return self._client.embed_documents(texts)

--- a/src/metis/providers/ollama.py
+++ b/src/metis/providers/ollama.py
@@ -48,6 +48,7 @@ class OllamaProvider(OpenAICompatibleChatProvider):
 class OllamaEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
     DEFAULT_BASE_URL = OllamaProvider.DEFAULT_BASE_URL
     DEFAULT_API_KEY = OllamaProvider.DEFAULT_API_KEY
+    DEFAULT_CHECK_EMBEDDING_CTX_LENGTH = False
     CONFIG_SPEC = ProviderConfigSpec(
         display_name="Ollama embeddings",
         required_keys=("code_embedding_model", "docs_embedding_model"),
@@ -60,6 +61,3 @@ class OllamaEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
             "docs_extra_kwargs",
         ),
     )
-
-    def __init__(self, config):
-        super().__init__(config)

--- a/src/metis/providers/registry.py
+++ b/src/metis/providers/registry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from importlib import metadata
-from importlib import import_module
 from typing import Literal, Type, TypeVar
 
 from metis.providers.base import ChatProvider
@@ -69,15 +68,17 @@ def _get_provider(
     if not dotted_path:
         raise ValueError(f"Unsupported {surface} provider: {name}")
 
-    module_path, class_name = dotted_path.split(":", 1)
     try:
-        module = import_module(module_path)
+        provider_cls = metadata.EntryPoint(
+            name=f"{name}.{surface}",
+            value=dotted_path,
+            group=_PROVIDER_ENTRY_POINT_GROUP,
+        ).load()
     except ModuleNotFoundError as exc:
         raise ModuleNotFoundError(
             f"{surface.capitalize()} provider '{name}' is registered but required "
             "dependencies are missing."
         ) from exc
-    provider_cls = getattr(module, class_name)
     providers[key] = provider_cls
     return provider_cls
 

--- a/src/metis/providers/vllm.py
+++ b/src/metis/providers/vllm.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
-
 from metis.providers.openai_compatible import OpenAICompatibleChatProvider
 from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
 from metis.providers.config import ApiKeySources
@@ -10,10 +8,8 @@ from metis.providers.config import ProviderConfigSpec
 from metis.utils import count_tokens as count_tokens_for_model
 
 
-logger = logging.getLogger(__name__)
-
-
 class VLLMProvider(OpenAICompatibleChatProvider):
+    DEFAULT_API_KEY = "sk-no-key-required"
     CONFIG_SPEC = ProviderConfigSpec(
         display_name="vLLM",
         required_keys=("base_url", "model"),
@@ -26,14 +22,13 @@ class VLLMProvider(OpenAICompatibleChatProvider):
         if not self.base_url:
             raise ValueError("vLLM provider requires 'base_url' to be configured")
 
-        if not self.api_key:
-            logger.debug("vLLM provider running without API key")
-
     def count_tokens(self, text: str, model: str | None = None) -> int:
         return count_tokens_for_model(text, model or self.default_model)
 
 
 class VLLMEmbeddingProvider(OpenAICompatibleEmbeddingProvider):
+    DEFAULT_API_KEY = VLLMProvider.DEFAULT_API_KEY
+    DEFAULT_CHECK_EMBEDDING_CTX_LENGTH = False
     CONFIG_SPEC = ProviderConfigSpec(
         display_name="vLLM embeddings",
         required_keys=("base_url", "code_embedding_model", "docs_embedding_model"),

--- a/src/metis/runlog/session.py
+++ b/src/metis/runlog/session.py
@@ -228,7 +228,6 @@ class RunLogSession:
         created_ndjson = False
         try:
             self.output_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-            self.output_dir.chmod(0o700)
             self._file = self.ndjson_path.open("x", encoding="utf-8", buffering=1)
             created_ndjson = True
             self.ndjson_path.chmod(0o600)

--- a/src/metis/sarif/writer.py
+++ b/src/metis/sarif/writer.py
@@ -128,12 +128,18 @@ def generate_sarif(
             anchor = (
                 issue.get("anchor") if isinstance(issue.get("anchor"), dict) else None
             )
-            anchor_start = (
-                int(anchor["start_line"]) if anchor and anchor.get("start_line") else 0
-            )
-            anchor_end = (
-                int(anchor["end_line"]) if anchor and anchor.get("end_line") else 0
-            )
+            anchor_start = anchor_end = 0
+            anchor_fp = None
+            if anchor:
+                try:
+                    anchor_start = int(anchor["start_line"])
+                    anchor_end = int(anchor["end_line"])
+                    if anchor_start < 0 or anchor_end < anchor_start:
+                        raise ValueError("Invalid anchor line range")
+                    anchor_fp = anchor_fingerprint(anchor)
+                except (KeyError, TypeError, ValueError, OverflowError):
+                    anchor = None
+                    anchor_start = anchor_end = 0
             reported_line_num = _normalise_line_number(
                 anchor_start or issue.get("line_number", 1)
             )
@@ -148,7 +154,6 @@ def generate_sarif(
             fingerprint = create_fingerprint(
                 file_path or artifact_uri, line_num, RULES[0]["id"]
             )
-            anchor_fp = anchor_fingerprint(anchor) if anchor else None
 
             # Prefer model-provided snippet; fall back to file content if available
             if snippet_override:

--- a/src/metis/usage/llamaindex.py
+++ b/src/metis/usage/llamaindex.py
@@ -94,6 +94,10 @@ class UsageLlamaIndexHandler(BaseCallbackHandler):
         event_id: str = "",
         **kwargs: Any,
     ) -> None:
+        pending_model = "unknown"
+        if event_type == CBEventType.EMBEDDING and event_id:
+            with self._embedding_models_lock:
+                pending_model = self._embedding_models.pop(event_id, "unknown")
         scope_id = current_scope()
         if not scope_id:
             return
@@ -118,12 +122,8 @@ class UsageLlamaIndexHandler(BaseCallbackHandler):
         if not isinstance(chunks, list) or not chunks:
             return
         model_name = _extract_embedding_model(payload)
-        if model_name == "unknown" and event_id:
-            with self._embedding_models_lock:
-                model_name = self._embedding_models.pop(event_id, "unknown")
-        elif event_id:
-            with self._embedding_models_lock:
-                self._embedding_models.pop(event_id, None)
+        if model_name == "unknown":
+            model_name = pending_model
         input_tokens = 0
         for chunk in chunks:
             text = str(chunk or "")

--- a/src/metis/usage/runtime.py
+++ b/src/metis/usage/runtime.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import json
 from pathlib import Path
 from threading import Lock
 from typing import Any, Iterator
@@ -15,6 +14,7 @@ from .collector import UsageCollector
 from .context import usage_operation, usage_scope
 from .langchain import UsageCallbackHandler
 from .llamaindex import UsageLlamaIndexHandler
+from metis.json_io import write_json_atomic
 from metis.runlog.langchain import RUNLOG_CALLBACK_HANDLER
 
 from metis.providers.base import (
@@ -159,5 +159,5 @@ class UsageRuntime:
         target = Path(output_path or self.default_output_path())
         payload = self.build_persisted_payload()
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        write_json_atomic(target, payload, indent=2)
         return str(target)

--- a/src/metis/vector_store/chroma_store.py
+++ b/src/metis/vector_store/chroma_store.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from contextlib import suppress
 from threading import RLock
 
 from chromadb import PersistentClient
 from chromadb.config import Settings
+from chromadb.errors import NotFoundError
 from llama_index.core import StorageContext
 from llama_index.vector_stores.chroma import ChromaVectorStore
 
@@ -35,6 +37,7 @@ class ChromaStore(LlamaIndexVectorBackend):
         with self._init_lock:
             if self._initialized:
                 return
+            client = None
             try:
                 settings = Settings(anonymized_telemetry=False)
                 # Ensure this local store always uses Chroma's embedded backend.
@@ -51,8 +54,11 @@ class ChromaStore(LlamaIndexVectorBackend):
                 logger.info("Chroma vector components initialized.")
 
             except Exception as e:
+                if client is not None:
+                    with suppress(Exception):
+                        client.close()
                 logger.error(f"Error initializing ChromaStore: {e}")
-                raise VectorStoreInitError()
+                raise VectorStoreInitError() from e
 
     def get_retrievers(
         self,
@@ -67,25 +73,17 @@ class ChromaStore(LlamaIndexVectorBackend):
                 self.query_config,
                 callbacks=callbacks,
             )
-            retriever_code = QueryAnswerRetriever(
-                ChromaCollectionRetriever(
-                    self.collection_code,
-                    self.embed_model_code,
-                    k=top_k,
-                ),
-                llm_provider,
-                chat_model_kwargs=chat_model_kwargs,
+            return tuple(
+                QueryAnswerRetriever(
+                    ChromaCollectionRetriever(collection, embed_model, k=top_k),
+                    llm_provider,
+                    chat_model_kwargs=chat_model_kwargs,
+                )
+                for collection, embed_model in (
+                    (self.collection_code, self.embed_model_code),
+                    (self.collection_docs, self.embed_model_docs),
+                )
             )
-            retriever_docs = QueryAnswerRetriever(
-                ChromaCollectionRetriever(
-                    self.collection_docs,
-                    self.embed_model_docs,
-                    k=top_k,
-                ),
-                llm_provider,
-                chat_model_kwargs=chat_model_kwargs,
-            )
-            return (retriever_code, retriever_docs)
         except Exception as e:
             logger.error(f"Error creating Chroma retrievers: {e}")
             raise RetrieverInitError()
@@ -115,7 +113,7 @@ class ChromaStore(LlamaIndexVectorBackend):
         for name in ("code", "docs"):
             try:
                 self._client.delete_collection(name)
-            except Exception:
+            except NotFoundError:
                 logger.debug("Chroma collection '%s' did not exist during reset", name)
         code_collection = self._client.get_or_create_collection("code")
         docs_collection = self._client.get_or_create_collection("docs")

--- a/src/metis/vector_store/llama_index_backend.py
+++ b/src/metis/vector_store/llama_index_backend.py
@@ -13,8 +13,6 @@ from metis.vector_store.retrievers import query_chat_model_kwargs
 class LlamaIndexVectorBackend(BaseVectorStore):
     """Shared behavior for backends exposed through LlamaIndex vector stores."""
 
-    index_class = VectorStoreIndex
-
     def get_retrievers(
         self,
         llm_provider,
@@ -56,7 +54,7 @@ class LlamaIndexVectorBackend(BaseVectorStore):
             (embed_model_code, embed_model_docs),
             strict=True,
         ):
-            self.index_class(
+            VectorStoreIndex(
                 nodes,
                 storage_context=storage_context,
                 embed_model=embed_model,
@@ -87,7 +85,7 @@ class LlamaIndexVectorBackend(BaseVectorStore):
             self.embed_model_docs,
         )
         return tuple(
-            self.index_class.from_vector_store(
+            VectorStoreIndex.from_vector_store(
                 vector_store,
                 storage_context=storage_context,
                 embed_model=embed_model,

--- a/src/metis/vector_store/qdrant_store.py
+++ b/src/metis/vector_store/qdrant_store.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from contextlib import suppress
 
 from llama_index.core import StorageContext
-from llama_index.core import VectorStoreIndex
 from llama_index.vector_stores.qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient
 from qdrant_client.models import Distance
@@ -15,21 +14,7 @@ from qdrant_client.models import VectorParams
 from metis.vector_store.llama_index_backend import LlamaIndexVectorBackend
 
 
-class QdrantVectorStoreIndex(VectorStoreIndex):
-    """Vector index that updates documents stored in Qdrant."""
-
-    def refresh_ref_docs(self, documents, **update_kwargs):
-        for document in documents:
-            self.update_ref_doc(
-                document,
-                **update_kwargs.get("update_kwargs", {}),
-            )
-        return [True] * len(documents)
-
-
 class QdrantStore(LlamaIndexVectorBackend):
-    index_class = QdrantVectorStoreIndex
-
     def __init__(
         self,
         *,
@@ -54,7 +39,12 @@ class QdrantStore(LlamaIndexVectorBackend):
         if self._client is not None:
             return
         client = QdrantClient(url=self.url, api_key=self.api_key)
-        components = self._build_store_components(client)
+        try:
+            components = self._build_store_components(client)
+        except Exception:
+            with suppress(Exception):
+                client.close()
+            raise
 
         (
             self.vector_store_code,

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
+from contextlib import closing, nullcontext
 from pathlib import Path
 import sqlite3
 from types import SimpleNamespace
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 from metis.cli import commands
+from metis.cli import review_checkpoints
 from metis.cli.command_runtime import CommandRuntime
 from metis.cli.review_checkpoints import review_checkpoint_callbacks
 from metis.cli.review_progress import ExecutionGraphProgressReporter
@@ -391,6 +392,35 @@ def test_review_producers_keep_separate_resumable_outputs(tmp_path):
     assert other_output["review_resume_callback"]("simple_llm_review") == {
         "file:key": simple.record,
         "file:next": {"reviews": [{"issue": "next"}]},
+    }
+
+
+def test_review_checkpoint_reader_preserves_locked_database(monkeypatch, tmp_path):
+    callbacks = review_checkpoint_callbacks(codebase_path=tmp_path, enabled=True)
+    record = ReviewCheckpointRecord(
+        metis_version=METIS_VERSION,
+        producer="simple_llm_review",
+        key="file:key",
+        record={"reviews": []},
+    )
+    callbacks["review_checkpoint_callback"](record.model_dump(mode="json"), 1, 1)
+    checkpoint_path = (
+        tmp_path / ".metis" / "checkpoints" / "review.simple_llm_review.sqlite3"
+    )
+    connect = review_checkpoints._connect_checkpoint
+
+    def connect_without_wait(path):
+        connection = connect(path)
+        connection.execute("PRAGMA busy_timeout = 0")
+        return connection
+
+    monkeypatch.setattr(review_checkpoints, "_connect_checkpoint", connect_without_wait)
+    with closing(sqlite3.connect(checkpoint_path)) as blocker:
+        blocker.execute("BEGIN EXCLUSIVE")
+        assert callbacks["review_resume_callback"]("simple_llm_review") is None
+
+    assert callbacks["review_resume_callback"]("simple_llm_review") == {
+        "file:key": record.record
     }
 
 

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -99,6 +99,52 @@ def test_execute_command_allows_interactive_ask_with_global_triage_flag(monkeypa
     assert calls == [("ask", ["hi"])]
 
 
+def test_interactive_output_override_does_not_replace_global_output(monkeypatch):
+    args = SimpleNamespace(quiet=True, output_file=["global.json"])
+    engine = SimpleNamespace(usage_command=lambda *_args, **_kwargs: None)
+    outputs = []
+    monkeypatch.setattr(
+        command_registry.CommandSpec,
+        "invoke",
+        lambda self, engine, cmd_args, command_args, runtime: outputs.append(
+            command_args.output_file
+        ),
+    )
+
+    entry.execute_command(
+        engine, "review_file", ["source.py", "--output-file", "override.json"], args
+    )
+    entry.execute_command(engine, "review_file", ["source.py"], args)
+
+    assert outputs == [["override.json"], ["global.json"]]
+    assert args.output_file == ["global.json"]
+
+
+def test_interactive_loop_parses_quoted_paths_and_recovers_from_bad_quotes(monkeypatch):
+    inputs = iter(
+        [
+            "review_file 'unterminated",
+            r'review_file "source file.py" --output-file report\ file.json',
+            "exit",
+        ]
+    )
+    monkeypatch.setattr(entry, "prompt", lambda *_args, **_kwargs: next(inputs))
+    monkeypatch.setattr(entry, "PG_SUPPORTED", False)
+    calls = []
+
+    def execute(engine, cmd, cmd_args, args):
+        calls.append((cmd, cmd_args))
+        return entry.EXIT_REQUESTED if cmd == "exit" else None
+
+    monkeypatch.setattr(entry, "execute_command", execute)
+
+    assert entry.run_interactive_loop(None, SimpleNamespace(quiet=True), None)
+    assert calls == [
+        ("review_file", ["source file.py", "--output-file", "report file.json"]),
+        ("exit", []),
+    ]
+
+
 def test_main_version_does_not_require_runtime_config(monkeypatch, capsys):
     def fail_load_runtime_config(*_args, **_kwargs):
         raise AssertionError("runtime config should not be loaded for --version")

--- a/tests/test_cli_triage.py
+++ b/tests/test_cli_triage.py
@@ -36,12 +36,18 @@ def test_save_output_propagates_export_failure(
         save_output(tmp_path / f"report{suffix}", {"reviews": []}, quiet=True)
 
 
-def test_save_output_replaces_json_only_after_serialization_succeeds(tmp_path):
-    output_path = tmp_path / "report.json"
+@pytest.mark.parametrize("suffix", ("json", "sarif"))
+def test_save_output_replaces_json_only_after_serialization_succeeds(tmp_path, suffix):
+    output_path = tmp_path / f"report.{suffix}"
     output_path.write_text('{"original": true}', encoding="utf-8")
 
     with pytest.raises(TypeError):
-        save_output(output_path, {"invalid": object()}, quiet=True)
+        save_output(
+            output_path,
+            {"invalid": object()},
+            quiet=True,
+            sarif_payload={"invalid": object()},
+        )
 
     assert output_path.read_text(encoding="utf-8") == '{"original": true}'
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -10,6 +10,7 @@ from metis.configuration import build_embedding_provider_config
 from metis.configuration import load_execution_config
 from metis.configuration import load_metis_config
 from metis.configuration import load_runtime_config
+from metis.configuration import pgvector_use_halfvec_setting
 from metis.runtime_settings import CapabilityRuntimeSettings
 from metis.runtime_settings import ModelToolSettings
 from metis.runtime_settings import TriageOptions
@@ -371,6 +372,8 @@ llm_provider:
     ("path", "value", "message"),
     [
         (("model_tools", "max_contract_chars"), 0, "max_contract_chars"),
+        (("model_tools",), "disabled", "model_tools must be a mapping"),
+        (("model_tools",), False, "model_tools must be a mapping"),
     ],
 )
 def test_load_runtime_config_rejects_invalid_tool_limits(
@@ -427,6 +430,12 @@ llm_provider:
         "enabled": True,
         "max_commits": 75,
     }
+
+
+@pytest.mark.parametrize("value", (2, [], "invalid"))
+def test_pgvector_halfvec_rejects_invalid_flags(value):
+    with pytest.raises(ValueError, match="pgvector_use_halfvec"):
+        pgvector_use_halfvec_setting(value, 3072)
 
 
 def test_load_runtime_config_accepts_pgvector_halfvec_flag(tmp_path, monkeypatch):

--- a/tests/test_engine_chroma.py
+++ b/tests/test_engine_chroma.py
@@ -2,14 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+from chromadb.errors import NotFoundError
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from llama_index.core.settings import Settings
 
 from metis.cli.utils import build_chroma_backend
 from metis.engine import MetisEngine
+from metis.exceptions import VectorStoreInitError
 from metis.vector_store.chroma_store import ChromaStore
 
 
@@ -86,6 +89,7 @@ def test_chroma_store_reset_recreates_collections(tmp_path):
 
     with patch("metis.vector_store.chroma_store.PersistentClient") as client_ctor:
         client = client_ctor.return_value
+        client.delete_collection.side_effect = [None, NotFoundError("missing")]
         collections = [object(), object(), object(), object()]
         client.get_or_create_collection.side_effect = collections
 
@@ -107,6 +111,10 @@ def test_chroma_store_reset_recreates_collections(tmp_path):
     client.delete_collection.assert_any_call("code")
     client.delete_collection.assert_any_call("docs")
     assert client.get_or_create_collection.call_count == 4
+    client.delete_collection.side_effect = RuntimeError("storage failure")
+    with pytest.raises(RuntimeError, match="storage failure"):
+        backend.reset_index()
+    assert client.get_or_create_collection.call_count == 4
 
 
 def test_build_chroma_backend_receives_retriever_query_config(tmp_path):
@@ -122,10 +130,37 @@ def test_build_chroma_backend_receives_retriever_query_config(tmp_path):
     class _Args:
         chroma_dir = str(tmp_path / "chroma_test")
 
-    backend = build_chroma_backend(_Args(), runtime, embed, embed)
+    docs_embed = MockEmbedding(embed_dim=16)
+    backend = build_chroma_backend(_Args(), runtime, embed, docs_embed)
 
     assert backend.query_config == {
         "llama_query_model": "gpt-test",
         "chat_model_kwargs": {"reasoning_effort": "low"},
         "similarity_top_k": 7,
     }
+    backend.collection_code, backend.collection_docs = object(), object()
+    assert [
+        (item._retriever._collection, item._retriever._embed_model, item._retriever._k)
+        for item in backend.get_retrievers(Mock())
+    ] == [
+        (backend.collection_code, embed, 7),
+        (backend.collection_docs, docs_embed, 7),
+    ]
+
+
+def test_chroma_failed_init_closes_client_without_masking_error(tmp_path):
+    backend = ChromaStore(str(tmp_path), Mock(), Mock(), {})
+    failure = RuntimeError("component failure")
+    with (
+        patch("metis.vector_store.chroma_store.PersistentClient") as client_constructor,
+        patch.object(backend, "_set_collections", side_effect=failure),
+    ):
+        client = client_constructor.return_value
+        client.close.side_effect = RuntimeError("close failure")
+        with pytest.raises(VectorStoreInitError) as raised:
+            backend.init()
+
+    assert raised.value.__cause__ is failure
+    client.close.assert_called_once_with()
+    assert backend._client is None
+    assert not backend._initialized

--- a/tests/test_execution_graph.py
+++ b/tests/test_execution_graph.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from typing import Any
 from typing import Literal
 from unittest.mock import Mock
+from unittest.mock import sentinel
 
 import pytest
 from pydantic import BaseModel
@@ -1428,6 +1429,76 @@ def test_explicit_input_resolves_an_implicit_binding_ambiguity():
     result = run_stage("initialize", plan, _node_context(), {})
 
     assert result.outputs["consumer"] == "first"
+
+
+@pytest.mark.parametrize(
+    ("bindings", "source_annotation", "target_annotation", "value", "expected"),
+    (
+        ({}, Any, Any, sentinel.value, sentinel.value),
+        (
+            {},
+            tuple[str, ...],
+            tuple[str, ...],
+            ("first", "second"),
+            ("first", "second"),
+        ),
+        ({"values": ["$inputs.values"]}, str, tuple[str, ...], "first", ("first",)),
+    ),
+)
+def test_stage_inputs_preserve_any_and_tuple_values(
+    bindings, source_annotation, target_annotation, value, expected
+):
+    registration = NodeRegistration(
+        "echo",
+        "initialize",
+        EmptyNodeConfiguration,
+        {"values": target_annotation},
+        {"values": target_annotation},
+        lambda invocation: NodeResult({"values": invocation.inputs["values"]}),
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"echo": {"inputs": bindings}}})
+    plan = compile_stage(
+        NodeCatalog((registration,), ()),
+        "initialize",
+        stage,
+        {},
+        {"values": source_annotation},
+    )
+
+    result = run_stage("initialize", plan, _node_context(), {"values": value})
+
+    assert result.status is ExecutionStatus.OK
+    assert result.outputs["echo"] == expected
+
+
+@pytest.mark.parametrize(
+    ("bindings", "target_annotation"),
+    (
+        ({"values": "$inputs.values"}, tuple[str, ...]),
+        ({"values": ["$inputs.values"]}, str),
+    ),
+)
+def test_stage_inputs_reject_scalar_and_collection_mismatches(
+    bindings, target_annotation
+):
+    registration = NodeRegistration(
+        "echo",
+        "initialize",
+        EmptyNodeConfiguration,
+        {"values": target_annotation},
+        {"values": target_annotation},
+        lambda invocation: NodeResult({"values": invocation.inputs["values"]}),
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"echo": {"inputs": bindings}}})
+
+    with pytest.raises(ValueError, match="incompatible|multiple sources"):
+        compile_stage(
+            NodeCatalog((registration,), ()),
+            "initialize",
+            stage,
+            {},
+            {"values": str},
+        )
 
 
 def test_collection_input_collects_all_compatible_producers():

--- a/tests/test_external_stages.py
+++ b/tests/test_external_stages.py
@@ -3,12 +3,55 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 import pytest
+from pydantic import ValidationError
 
+from metis.engine.external_stages.schemas import ExternalValidationDecisionModel
+from metis.engine.external_stages.schemas import ExternalStageCommandModel
+from metis.engine.external_stages.runner import ExternalStageRunner
 from metis.engine.external_stages.service import ExternalStageService
+
+
+@pytest.mark.parametrize(
+    "fields",
+    (
+        {"status": "valid"},
+        {"status": "valid", "evidence": ["source.c:1"]},
+        {"status": "inconclusive"},
+    ),
+)
+def test_external_validation_decision_validates_missing_evidence(fields):
+    payload = {"run_index": 0, "result_index": 0, "reason": "Checked.", **fields}
+
+    with pytest.raises(ValidationError):
+        ExternalValidationDecisionModel.model_validate(payload)
+
+
+@pytest.mark.parametrize("already_exited", (False, True))
+def test_external_stage_cancellation_reaps_process(monkeypatch, already_exited):
+    process = Mock(returncode=-9)
+    process.communicate = AsyncMock(side_effect=[asyncio.CancelledError(), (b"", b"")])
+    if already_exited:
+        process.kill.side_effect = ProcessLookupError()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=process)
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            ExternalStageRunner().run(
+                ExternalStageCommandModel(command=["local-test"]), bindings={}
+            )
+        )
+
+    process.kill.assert_called_once_with()
+    assert process.communicate.await_count == 2
 
 
 def test_external_stage_pipeline_invokes_black_boxes_and_applies_decisions(tmp_path):

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from importlib.resources import files
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_chart_tooltips_encode_labels_and_paths():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required to execute the report formatters")
+
+    template = files("metis.cli").joinpath("report_template.html").read_text()
+    severity_formatter = template.split("formatter: params => ", 1)[1].split("\n", 1)[0]
+    treemap_formatter = template.split("formatter: info => ", 1)[1].split(
+        "\n                },", 1
+    )[0]
+    script = r"""
+const assert = require('node:assert/strict');
+// Stand in for the existing ECharts encoder; exercise the actual formatters.
+const echarts = {format: {encodeHTML: value => String(value).replace(/[<>&]/g,
+    char => ({'<': '&lt;', '>': '&gt;', '&': '&amp;'}[char]))}};
+const severityRank = {};
+const severityFormatter = (__SEVERITY_FORMATTER__);
+const treemapFormatter = (__TREEMAP_FORMATTER__);
+assert.equal(severityFormatter({name: 'High <>&', value: 2}),
+    'High &lt;&gt;&amp;: 2');
+assert.equal(treemapFormatter({data: {
+    isFile: true, fullPath: 'folder/<>&.c', severity: 'High <>&',
+    severityCounts: {'High <>&': 2}, filterType: 'file'
+}}), '<strong>folder/&lt;&gt;&amp;.c</strong><br/>Severity: High &lt;&gt;&amp;'
+    + '<br/>Total issues: 2<br/>High &lt;&gt;&amp;: 2<br/>Click to filter by file');
+"""
+    script = script.replace(
+        "__SEVERITY_FORMATTER__", "params => " + severity_formatter
+    ).replace("__TREEMAP_FORMATTER__", "info => " + treemap_formatter)
+    subprocess.run(
+        [node, "-e", script], check=True, capture_output=True, text=True, timeout=10
+    )

--- a/tests/test_indexing_updates.py
+++ b/tests/test_indexing_updates.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from llama_index.core import VectorStoreIndex
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.schema import Document
+from llama_index.core.vector_stores.simple import SimpleVectorStore
+
+
+def test_modified_patch_replaces_vectors_with_fresh_index_handles(
+    engine, dummy_backend
+):
+    embed = MockEmbedding(embed_dim=8)
+    store = SimpleVectorStore()
+    store.stores_text = True
+    codebase = Path(engine._config.codebase_path)
+    doc_id = f"{codebase.name}/update.c"
+    original_index = VectorStoreIndex.from_vector_store(store, embed_model=embed)
+    original_index.insert(Document(text="int before;", id_=doc_id))
+    original_index.insert(Document(text="int untouched;", id_="untouched"))
+    original_nodes = set(store.data.embedding_dict)
+
+    updated_index = VectorStoreIndex.from_vector_store(store, embed_model=embed)
+    assert updated_index.docstore.get_document_hash(doc_id) is None
+    dummy_backend.get_index_handles.return_value = (updated_index, Mock())
+    (codebase / "update.c").write_text("int after;", encoding="utf-8")
+    engine.indexing.update_index(
+        "--- a/update.c\n+++ b/update.c\n@@ -1 +1 @@\n-int before;\n+int after;\n"
+    )
+    references = store.data.text_id_to_ref_doc_id
+    assert sorted(references.values()) == sorted([doc_id, "untouched"])
+    assert len(original_nodes & references.keys()) == 1

--- a/tests/test_memory_backend.py
+++ b/tests/test_memory_backend.py
@@ -66,7 +66,7 @@ def test_sqlite_memory_store_search_filter_namespaces_and_delete(tmp_path):
             "memory_type": "semantic",
             "metadata": {"authority": "documented"},
             "summary_text": "CLI accepts untrusted SARIF files",
-            "search_text": "cli sarif trust boundary",
+            "search_text": "cli sarif trust boundary 安全",
         },
     )
     store.put(
@@ -92,6 +92,9 @@ def test_sqlite_memory_store_search_filter_namespaces_and_delete(tmp_path):
 
     assert [(item.namespace, item.key) for item in results] == [
         (("metis", "profiles", "repo1"), "target_profile")
+    ]
+    assert [item.key for item in store.search(("metis",), query="安全")] == [
+        "target_profile"
     ]
     assert store.list_namespaces(prefix=("metis",), max_depth=2) == [
         ("metis", "history"),

--- a/tests/test_memory_registry.py
+++ b/tests/test_memory_registry.py
@@ -62,6 +62,7 @@ def test_runtime_configuration_rejects_invalid_memory_values(tmp_path, value):
     path = tmp_path / "metis.yaml"
     path.write_text(
         f"memory: {value}\nllm_provider:\n  name: openai\n  model: gpt-test\n"
+        "  api_key: test-key\n"
     )
     with pytest.raises(ValidationError):
         load_runtime_config(path)

--- a/tests/test_memory_registry.py
+++ b/tests/test_memory_registry.py
@@ -3,7 +3,12 @@
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
+from metis.configuration import load_runtime_config
 from metis.memory import SQLiteMemoryStore
+from metis.memory.configuration import MemoryCapabilityConfiguration
 from metis.memory.registry import build_memory_store
 from metis.memory.registry import MemoryStoreSpec
 from metis.memory.registry import parse_memory_store_spec
@@ -38,3 +43,25 @@ def test_memory_store_factory_uses_registered_backend():
     assert captured == [
         MemoryStoreSpec(backend="unit-test-backend", location="unit-test-location")
     ]
+
+
+def test_memory_configuration_preserves_defaults_and_normalization(tmp_path):
+    defaults = MemoryCapabilityConfiguration()
+    for value in (None, {"backend": None, "location": ""}):
+        assert MemoryCapabilityConfiguration.model_validate(value) == defaults
+    value = {"backend": " SQLite ", "location": tmp_path / "memory.sqlite3"}
+    configuration = MemoryCapabilityConfiguration.model_validate(value)
+    assert configuration.backend == "sqlite"
+    assert configuration.location == str(value["location"])
+
+
+@pytest.mark.parametrize(
+    "value", ["{locaton: custom.sqlite3}", "{backend: 123}", "{location: false}", "[]"]
+)
+def test_runtime_configuration_rejects_invalid_memory_values(tmp_path, value):
+    path = tmp_path / "metis.yaml"
+    path.write_text(
+        f"memory: {value}\nllm_provider:\n  name: openai\n  model: gpt-test\n"
+    )
+    with pytest.raises(ValidationError):
+        load_runtime_config(path)

--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -1,12 +1,19 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from typing import Any, cast
+from unittest.mock import Mock
 
+import pytest
+
+from langchain_core.embeddings import Embeddings
 from langchain_openai import ChatOpenAI
 
 from metis.providers.embedding_adapter import LangChainEmbeddingAdapter
 from metis.providers.llamacpp import LlamaCppEmbeddingProvider
+from metis.providers.ollama import OllamaEmbeddingProvider
+from metis.providers.vllm import VLLMProvider, VLLMEmbeddingProvider
 from metis.providers.openai_compatible import OpenAICompatibleChatConfig
 from metis.providers.openai_compatible import OpenAICompatibleChatProvider
 from metis.providers.openai_compatible import OpenAICompatibleEmbeddingConfig
@@ -111,3 +118,41 @@ def test_embedding_provider_builds_separate_code_and_docs_models() -> None:
         llama_provider.get_embed_model_docs(),
     ):
         assert cast(Any, embedding._client).check_embedding_ctx_length is False
+
+
+@pytest.mark.parametrize(
+    "provider_cls", [OllamaEmbeddingProvider, VLLMEmbeddingProvider]
+)
+def test_local_embeddings_allow_overriding_raw_text_default(provider_cls) -> None:
+    provider = provider_cls(
+        _embedding_config(
+            base_url="http://localhost:8000/v1",
+            code_extra_kwargs={"check_embedding_ctx_length": True},
+        )
+    )
+    assert provider.get_embed_model_code()._client.check_embedding_ctx_length is True
+    assert provider.get_embed_model_docs()._client.check_embedding_ctx_length is False
+
+
+def test_vllm_accepts_missing_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    chat = VLLMProvider(
+        _chat_config(api_key=None, base_url="http://localhost:8000/v1")
+    ).get_chat_model()
+    embedding = VLLMEmbeddingProvider(
+        _embedding_config(api_key=None, base_url="http://localhost:8000/v1")
+    ).get_embed_model_code()
+    assert chat.openai_api_key.get_secret_value() == "sk-no-key-required"
+    assert embedding._client.openai_api_key.get_secret_value() == "sk-no-key-required"
+
+
+def test_single_text_embeddings_use_document_mode() -> None:
+    client = Mock(spec=Embeddings)
+    client.embed_documents.return_value = [[2.0]]
+    client.aembed_documents.return_value = [[2.0]]
+    adapter = LangChainEmbeddingAdapter(client, model_name="test-model")
+
+    assert adapter.get_text_embedding("text") == [2.0]
+    assert asyncio.run(adapter.aget_text_embedding("text")) == [2.0]
+    client.embed_documents.assert_called_once_with(["text"])
+    client.aembed_documents.assert_awaited_once_with(["text"])

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from unittest.mock import Mock
 
 import pytest
 from llama_index.core.schema import Document
@@ -12,7 +13,13 @@ from metis.plugins.ipynb_plugin import IpynbPlugin
 from metis.plugins.registry import LanguagePluginRegistry
 
 
-def test_aarch64_assembly_splitter_parses_source_text():
+@pytest.mark.parametrize("parser_available", (True, False))
+def test_aarch64_assembly_splitter_parses_source_text(monkeypatch, parser_available):
+    if not parser_available:
+        monkeypatch.setattr(
+            "metis.plugins.aarch64_assembly_plugin.build_code_splitter",
+            Mock(side_effect=RuntimeError("parser unavailable")),
+        )
     plugin = AArch64AssemblyPlugin(plugin_config={"plugins": {}})
     splitter = plugin.get_splitter()
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -66,6 +66,29 @@ def test_registry_rejects_embedding_for_chat_only_providers(name):
 def test_registry_reuses_loaded_provider(get_provider) -> None:
     provider_cls = get_provider("openai")
 
-    with patch("metis.providers.registry.import_module") as import_module:
+    with patch("metis.providers.registry.metadata.EntryPoint.load") as load:
         assert get_provider("OPENAI") is provider_cls
-    import_module.assert_not_called()
+    load.assert_not_called()
+
+
+def test_registry_loads_nested_entry_point_with_extras(monkeypatch):
+    from types import SimpleNamespace
+
+    from metis.providers import registry
+    from metis.providers.base import ChatProvider
+
+    monkeypatch.setattr(
+        registry, "example", SimpleNamespace(Provider=ChatProvider), raising=False
+    )
+    monkeypatch.setattr(registry, "_PROVIDER_LOADERS_DISCOVERED", True)
+    monkeypatch.setattr(registry, "_CHAT_PROVIDERS", {})
+    monkeypatch.setattr(
+        registry,
+        "_PROVIDER_LOADERS",
+        {
+            "example": registry.ProviderLoader(
+                chat="metis.providers.registry:example.Provider [extra]"
+            )
+        },
+    )
+    assert get_chat_provider("example") is ChatProvider

--- a/tests/test_qdrant_store.py
+++ b/tests/test_qdrant_store.py
@@ -3,14 +3,12 @@
 
 from types import SimpleNamespace
 from unittest.mock import Mock
-from unittest.mock import call
 
 import pytest
 from qdrant_client.models import Distance
 
 from metis.vector_store import qdrant_store
 from metis.vector_store.qdrant_store import QdrantStore
-from metis.vector_store.qdrant_store import QdrantVectorStoreIndex
 
 
 @pytest.fixture
@@ -71,24 +69,13 @@ def test_init_creates_collections_once(qdrant):
 
 
 def test_failed_init_does_not_publish_partial_state(qdrant):
+    qdrant.client.close.side_effect = RuntimeError("close failure")
     qdrant.context_constructor.side_effect = RuntimeError("context failure")
 
     with pytest.raises(RuntimeError, match="context failure"):
         qdrant.backend.init()
 
+    qdrant.client.close.assert_called_once_with()
     assert qdrant.backend._client is None
     assert not hasattr(qdrant.backend, "vector_store_code")
     assert not hasattr(qdrant.backend, "storage_context_code")
-
-
-def test_refresh_replaces_qdrant_documents():
-    index = Mock()
-    documents = [Mock(), Mock()]
-
-    refreshed = QdrantVectorStoreIndex.refresh_ref_docs(index, documents)
-
-    assert index.update_ref_doc.call_args_list == [
-        call(documents[0]),
-        call(documents[1]),
-    ]
-    assert refreshed == [True, True]

--- a/tests/test_runlog.py
+++ b/tests/test_runlog.py
@@ -392,6 +392,22 @@ def test_parallel_jobs_are_traced_with_compact_keys(tmp_path):
     runlog.validate_runlog(session.ndjson_path)
 
 
+def test_scheduler_accepts_none_jobs_without_losing_worker_capacity() -> None:
+    scheduler = JobScheduler(1)
+    with ThreadPoolExecutor(max_workers=1) as caller:
+        try:
+            result = caller.submit(
+                scheduler.limit(1).run,
+                [None, 2],
+                lambda value: value,
+                label=None,
+                result_key=str,
+            )
+            assert result.result(timeout=2) == [None, 2]
+        finally:
+            scheduler.close()
+
+
 def test_scheduler_shares_global_workers_across_node_limits() -> None:
     scheduler = JobScheduler(2)
     state_lock = threading.Lock()
@@ -896,3 +912,16 @@ def test_runtime_write_failure_disables_logging_without_failing_run(tmp_path):
 
     meta = json.loads(session.meta_path.read_text(encoding="utf-8"))
     assert meta["complete"] is False
+
+
+def test_runlog_preserves_existing_output_directory_permissions(tmp_path):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    output_dir.chmod(0o750)
+
+    with runlog.open_runlog(
+        runlog.RunLogConfig(path=output_dir / "run.ndjson")
+    ) as session:
+        assert output_dir.stat().st_mode & 0o777 == 0o750
+        assert session.ndjson_path.stat().st_mode & 0o777 == 0o600
+        assert session.meta_path.stat().st_mode & 0o777 == 0o600

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -4,6 +4,8 @@
 import hashlib
 from pathlib import Path
 
+import pytest
+
 from metis.sarif.writer import generate_sarif
 from metis.sarif.utils import read_file_lines, create_fingerprint
 from metis.sarif.triage import METIS_FINDING_ID_KEY
@@ -317,3 +319,32 @@ def test_anchor_fingerprint_line_independent():
     assert (
         anchor_fingerprint({"file_path": "f.c", "start_line": 1, "end_line": 1}) is None
     )
+
+
+@pytest.mark.parametrize(
+    "anchor",
+    [
+        {"file_path": "code.c", "start_line": "unknown", "end_line": 4},
+        {"file_path": "code.c", "start_line": 1, "end_line": [4]},
+        {"file_path": "code.c", "start_line": float("inf"), "end_line": 4},
+        {"start_line": 1, "end_line": 4, "content_hash": "abc"},
+        {"file_path": "code.c", "start_line": 4, "end_line": 1},
+    ],
+)
+def test_generate_sarif_ignores_malformed_optional_anchor(anchor):
+    finding = {
+        "issue": "Example issue",
+        "line_number": 7,
+        "code_snippet": "first line\nsecond line",
+        "anchor": anchor,
+    }
+    sarif = generate_sarif({"reviews": [{"file": "code.c", "reviews": [finding]}]})
+
+    entry = sarif["runs"][0]["results"][0]
+    region = entry["locations"][0]["physicalLocation"]["region"]
+    assert region == {
+        "startLine": 7,
+        "endLine": 8,
+        "snippet": {"text": "first line\nsecond line"},
+    }
+    assert "anchor" not in entry["properties"]

--- a/tests/test_source_map.py
+++ b/tests/test_source_map.py
@@ -269,6 +269,21 @@ def test_source_map_preserves_crlf_byte_offsets() -> None:
     assert source_map.byte_slice(anchor.start_byte, anchor.end_byte) == "a"
 
 
+def test_repository_preserves_source_bytes_and_relative_paths(tmp_path):
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    source = b"a\xff\r\nb\r\n"
+    (nested / "source.txt").write_bytes(source)
+    repo = SourceRepository()
+    outer = repo.get(str(tmp_path), "nested/source.txt")
+    inner = repo.get(str(nested), "source.txt")
+
+    assert outer.rel_path == "nested/source.txt"
+    assert inner.rel_path == "source.txt"
+    anchor = inner.anchor_for_lines(2, 2)
+    assert (anchor.start_byte, anchor.end_byte) == (4, 5)
+
+
 @pytest.mark.parametrize(
     "source",
     [b"", b"\n", b"\r", b"a\r\nb\n", "αé\n尾".encode(), bytes(range(256))],

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,19 +1,24 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import nullcontext
 import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 from llama_index.core import StorageContext, VectorStoreIndex
 from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.core.callbacks.schema import CBEventType, EventPayload
 from llama_index.core.vector_stores import SimpleVectorStore
 
 from metis.engine import MetisEngine
 from metis.engine.nodes.simple_llm_review.service import SimpleLlmReviewService
 from metis.usage.collector import UsageCollector
-from metis.usage.context import current_operation, current_scope
+from metis.usage.context import current_operation, current_scope, usage_scope
+from metis.usage.llamaindex import UsageLlamaIndexHandler
 from metis.usage.runtime import UsageRuntime
 
 
@@ -47,7 +52,7 @@ def test_usage_collector_aggregates_by_scope_model_and_operation():
     assert scoped["output_tokens"] == 35
 
 
-def test_usage_runtime_command_summary_and_persistence(tmp_path):
+def test_usage_runtime_command_summary_and_persistence(tmp_path, monkeypatch):
     runtime = UsageRuntime(tmp_path)
 
     with runtime.command("index") as command:
@@ -66,7 +71,7 @@ def test_usage_runtime_command_summary_and_persistence(tmp_path):
     assert record["summary"]["total_tokens"] == 80
     assert record["cumulative"]["total_tokens"] == 80
 
-    output_path = Path(runtime.save_run_summary())
+    output_path = Path(runtime.save_run_summary(str(tmp_path / "summary.json")))
     payload = json.loads(output_path.read_text(encoding="utf-8"))
 
     assert payload["totals"]["total_tokens"] == 80
@@ -74,6 +79,14 @@ def test_usage_runtime_command_summary_and_persistence(tmp_path):
 
     fresh_runtime = UsageRuntime(tmp_path)
     assert fresh_runtime.snapshot_total()["total_tokens"] == 0
+
+    monkeypatch.setattr(
+        "metis.json_io.os.replace", Mock(side_effect=OSError("replace failed"))
+    )
+    with pytest.raises(OSError, match="replace failed"):
+        runtime.save_run_summary(str(output_path))
+    assert json.loads(output_path.read_text(encoding="utf-8")) == payload
+    assert list(tmp_path.iterdir()) == [output_path]
 
 
 def test_review_code_propagates_usage_context_into_worker_threads(capability_settings):
@@ -248,3 +261,27 @@ def test_index_codebase_records_embedding_usage(tmp_path, capability_settings):
     assert record["summary"]["total_tokens"] > 0
     assert record["summary"]["by_operation"]["index"]["input_tokens"] > 0
     assert record["summary"]["by_model"]["dummy"]["input_tokens"] > 0
+
+
+@pytest.mark.parametrize(
+    ("scoped", "payload"),
+    [
+        (False, {EventPayload.CHUNKS: ["hello"]}),
+        (True, None),
+        (True, {}),
+    ],
+)
+def test_embedding_event_cleans_pending_model_when_usage_is_skipped(scoped, payload):
+    collector = UsageCollector()
+    handler = UsageLlamaIndexHandler(collector)
+    handler.on_event_start(
+        CBEventType.EMBEDDING,
+        {EventPayload.MODEL_NAME: "embedding-model"},
+        event_id="embedding-event",
+    )
+
+    with usage_scope("index") if scoped else nullcontext():
+        handler.on_event_end(CBEventType.EMBEDDING, payload, event_id="embedding-event")
+
+    assert handler._embedding_models == {}
+    assert collector.snapshot()["total_tokens"] == 0


### PR DESCRIPTION
- Prevent scheduler hangs on None jobs and preserve Any/tuple port values.
- Reap cancelled subprocesses and reuse triage decision validation.
- Replace stale document vectors and clean up failed vector-store clients.
- Reject malformed tool, memory and half-vector configuration values.
- Load provider entry points correctly and use document-mode embeddings.
- Send raw text to local embedding APIs and allow optional vLLM API keys.
- Write SARIF and usage summaries atomically; preserve busy checkpoints.
- Preserve source byte offsets, relative paths and Unicode search terms.
- Isolate interactive command options and handle quoted or escaped paths.
- Escape report tooltips and fall back safely from malformed SARIF anchors.
- Preserve log-directory permissions and release pending usage metadata.
- Remove duplicate adapters and helpers; consolidate regression coverage.