### PR TITLE
fix(core): stabilize YAML configuration and execution contracts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
-include src/metis/plugins/plugins.yaml
 include src/metis/metis.yaml

--- a/docs/capabilities/adding-capability.md
+++ b/docs/capabilities/adding-capability.md
@@ -89,6 +89,28 @@ private_analysis = "external_metis_capabilities.analysis:registration"
 The entry-point name must match the registration and manifest name. A package
 may contain both external nodes and external capabilities.
 
+## Thread safety and lifetime
+
+One engine shares a constructed capability across its nodes and job workers,
+including concurrent graph executions. Factory construction is synchronized;
+method calls are not. Make operations safe for concurrent use: protect mutable
+state with an instance lock, use a thread-safe client, or serialize access to a
+client that requires it. Read-only data may be shared. Keep invocation-specific
+state in the caller and never mutate borrowed node inputs.
+
+Do not hold a state lock while invoking caller callbacks or waiting for engine
+work that may need the same lock. Use finite I/O and subprocess timeouts, and
+cooperate with the calling node's cancellation signal. Background work must be
+joined before the operation returns; a returned operation must not keep using a
+capability that the engine can then close.
+
+Engine shutdown drains its active nodes and jobs before invoking capability
+closers, once, in reverse construction order. External callers using a capability
+directly must coordinate their own lifetime with shutdown. Closing the owner or
+starting a nested graph from its active node, job or callback is rejected.
+See the [execution concurrency contract](../execution-graph.md) for the three
+engine limits and callback guarantees.
+
 ## 3. Describe Operations When Needed
 
 The minimal manifest needs only the stable name. When a node exposes capability

--- a/docs/execution-graph.md
+++ b/docs/execution-graph.md
@@ -113,7 +113,10 @@ Capability runtime settings live under `metis_engine.capabilities`. A node's
 capability.
 
 Unregistered stages, nodes, unknown inputs, formats, and configuration fields
-are rejected when the YAML is loaded.
+are rejected when the YAML is loaded. Duplicate explicit YAML keys and malformed
+core settings are errors; omissions inherit the packaged defaults. YAML merge
+keys may be overridden explicitly. YAML scalar rules are unchanged: quote names
+such as `on`, `off`, `yes`, and `no` when they are identifiers.
 
 ## Stage contracts
 
@@ -234,6 +237,16 @@ bindings resolve singular ambiguities and may select or order collection
 sources. Same-named stage inputs, such as the Review request, retain precedence.
 Cross-stage values remain explicit under the stage's `inputs` mapping.
 
+Fan-in is declared with a homogeneous `tuple[T, ...]` port, including an
+`Annotated` or nullable wrapper. Fixed-length and unparameterized tuples are
+single payloads. Values are validated strictly against the declared annotation;
+nullable ports do not enable coercion. Omitted nullable inputs become `None` for
+both inferred bindings and explicit `$inputs` references. Unsupported annotations
+are rejected during compilation. A registration may name inputs in
+`required_when_bound` when a selected producer must succeed even though an
+unbound input accepts `None`; this requirement follows the port rather than a
+built-in node name.
+
 An explicit source written as `node_name` selects that node's only output. Use
 `node_name.output_name` when the producer has multiple outputs. Cross-stage
 bindings use `stage_name.output_name`. In a stage's `inputs` mapping,
@@ -259,7 +272,10 @@ result:
   filename: results/review
 ```
 
-This writes `results/review.sarif` and `results/review.json`.
+This writes `results/review.sarif` and `results/review.json`. A stage may configure
+one filename, on the node that publishes its `filename` output. An external
+replacement can use its own name and an explicit binding such as
+`outputs: {filename: private_result.filename}`.
 
 Any explicit `--output-file` path makes the CLI authoritative for that run.
 The `.sarif`, `.html`, `.csv`, or `.json` extension selects its format. Each
@@ -270,9 +286,13 @@ the later Triage result; Review uses a timestamped `graph_review` path to keep
 the files distinct. A result node's YAML `filename` is used only when the CLI
 does not supply an output path. When neither CLI nor YAML supplies a filename,
 a graph run writes
-`results/graph_review_<timestamp>.<format>` and
-`results/graph_triage_<timestamp>.<format>` for the formats requested by each
-stage. Supported formats are SARIF, JSON, HTML, and CSV.
+`results/graph_review_<timestamp>_<unique-id>.<format>` and
+`results/graph_triage_<timestamp>_<unique-id>.<format>` for the formats requested by each
+stage. Supported formats are SARIF, JSON, HTML, and CSV. Conflicting effective
+YAML destinations are rejected before writing, including case and Unicode aliases on
+filesystems that equate those names. JSON, SARIF, HTML, and CSV replace
+the destination atomically after a complete write, preserving the prior file if
+rendering or writing fails.
 
 ### Review checkpoints and resume
 
@@ -297,6 +317,16 @@ packet responses; deterministic anchoring, admission, authority filtering, and
 finding preparation always run again. Failures are not cached. Each successful
 work item is atomically upserted by key. `finding_dedup` writes the normal final
 output without replacing producer files.
+
+Checkpoint storage is best effort. Unreadable or incompatible databases are
+preserved and treated as a cache miss; failed writes are logged. Metis does not
+remove or rebuild them automatically, because another process may have repaired
+the file after the failure was observed. Malformed individual records are skipped
+without hiding other valid records.
+
+Short lowercase ASCII producer identifiers retain readable filenames. Other
+identifiers use an exact-name digest so case, Unicode normalization and long
+names cannot mix producer state. Ambiguous older filenames are not resumed.
 
 Disable review checkpoint reads and writes globally in the selected YAML:
 
@@ -369,9 +399,20 @@ corresponding stage contract directly:
 | `review_code`, `review_dir`, `review_file`, `review_patch` | `review` |
 | `triage` | `triage` |
 
-Direct commands do not rewrite YAML topology. The graph stops after a failed
-stage. An inconclusive review may publish valid partial findings and SARIF so
-triage can continue.
+Direct commands use the selected stage's transitive prerequisites in the same
+topological order as full graph execution; unrelated stages are skipped. Explicit
+inputs supplied to direct triage satisfy its data bindings, while declared control
+dependencies still run. Resolved contracts and topology are owned by the engine;
+mutating the caller's configuration after construction does not change execution.
+
+The graph stops after a failed stage, retaining validated outputs from completed
+nodes and stages. Public execution raises `metis.engine.ExecutionGraphError`, a
+`RuntimeError` whose `result` contains those outputs and structured diagnostics.
+Values that cannot be serialized to JSON remain native values in that error
+result, so serialization cannot hide the original execution failure.
+An inconclusive review may publish valid partial findings and SARIF so triage can
+continue. The CLI records the inconclusive status and prints a warning, retaining
+its existing zero exit code; an execution error exits nonzero.
 
 ## Built-in implementation layout
 
@@ -519,17 +560,22 @@ verify = "external_metis_stages.verify:registration"
 ```
 
 ```python
-from metis.execution_nodes import ReviewRun
+from metis.execution_nodes import ReviewResult
 from metis.execution_stages import StageContract, StageRegistration
 
 registration = StageRegistration(
     name="verify",
     contract=StageContract(
-        inputs={"review": ReviewRun},
+        inputs={"review": ReviewResult},
         required_outputs={"verdict": str},
     ),
 )
 ```
+
+Bind this stage's `review` input to `review.findings` to consume the default
+Review stage's published findings. `ReviewRun` is the internal node-to-node
+collection contract; `FinalReviewRun` and `JsonPromptRequest` are also available
+from `metis.execution_nodes` for separately distributed handlers.
 
 Put Metis compatibility bounds in `project.dependencies`. `tool.uv.sources`
 only selects the local editable source during development.
@@ -706,25 +752,101 @@ callbacks. Dependency-ready nodes run concurrently. For example,
 `threat_model` and `codegraph` run together in Initialize. After its barrier,
 `simple_llm_review` and `reachability` may run together over the initialized
 graph.
-`max_concurrency` limits that node's active jobs; omitted values use the global
-`metis_engine.max_workers` limit. All nodes on one engine share that job pool,
-so their combined active jobs never exceed the global limit and newly active
-nodes receive the next available workers before a busier node is replenished.
-Running calls are not preempted. Interrupting a stage cancels queued jobs and
-signals active nodes through `runtime.is_cancelled`; built-in long-running nodes
-check that signal through their progress callbacks. Provider calls already in
-flight still run until their configured timeout. Node-coordinator threads are
-separate from this job budget. A node submits bounded work through
-`invocation.context.jobs.run(...)`; it does not construct its own executor. A node
-accesses only the names in `invocation.context.capabilities`. A node declares
+
+The engine has three independent concurrency limits:
+
+| Setting under `metis_engine` | Scope | Default |
+| --- | --- | --- |
+| `max_workers` | Active jobs across all nodes and graph executions on one engine | `5` |
+| `max_active_nodes` | Active node handlers across all stages and graph executions on one engine | Inherits `max_workers` |
+| `max_concurrent_executions` | Admitted graph executions, including direct stage entry points | Inherits `max_workers` |
+
+All limits accept positive integers; `null` for either new setting means inherit
+`max_workers`. For example:
+
+```yaml
+metis_engine:
+  max_workers: 8
+  max_active_nodes: 3
+  max_concurrent_executions: 2
+```
+
+This engine admits two executions, runs at most three node handlers, and runs at
+most eight jobs. Further execution callers wait for admission without creating
+another pool. They wake with a closed-service error if the engine closes while
+waiting. A handler, job or callback must not synchronously execute another graph
+on the same engine: reentry is rejected before waiting, even when capacity is
+available. An unrelated engine has its own limits.
+
+The node pool and job pool are separate and owned by the execution service.
+This allows a node to wait for its jobs even with a single worker in either pool.
+Caller threads, provider background threads and direct capability calls are not
+counted as job workers. These settings are not a provider-wide request limit:
+a direct prompt call occupies its node handler, while a call inside `jobs.run`
+occupies a job worker. Nodes use `invocation.context.jobs.run(...)` instead of
+creating executors or leaving background work after returning.
+
+`max_concurrency` limits a node's active jobs; omitted values use
+`metis_engine.max_workers`. Concurrent submissions through the same node handle
+share its limit. All nodes share the engine's job pool; newly active job runs
+receive available workers before busier runs are replenished. A pool job must
+not synchronously submit another run to the same scheduler; this raises
+`RuntimeError`. Slow completion callbacks retain backpressure for their own job
+run without blocking other eligible runs. Node submission and graph admission
+do not promise FIFO ordering.
+
+Cancellation is cooperative. Each execution owns a root signal, and the runtime
+creates child scopes for its stages and nodes. A child inherits cancellation from
+its ancestors; cancelling it never sets an ancestor or sibling signal.
+`jobs.with_cancellation(event)` binds a child handle to that Event, and `cancel()`
+sets the bound Event, cancels queued jobs and signals active jobs. Custom
+`NodeJobs` implementations must honor the same contract. `runtime.is_cancelled()`
+and the job handle observe the same child signal. Context variables carry logging
+and execution identity into workers; they do not own cancellation.
+
+Handlers check `runtime.is_cancelled()` in long loops, or use
+`context.report_progress(...)`, which checks even without a progress callback.
+Returning a successful result after cancelling the node is rejected as
+cancellation. Ordinary job failures become node errors and cancel that node's
+cooperative job peers; independent nodes may continue. `CancelledError` from a
+handler or callback aborts its stage and propagates to the caller. A stage drains
+its own active handlers before returning, including on failure, and leaves other
+executions' shared-pool work intact.
+
+Closing an engine rejects new work, wakes waiting callers, signals admitted
+executions, drains handlers and jobs, then closes capabilities. Close from an
+active handler, job or callback is rejected. Threads and in-flight I/O cannot be
+preempted: extensions must use finite network/subprocess timeouts and join any
+work they start before returning. A non-cooperative call delays shutdown until
+it returns or its timeout expires. Concurrent close callers all wait for execution
+draining. Capability cleanup runs once; a repeated close may return while that
+cleanup is running, so cleanup callbacks can reenter close. Interruptions during
+draining are re-raised after cleanup completes.
+
+A node accesses only the names in `invocation.context.capabilities`. A node declares
 `request: ReviewCommand` when it needs the review-stage request; the runner
 supplies that typed stage input without extra YAML. The context does not expose
 internal engine services or `EngineConfig`. Installed node code runs in the
 Metis process; private distribution does not imply sandboxing.
 
 The runner passes typed values between nodes using explicit bindings or the
-inferred typed contracts described above. Nodes do not receive or invoke other
-executable nodes: keeping execution in the runner preserves dependency
+inferred typed contracts described above. Each invocation receives a fresh
+configuration model validated from a private snapshot of the original node
+settings; shared port values are borrowed and should be treated as read-only
+by handlers. Copy a mutable port value before modifying it, and keep per-run
+state in the invocation rather than in a registration, global variable or shared
+capability. Capability objects are shared across node handlers, jobs and admitted
+executions. Their implementations must synchronize mutable state or confine
+non-thread-safe clients to a serialized operation. Factory/cleanup synchronization
+does not serialize capability method calls; keep locks inside the capability's
+state boundary and release them before invoking external callbacks.
+
+Progress delivery is serialized within one execution. Other callbacks (debug,
+checkpoint, resume and diagnostic), and callbacks reused across executions, may
+run concurrently. They must protect shared state. Callbacks run inline and must
+not wait on another handler or callback that needs their lock or worker capacity.
+Cancellation exceptions propagate from callbacks. Nodes do not receive or invoke
+other executable nodes: keeping execution in the runner preserves dependency
 validation, ordering, diagnostics, and replacement by another registration
 such as `reachability_v2`.
 
@@ -742,6 +864,13 @@ nodes continue. Long-running node loops should emit through
 the CLI is not rendering progress.
 
 ## CodeGraph provider contract
+
+CodeGraph references identify immutable stored revisions. Retrying an incomplete
+graph or building the same fingerprint from another service does not invalidate
+an issued reference. Fingerprint lookup prefers the latest valid complete revision
+and otherwise returns the latest valid incomplete revision. Existing v2 stores
+migrate their fingerprint constraint transactionally while preserving revisions
+and record rows. Revisions are retained without automatic pruning.
 
 Adding language support does not change the execution graph. A language
 package must:

--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -103,17 +103,19 @@ with `Authorization: Bearer $VLLM_API_KEY`.
 
 ## 4. Configure Metis
 
-Point Metis at the LiteLLM proxy by updating `metis.yaml`:
+Point Metis at the LiteLLM proxy by updating `metis.yaml`. Replace
+`<llm-host-ip>` with your host address; Metis does not expand environment
+variables inside YAML values:
 
 ```yaml
 llm_provider:
   name: "vllm"
-  base_url: "http://${LLM_HOST_IP}:8888/v1"
+  base_url: "http://<llm-host-ip>:8888/v1"
   model: "<chat-model-id>"
 
 embedding_provider:
   name: "vllm"
-  base_url: "http://${LLM_HOST_IP}:8888/v1"
+  base_url: "http://<llm-host-ip>:8888/v1"
   code_embedding_model: "<embedding-model-id>"
   docs_embedding_model: "<embedding-model-id>"
 

--- a/docs/repository-memory.md
+++ b/docs/repository-memory.md
@@ -78,6 +78,39 @@ turning every structured field into a SQL column.
 SQLite opens the database in WAL mode and uses a busy timeout. That is enough
 for normal local read and write overlap. It is still a local store.
 
+## Custom Backend Compatibility
+
+Custom backends keep the existing `put`, `get`, `search`, `delete`, `batch`, and
+namespace-listing interface for ordinary reads and writes. Persistent backends
+additionally need this operation for namespace replacement and reset:
+
+```python
+def replace_records(namespace_prefix: tuple[str, ...], records: Iterable[PutOp]) -> int:
+    ...
+```
+
+Each `PutOp` supplies a namespace, key, and non-null record value under the given
+prefix. The backend must atomically delete the previous subtree and insert the
+replacement, returning the number of records removed. An empty replacement
+resets the subtree. Concurrent replacements must produce one complete snapshot;
+a failed replacement must preserve the previous snapshot. SQLite performs the
+entire operation in one write transaction, including its search-index updates.
+
+`MemoryService.replace_records()` and `reset_records()` raise `TypeError` with
+`Memory backend must support atomic namespace replacement` when a persistent backend lacks
+this operation. Other reads and writes remain available. Persistent backends have
+no fallback that enumerates and deletes records in separate transactions.
+
+LangGraph's `InMemoryStore`, used for temporary candidate records, remains
+supported without that extra backend method. `MemoryService` serializes its
+replacement/reset calls with one shared lock per store, including calls through
+different service instances. This only coordinates these operations within the
+current process; direct writes to the raw store bypass that lock. Persistent
+backends still require their own transaction.
+
+A backend may expose `close()` for resource cleanup. Engine shutdown delegates to
+it through `MemoryService.close()`; backends without `close()` need no change.
+
 ## Retrieval
 
 The store supports exact lookup and bounded search by namespace prefix, text

--- a/examples/anthropic/metis_anthropic_example.yaml
+++ b/examples/anthropic/metis_anthropic_example.yaml
@@ -47,6 +47,5 @@ embedding_provider:
 
 query:
   similarity_top_k: 5
-  response_mode: "tree_summarize"
   max_tokens: 5000
   temperature: 0.0

--- a/examples/llamacpp/metis_llamacpp_example.yaml
+++ b/examples/llamacpp/metis_llamacpp_example.yaml
@@ -53,6 +53,5 @@ embedding_provider:
 
 query:
   similarity_top_k: 5
-  response_mode: "compact"
   max_tokens: 2048
   temperature: 0.0

--- a/examples/ollama/metis_ollama_example.yaml
+++ b/examples/ollama/metis_ollama_example.yaml
@@ -53,6 +53,5 @@ embedding_provider:
 
 query:
   similarity_top_k: 5
-  response_mode: "compact"
   max_tokens: 2048
   temperature: 0.0

--- a/examples/vllm/metis_vllm_example.yaml
+++ b/examples/vllm/metis_vllm_example.yaml
@@ -50,6 +50,5 @@ embedding_provider:
 
 query:
   similarity_top_k: 5
-  response_mode: "compact"
   max_tokens: 3072
   temperature: 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ version = "1.5.0"
 description = "Metis is a command line tool for performing security code reviews using LLMs"
 readme = "README.md"
 keywords = [ "code-review", "llm", "security" ]
-license = { file = "LICENSE.md" }
+license = "Apache-2.0"
+license-files = [ "LICENSE" ]
 requires-python = ">=3.12"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
@@ -77,6 +78,7 @@ optional-dependencies.qdrant = [
 optional-dependencies.test = [
   "pytest>=9.0.3",
   "pytest-cov>=7.1.0",
+  "setuptools>=82.0.1",
 ]
 scripts.metis = "metis.cli.entry:main"
 entry-points."metis.providers"."anthropic.chat" = "metis.providers.anthropic:AnthropicProvider"
@@ -111,7 +113,6 @@ package-data."metis.plugins.config" = [ "*.yaml" ]
 package-data."metis.plugins.languages" = [ "*.yaml" ]
 package-data."metis.plugins.manifests" = [ "*.yaml" ]
 package-data."metis.plugins.profiles" = [ "*.yaml" ]
-package-data."metis.schemas" = [ "*.json" ]
 package-data.metis = [ "metis.yaml" ]
 
 [tool.ruff]

--- a/src/metis/__main__.py
+++ b/src/metis/__main__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from .cli import main
+from .cli.entry import main
 
 if __name__ == "__main__":
     main()

--- a/src/metis/cli/command_registry.py
+++ b/src/metis/cli/command_registry.py
@@ -48,15 +48,23 @@ class CommandSpec:
         return f"{cmd} {Path(target).name}"
 
     def validate(self, cmd: str, cmd_args: list[str], args) -> bool:
-        if self.invocation_mode == "path" and not cmd_args:
+        if self.invocation_mode == "path" and len(cmd_args) != 1:
             print_console(
-                f"[red]Error:[/red] Command '{escape(cmd)}' requires a file path argument.",
+                f"[red]Error:[/red] Command '{escape(cmd)}' requires exactly one file path argument.",
                 args.quiet,
             )
             return False
-        if self.invocation_mode == "args" and cmd_args:
+        if self.invocation_mode not in {"path", "question"} and cmd_args:
             print_console(
                 f"[red]Error:[/red] Command '{escape(cmd)}' does not accept positional arguments.",
+                args.quiet,
+            )
+            return False
+        if self.invocation_mode == "question" and not any(
+            arg.strip() for arg in cmd_args
+        ):
+            print_console(
+                f"[red]Error:[/red] Command '{escape(cmd)}' requires a question.",
                 args.quiet,
             )
             return False

--- a/src/metis/cli/commands.py
+++ b/src/metis/cli/commands.py
@@ -27,6 +27,7 @@ from .utils import (
     pretty_print_reviews,
     save_output,
     print_console,
+    print_execution_diagnostic,
     output_format,
     output_files_for_formats,
 )
@@ -145,12 +146,16 @@ def _run_review_command(engine, mode, target, args, spinner_text):
         if triage is not None:
             sarif_output = triage["sarif"]
             formats = tuple(dict.fromkeys((*formats, *triage["formats"])))
-    generated_output = bool(getattr(args, "_metis_generated_output", False))
+    generated_output = (
+        bool(getattr(args, "_metis_generated_output", False)) or not args.output_file
+    )
     if not generated_output:
         explicit_formats = tuple(output_format(path) for path in args.output_file or ())
         formats = tuple(dict.fromkeys((*formats, *explicit_formats)))
     args.output_file = output_files_for_formats(
-        args.output_file,
+        [outputs["filename"]]
+        if generated_output and outputs.get("filename") is not None
+        else args.output_file,
         formats,
         command=f"review_{mode}",
         generated_output=generated_output,
@@ -164,7 +169,7 @@ def _run_review_command(engine, mode, target, args, spinner_text):
 
 def _execute_review(engine, mode, target, args, spinner_text):
     callbacks = {
-        "diagnostic_callback": lambda diagnostic: _print_review_diagnostic(
+        "diagnostic_callback": lambda diagnostic: print_execution_diagnostic(
             diagnostic,
             args.quiet,
         )
@@ -199,14 +204,6 @@ def _execute_review(engine, mode, target, args, spinner_text):
             )
         finally:
             reporter.finish()
-
-
-def _print_review_diagnostic(diagnostic, quiet):
-    color = "yellow" if diagnostic.severity == "warning" else "red"
-    print_console(
-        f"[{color}]{escape(diagnostic.message)}[/{color}]",
-        quiet,
-    )
 
 
 def _triage_review_output(engine, sarif_payload, codegraph, args):
@@ -348,10 +345,10 @@ def run_triage(engine, findings_path, args, runtime: CommandRuntime):
         spinner_text="Triaging SARIF findings...",
     )
     output_files = output_files_for_formats(
-        args.output_file or [findings_path],
+        args.output_file or [triage.get("filename") or findings_path],
         tuple(triage["formats"]),
         command="triage",
-        generated_output=args.output_file is None,
+        generated_output=not args.output_file,
     )
     save_output(
         output_files,
@@ -391,10 +388,10 @@ def _run_json_triage(engine, json_path, args, runtime: CommandRuntime):
     )
 
     output_files = output_files_for_formats(
-        args.output_file or [json_path],
+        args.output_file or [triage.get("filename") or json_path],
         tuple(triage["formats"]),
         command="triage",
-        generated_output=args.output_file is None,
+        generated_output=not args.output_file,
     )
     save_output(
         output_files,

--- a/src/metis/cli/entry.py
+++ b/src/metis/cli/entry.py
@@ -9,14 +9,17 @@ from pathlib import Path
 import shlex
 from typing import Any
 from typing import cast
+from uuid import uuid4
 
 from rich.markup import escape
 from prompt_toolkit import prompt
 from prompt_toolkit.history import InMemoryHistory
+from yaml import YAMLError
 
 from metis.configuration import build_embedding_provider_config, load_runtime_config
 from metis.engine import MetisEngine
 from metis.engine.execution import ExecutionResult
+from metis.engine.execution import ExecutionStatus
 from metis.usage import UsageRuntime
 from metis.utils import read_file_content
 from metis.providers.registry import get_chat_provider
@@ -41,12 +44,14 @@ from .utils import (
     build_qdrant_backend,
     build_standard_progress,
     print_console,
+    print_execution_diagnostic,
     print_usage_summary,
     print_final_usage_summary,
     check_dir_exists,
     save_output,
     output_format,
     output_files_for_formats,
+    output_path_identity,
     workflow_debug_context,
 )
 
@@ -54,14 +59,6 @@ logging.captureWarnings(True)
 logging.getLogger().setLevel(logging.ERROR)
 logger = logging.getLogger("metis")
 EXIT_REQUESTED = object()
-
-
-def _print_graph_diagnostic(diagnostic, quiet):
-    color = "yellow" if diagnostic.severity == "warning" else "red"
-    print_console(
-        f"[{color}]{escape(diagnostic.message)}[/{color}]",
-        quiet,
-    )
 
 
 def _execute_graph_with_progress(
@@ -97,9 +94,35 @@ def _save_graph_outputs(
     triage_sarif = triage_result.get("sarif")
     review_formats = tuple(review.get("formats", ()))
     triage_formats = tuple(triage_result.get("formats", ()))
+    partial = result.status is ExecutionStatus.ERROR
+    if partial:
+        review_formats = tuple(
+            name
+            for name in review_formats
+            if (review_sarif is not None if name == "sarif" else findings is not None)
+        )
+        if triage_sarif is None:
+            triage_formats = ()
     review_filename = review.get("filename")
     triage_filename = triage_result.get("filename")
     explicit_output = bool(output_files) and not generated_output
+    if (
+        not explicit_output
+        and review_formats
+        and triage_formats
+        and review_filename is not None
+        and triage_filename is not None
+    ):
+        review_paths = {
+            output_path_identity(Path(review_filename).with_suffix(f".{fmt}"))
+            for fmt in review_formats
+        }
+        triage_paths = {
+            output_path_identity(Path(triage_filename).with_suffix(f".{fmt}"))
+            for fmt in triage_formats
+        }
+        if review_paths & triage_paths:
+            raise ValueError("Output paths for graph stages must be distinct")
     review_files: list[str] = []
     triage_files: list[str] = []
     explicit_files = (output_files or ()) if explicit_output else ()
@@ -112,9 +135,17 @@ def _save_graph_outputs(
         elif triage_sarif is not None:
             triage_formats = (*triage_formats, format_name)
             triage_files.append(path)
-        elif findings is not None:
+        elif (
+            review_sarif is not None if format_name == "sarif" else findings is not None
+        ):
             review_formats = (*review_formats, format_name)
             review_files.append(path)
+        elif partial:
+            print_console(
+                f"[yellow]No validated {format_name} output available for "
+                f"{escape(str(path))}.[/yellow]",
+                quiet,
+            )
         else:
             raise ValueError(f"Execution graph did not produce {format_name} output")
 
@@ -131,7 +162,9 @@ def _save_graph_outputs(
             reserved_paths={Path(path) for path in review_files},
         )
     if review_formats:
-        if findings is None or review_sarif is None:
+        if ("sarif" in review_formats and review_sarif is None) or (
+            any(name != "sarif" for name in review_formats) and findings is None
+        ):
             raise ValueError("Execution graph did not produce review results")
         review_files = output_files_for_formats(
             review_files
@@ -144,7 +177,7 @@ def _save_graph_outputs(
         )
         save_output(
             review_files,
-            findings,
+            findings if findings is not None else review_sarif,
             quiet,
             sarif_payload=review_sarif,
         )
@@ -164,8 +197,13 @@ def determine_output_file(cmd, args, cmd_args):
 
     while "--output-file" in cmd_args:
         idx = cmd_args.index("--output-file")
-        if idx + 1 < len(cmd_args):
-            overrides.append(cmd_args[idx + 1])
+        if (
+            idx + 1 >= len(cmd_args)
+            or not cmd_args[idx + 1]
+            or cmd_args[idx + 1] == "--output-file"
+        ):
+            raise ValueError("--output-file requires a filename")
+        overrides.append(cmd_args[idx + 1])
         del cmd_args[idx : idx + 2]
 
     if overrides:
@@ -183,9 +221,8 @@ def determine_output_file(cmd, args, cmd_args):
         args._metis_generated_output = False
         return
 
-    Path("results").mkdir(exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    args.output_file = [f"results/{cmd}_{timestamp}.json"]
+    args.output_file = [f"results/{cmd}_{timestamp}_{uuid4().hex}.json"]
     args._metis_generated_output = True
 
 
@@ -216,7 +253,6 @@ def build_engine(args, runtime):
         raise RuntimeError("llm_provider configuration is required.")
     llm_provider_name = str(llm_provider_name)
     chat_provider_cls = get_chat_provider(llm_provider_name)
-    llm_provider = chat_provider_cls(cast(dict, runtime["llm_provider"]))
     engine_runtime.pop("llm_provider_name", None)
     engine_runtime.pop("llm_provider", None)
 
@@ -224,6 +260,7 @@ def build_engine(args, runtime):
     embedding_provider_config = build_embedding_provider_config(
         cast(dict | None, runtime.get("embedding_provider_raw_config"))
     )
+    llm_provider = chat_provider_cls(cast(dict, runtime["llm_provider"]))
     if embedding_provider_config is not None:
         embedding_provider_cls = get_embedding_provider(
             str(embedding_provider_config["name"])
@@ -274,11 +311,11 @@ def finalize_cli_session_and_close(engine, args, farewell):
     try:
         finalize_cli_session(engine, args)
     finally:
-        if farewell:
-            print_console(farewell, args.quiet)
         close_fn = getattr(engine, "close", None)
         if callable(close_fn):
             close_fn()
+        if farewell:
+            print_console(farewell, args.quiet)
 
 
 def execute_command(engine, cmd, cmd_args, args):
@@ -299,8 +336,6 @@ def _execute_command(engine, cmd, cmd_args, args):
         return
 
     spec = COMMANDS[cmd]
-    if cmd == "exit":
-        return EXIT_REQUESTED
     args = copy(args)
     runtime = CommandRuntime(command=cmd, command_args=list(cmd_args))
 
@@ -309,6 +344,8 @@ def _execute_command(engine, cmd, cmd_args, args):
 
     if not spec.validate(cmd, runtime.command_args, args):
         return
+    if cmd == "exit":
+        return EXIT_REQUESTED
 
     usage_command = None
     if spec.tracked:
@@ -355,10 +392,7 @@ def run_interactive_loop(engine, args, vector_backend):
                         "[red]Schema exists. Cannot re-index.[/red]", args.quiet
                     )
                     continue
-                if (
-                    cmd in {"ask", "review_code", "review_dir", "review_file"}
-                    and not vector_backend.check_project_schema_exists()
-                ):
+                if cmd == "ask" and not vector_backend.check_project_schema_exists():
                     print_console(
                         "[red]Schema missing. Did you forget to index?[/red]",
                         args.quiet,
@@ -400,7 +434,12 @@ def main():
         choices=["chroma", "postgres", "qdrant"],
     )
     parser.add_argument("--log-file", type=str)
-    parser.add_argument("--log-level", type=str, default="ERROR")
+    parser.add_argument(
+        "--log-level",
+        type=str.upper,
+        choices=logging.getLevelNamesMapping(),
+        default="ERROR",
+    )
     parser.add_argument(
         "--log-workflow-debug",
         action="store_true",
@@ -457,7 +496,10 @@ def main():
         help=argparse.SUPPRESS,
     )
     args = parser.parse_args()
-    graph_requested = not args.interactive
+    if args.tools is not None:
+        parser.error(
+            "--tools has been removed; configure execution nodes and capability grants in YAML"
+        )
     if args.output_files:
         if args.output_file:
             args.output_file.extend(args.output_files)
@@ -482,10 +524,17 @@ def main():
             ),
         )
         return
-    if not check_dir_exists(args.codebase_path):
-        raise SystemExit(1)
+    try:
+        if not check_dir_exists(args.codebase_path):
+            raise SystemExit(1)
+        configure_logger(logger, args)
+        _run_cli(args)
+    except (OSError, ValueError, YAMLError) as exc:
+        print_console(f"[bold red]Error:[/bold red] {escape(str(exc))}", args.quiet)
+        raise SystemExit(1) from None
 
-    configure_logger(logger, args)
+
+def _run_cli(args):
     with workflow_debug_context(args) as runlog_session:
         if runlog_session is not None:
             args._metis_runlog = runlog_session
@@ -506,7 +555,7 @@ def main():
                 "review_checkpoints_enabled", True
             )
             engine, vector_backend = build_engine(args, runtime)
-            if graph_requested:
+            if not args.interactive:
                 with runlog.span(
                     "command",
                     "execution_graph",
@@ -516,7 +565,7 @@ def main():
                         determine_output_file("graph", args, [])
                         callbacks: dict[str, object] = {
                             "diagnostic_callback": (
-                                lambda diagnostic: _print_graph_diagnostic(
+                                lambda diagnostic: print_execution_diagnostic(
                                     diagnostic, args.quiet
                                 )
                             )
@@ -543,6 +592,23 @@ def main():
                             ),
                         )
                     except Exception as exc:
+                        partial = getattr(exc, "result", None)
+                        if isinstance(partial, ExecutionResult) and partial.outputs:
+                            try:
+                                _save_graph_outputs(
+                                    args.output_file,
+                                    partial,
+                                    args.quiet,
+                                    generated_output=bool(
+                                        getattr(args, "_metis_generated_output", False)
+                                    ),
+                                )
+                            except Exception as save_error:
+                                print_console(
+                                    f"[red]Unable to save partial outputs: "
+                                    f"{escape(str(save_error))}[/red]",
+                                    args.quiet,
+                                )
                         command_span.end(status="error", exc=exc)
                         print_console(
                             f"[bold red]Error:[/bold red] {escape(str(exc))}",
@@ -550,9 +616,23 @@ def main():
                         )
                         exit_code = 1
                     else:
-                        print_console(
-                            "[green]Execution graph complete.[/green]", args.quiet
-                        )
+                        command_span.end(status=result.status.value)
+                        if runlog_session is not None:
+                            runlog_session.set_outcome(result.status.value)
+                        if result.status is ExecutionStatus.OK:
+                            print_console(
+                                "[green]Execution graph complete.[/green]", args.quiet
+                            )
+                        elif result.status is ExecutionStatus.INCONCLUSIVE:
+                            print_console(
+                                "[yellow]Execution graph finished with inconclusive results.[/yellow]",
+                                args.quiet,
+                            )
+                        else:
+                            print_console(
+                                "[red]Execution graph failed.[/red]", args.quiet
+                            )
+                            exit_code = 1
             else:
                 farewell = run_interactive_loop(engine, args, vector_backend)
         finally:

--- a/src/metis/cli/exporters.py
+++ b/src/metis/cli/exporters.py
@@ -8,11 +8,14 @@ import html
 import json
 import re
 from collections import Counter
+from datetime import UTC
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Tuple
 
+from metis.json_io import atomic_text_writer
 from metis.json_io import write_json_atomic
+from metis.sarif.triage import extract_findings
 from metis.sarif.writer import generate_sarif
 
 
@@ -22,9 +25,10 @@ def export_html(
     """Render the HTML report template with the provided data."""
     issues = _flatten_issues(report_data)
     document = _build_html_document(issues, output_path.name, template, metis_version)
-    html_path = output_path.with_suffix(".html")
+    html_path = output_path
     html_path.parent.mkdir(parents=True, exist_ok=True)
-    html_path.write_text(document, encoding="utf-8")
+    with atomic_text_writer(html_path) as handle:
+        handle.write(document)
     return html_path
 
 
@@ -44,7 +48,7 @@ def export_csv(report_data, output_path: Path) -> Path:
     """Write flattened issues to a CSV file."""
     issues = _flatten_issues(report_data)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8", newline="") as csv_file:
+    with atomic_text_writer(output_path, newline="") as csv_file:
         writer = csv.writer(csv_file)
         writer.writerow(
             [
@@ -77,7 +81,7 @@ def export_csv(report_data, output_path: Path) -> Path:
 def _build_html_document(
     issues: Iterable[dict], source_name: str, template: str, metis_version: str
 ) -> str:
-    generated_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    generated_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
     display_name = Path(source_name).stem if source_name else source_name
     title = f"Metis Security Report - {display_name}"
 
@@ -151,11 +155,14 @@ def _build_html_document(
         "folderStats": folder_stats_serialized,
     }
     data_json = json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
-    return (
-        template.replace("__TITLE__", html.escape(title))
-        .replace("__GENERATED_AT__", html.escape(generated_at))
-        .replace("__DATA_JSON__", data_json)
-        .replace("__METIS_VERSION__", html.escape(metis_version))
+    substitutions = {
+        "__TITLE__": html.escape(title),
+        "__GENERATED_AT__": html.escape(generated_at),
+        "__DATA_JSON__": data_json,
+        "__METIS_VERSION__": html.escape(metis_version),
+    }
+    return re.sub(
+        "|".join(substitutions), lambda match: substitutions[match[0]], template
     )
 
 
@@ -165,6 +172,25 @@ def _flatten_issues(report_data) -> list[dict]:
         return issues
 
     reviews = report_data.get("reviews", [])
+    if "reviews" not in report_data:
+        for finding in extract_findings(report_data, include_triaged=True):
+            result = report_data["runs"][finding.run_index]["results"][
+                finding.result_index
+            ]
+            properties = result.get("properties")
+            reviews.append(
+                {
+                    "file": finding.file_path,
+                    "reviews": [
+                        {
+                            **(properties if isinstance(properties, dict) else {}),
+                            "issue": finding.message,
+                            "line_number": finding.line,
+                            "code_snippet": finding.snippet,
+                        }
+                    ],
+                }
+            )
     for file_entry in reviews:
         file_name = file_entry.get("file") or file_entry.get("file_path") or "Unknown"
         try:
@@ -178,6 +204,8 @@ def _flatten_issues(report_data) -> list[dict]:
                 severity = severity.strip() or "Unknown"
             else:
                 severity = str(severity)
+            if severity.lower() in {"critical", "high", "medium", "low", "unknown"}:
+                severity = severity.capitalize()
 
             cwe = issue.get("cwe") or "CWE-Unknown"
             if isinstance(cwe, (list, tuple)):

--- a/src/metis/cli/review_checkpoints.py
+++ b/src/metis/cli/review_checkpoints.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from contextlib import closing
 import json
+from hashlib import sha256
+import logging
 from pathlib import Path
 import sqlite3
 
@@ -14,10 +16,19 @@ from metis.version import __version__ as METIS_VERSION
 
 
 def _checkpoint_path(checkpoint_base: Path, producer: str) -> Path:
+    if (
+        not producer.isascii()
+        or not producer.isidentifier()
+        or producer != producer.lower()
+        or len(producer) > 128
+    ):
+        # @ cannot occur in a producer identifier, so encoded and legacy names
+        # cannot alias even on case-insensitive or Unicode-normalizing volumes.
+        producer = "@" + sha256(producer.encode("utf-8")).hexdigest()
     return checkpoint_base.with_name(f"{checkpoint_base.name}.{producer}.sqlite3")
 
 
-def _ensure_checkpoint_schema(connection: sqlite3.Connection) -> None:
+def _ensure_checkpoint_schema(connection: sqlite3.Connection) -> bool:
     connection.execute(
         """
         CREATE TABLE IF NOT EXISTS review_checkpoint_records (
@@ -28,6 +39,10 @@ def _ensure_checkpoint_schema(connection: sqlite3.Connection) -> None:
         ) WITHOUT ROWID
         """
     )
+    return any(
+        row[1] == "producer"
+        for row in connection.execute("PRAGMA table_info(review_checkpoint_records)")
+    )
 
 
 def _connect_checkpoint(path: Path) -> sqlite3.Connection:
@@ -36,95 +51,77 @@ def _connect_checkpoint(path: Path) -> sqlite3.Connection:
     return sqlite3.connect(path)
 
 
-def _discard_checkpoint(path: Path) -> None:
-    try:
-        path.unlink(missing_ok=True)
-    except OSError:
-        return
-
-
-def _sqlite_records(path: Path) -> dict[str, dict[str, object]] | None:
+def _sqlite_records(
+    path: Path, *, producer: str | None = None
+) -> dict[str, dict[str, object]] | None:
     if not path.exists():
         return None
     records: dict[str, dict[str, object]] = {}
     try:
         with closing(_connect_checkpoint(path)) as connection:
-            _ensure_checkpoint_schema(connection)
-            rows = connection.execute(
-                """
+            legacy = _ensure_checkpoint_schema(connection)
+            query = """
                 SELECT record_key, payload
                 FROM review_checkpoint_records
                 WHERE metis_version = ?
-                """,
-                (METIS_VERSION,),
-            )
+            """
+            parameters: tuple[str, ...] = (METIS_VERSION,)
+            if legacy and producer is not None:
+                query += " AND producer = ?"
+                parameters += (producer,)
+            rows = connection.execute(query, parameters)
             for key, payload in rows:
                 try:
                     record = json.loads(payload)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, RecursionError):
                     continue
                 if not isinstance(record, dict):
                     continue
                 records[str(key)] = record
-    except (OSError, sqlite3.Error) as exc:
-        if _should_discard_on(exc):
-            _discard_checkpoint(path)
+    except (OSError, sqlite3.Error):
         return None
     return records or None
 
 
-def _write_sqlite_record_once(path: Path, record: ReviewCheckpointRecord) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(
-        record.record,
-        allow_nan=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
-    with closing(_connect_checkpoint(path)) as connection:
-        path.chmod(0o600)
-        connection.execute("PRAGMA busy_timeout = 5000")
-        _ensure_checkpoint_schema(connection)
-        connection.execute(
-            """
-            INSERT INTO review_checkpoint_records (
-                metis_version, record_key, payload
-            ) VALUES (?, ?, ?)
-            ON CONFLICT (metis_version, record_key)
-            DO UPDATE SET payload = excluded.payload
-            """,
-            (record.metis_version, record.key, payload),
-        )
-        connection.commit()
-
-
-_TRANSIENT_SQLITE_CODES = frozenset({sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED})
-
-
-def _should_discard_on(exc: BaseException) -> bool:
-    if not isinstance(exc, sqlite3.Error):
-        return False
-    code = getattr(exc, "sqlite_errorcode", None)
-    if code in _TRANSIENT_SQLITE_CODES:
-        return False
-    if code is None:
-        message = str(exc).lower()
-        if "locked" in message or "busy" in message:
-            return False
-    return True
-
-
 def _write_sqlite_record(path: Path, record: ReviewCheckpointRecord) -> None:
     try:
-        _write_sqlite_record_once(path, record)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            record.record,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        with closing(_connect_checkpoint(path)) as connection:
+            path.chmod(0o600)
+            connection.execute("PRAGMA busy_timeout = 5000")
+            if _ensure_checkpoint_schema(connection):
+                connection.execute(
+                    """
+                    INSERT INTO review_checkpoint_records (
+                        producer, metis_version, record_key, payload
+                    ) VALUES (?, ?, ?, ?)
+                    ON CONFLICT (producer, metis_version, record_key)
+                    DO UPDATE SET payload = excluded.payload
+                    """,
+                    (record.producer, record.metis_version, record.key, payload),
+                )
+            else:
+                connection.execute(
+                    """
+                    INSERT INTO review_checkpoint_records (
+                        metis_version, record_key, payload
+                    ) VALUES (?, ?, ?)
+                    ON CONFLICT (metis_version, record_key)
+                    DO UPDATE SET payload = excluded.payload
+                    """,
+                    (record.metis_version, record.key, payload),
+                )
+            connection.commit()
     except (OSError, sqlite3.Error) as exc:
-        if _should_discard_on(exc):
-            _discard_checkpoint(path)
-        try:
-            _write_sqlite_record_once(path, record)
-        except (OSError, sqlite3.Error) as retry_exc:
-            if _should_discard_on(retry_exc):
-                _discard_checkpoint(path)
+        logging.getLogger("metis").error(
+            "Unable to save review checkpoint %s: %s", path, exc
+        )
 
 
 def review_checkpoint_callbacks(
@@ -139,7 +136,9 @@ def review_checkpoint_callbacks(
     )
 
     def resume(producer: str) -> Mapping[str, Mapping[str, object]] | None:
-        return _sqlite_records(_checkpoint_path(checkpoint_base, producer))
+        return _sqlite_records(
+            _checkpoint_path(checkpoint_base, producer), producer=producer
+        )
 
     def checkpoint(
         payload: dict[str, object],

--- a/src/metis/cli/review_progress.py
+++ b/src/metis/cli/review_progress.py
@@ -345,6 +345,7 @@ class ExecutionGraphProgressReporter:
         self._review: ReviewCodeProgressReporter | None = None
         self._triage: TriageProgressReporter | None = None
         self._triage_task: TaskID | None = None
+        self._triage_failed = False
 
     def __call__(self, event: Mapping[str, Any] | None) -> None:
         event = event or {}
@@ -366,12 +367,12 @@ class ExecutionGraphProgressReporter:
     def finish(self) -> None:
         if self._review is not None:
             self._review.finish()
-        if self._triage is not None:
+        if self._triage is not None and not self._triage_failed:
             self._triage.finish()
         self._snapshot_stage()
 
     def _start_stage(self, stage: str) -> None:
-        self._remove_review_tasks()
+        self._remove_stage_tasks()
         self._stage = stage
         self._progress.console.rule(
             _stage_progress_label(stage).title(),
@@ -380,6 +381,7 @@ class ExecutionGraphProgressReporter:
         if stage == "review":
             self._review = ReviewCodeProgressReporter(self._progress)
         elif stage == "triage":
+            self._triage_failed = False
             self._triage_task = self._progress.add_task(
                 "[cyan]Starting triage...[/cyan]",
                 total=1,
@@ -389,12 +391,15 @@ class ExecutionGraphProgressReporter:
                 self._triage_task,
             )
 
-    def _remove_review_tasks(self) -> None:
+    def _remove_stage_tasks(self) -> None:
+        self.finish()
         if self._review is not None:
-            self._review.finish()
-            self._snapshot_stage()
             self._review.remove()
             self._review = None
+        if self._triage_task is not None:
+            self._progress.remove_task(self._triage_task)
+            self._triage_task = None
+            self._triage = None
 
     def _snapshot_stage(self) -> None:
         if self._review is None and self._triage_task is None:
@@ -415,6 +420,7 @@ class ExecutionGraphProgressReporter:
         elif kind == "execution_node_end":
             if event.get("node") == "triage":
                 if event.get("status") == "error" and self._triage_task is not None:
+                    self._triage_failed = True
                     self._progress.update(
                         self._triage_task,
                         description="[red]Triage failed[/red]",
@@ -423,7 +429,7 @@ class ExecutionGraphProgressReporter:
                     self._triage.finish()
             else:
                 self._print_node_end(event)
-        elif kind == "execution_stage_end":
+        elif kind == "execution_stage_end" and not self._triage_failed:
             self._triage.finish()
 
     def _print_node(self, event: Mapping[str, Any]) -> None:
@@ -438,8 +444,6 @@ def _node_completion_description(event: Mapping[str, Any]) -> str:
     node = escape(str(event.get("node") or "unknown"))
     if event.get("status") == "error":
         return f"[red]✗ {stage}.{node} failed[/red]"
-    if event.get("node") == "result":
-        return f"[green]✓ {stage}.{node} complete[/green]"
     if event.get("status") == "inconclusive":
         return f"[yellow]! {stage}.{node} inconclusive[/yellow]"
     return f"[green]✓ {stage}.{node} complete[/green]"

--- a/src/metis/cli/utils.py
+++ b/src/metis/cli/utils.py
@@ -11,7 +11,10 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 import sys
+from tempfile import NamedTemporaryFile
+from unicodedata import normalize
 from importlib.resources import files
+from uuid import uuid4
 
 from rich.console import Console
 from rich.errors import MarkupError
@@ -55,30 +58,34 @@ except ImportError:
     PG_SUPPORTED = False
 
 
+def print_execution_diagnostic(diagnostic, quiet):
+    color = "yellow" if diagnostic.severity == "warning" else "red"
+    print_console(f"[{color}]{escape(diagnostic.message)}[/{color}]", quiet)
+
+
 def configure_logger(logger, args):
-    if logger.hasHandlers():
-        logger.handlers.clear()
-
-    default_level = logging.ERROR
     requested_level = getattr(args, "log_level", None)
-    if isinstance(requested_level, str):
-        level = logging._nameToLevel.get(requested_level.upper(), default_level)
-    else:
-        level = default_level
-
+    level = (
+        requested_level.upper() if isinstance(requested_level, str) else logging.ERROR
+    )
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 
     console_handler = logging.StreamHandler()
     console_handler.setLevel(level)
     console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
-
+    level = console_handler.level
+    handlers = [console_handler]
     if getattr(args, "log_file", None):
         file_handler = logging.FileHandler(args.log_file)
         file_handler.setLevel(level)
         file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
+        handlers.append(file_handler)
 
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+    for handler in handlers:
+        logger.addHandler(handler)
     logger.setLevel(level)
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
@@ -305,6 +312,24 @@ def output_format(output_file: str | Path) -> str:
     return suffix.removeprefix(".") if suffix in {".html", ".csv", ".sarif"} else "json"
 
 
+def output_path_identity(output_file: str | Path) -> Path:
+    """Compare destinations using their filesystem's case and Unicode rules."""
+    path = Path(output_file).resolve()
+    parent = path.parent
+    while not parent.exists():
+        parent = parent.parent
+    # Volumes on the same host can have different case rules. Probe the actual
+    # destination volume; the temporary file is removed before publication.
+    with NamedTemporaryFile(prefix=".metis-é-", dir=parent) as probe:
+        probe_path = Path(probe.name)
+        case_insensitive = probe_path.with_name(probe_path.name.swapcase()).exists()
+        normalizes_unicode = probe_path.with_name(
+            normalize("NFD", probe_path.name)
+        ).exists()
+    identity = str(path).casefold() if case_insensitive else str(path)
+    return Path(normalize("NFC", identity) if normalizes_unicode else identity)
+
+
 def output_files_for_formats(
     output_files: list[str] | None,
     formats: tuple[str, ...],
@@ -316,16 +341,16 @@ def output_files_for_formats(
     configured = tuple(dict.fromkeys(formats))
     provided = list(output_files or ())
     if provided:
-        base = Path(provided[0]).with_suffix("")
+        base = Path(provided[0])
     else:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        base = Path("results") / f"{command}_{timestamp}"
+        base = Path("results") / f"{command}_{timestamp}_{uuid4().hex}"
 
     selected = [] if generated_output else provided
-    selected_paths = {Path(path).resolve() for path in selected}
+    selected_paths = {output_path_identity(path) for path in selected}
     if len(selected_paths) != len(selected):
         raise ValueError("Output paths must be unique")
-    reserved = {path.resolve() for path in reserved_paths or set()}
+    reserved = {output_path_identity(path) for path in reserved_paths or set()}
     if selected_paths & reserved:
         raise ValueError("Output paths for graph stages must be distinct")
     for path in selected:
@@ -339,15 +364,17 @@ def output_files_for_formats(
         if format_name in selected_formats:
             continue
         candidate = base.with_suffix(f".{format_name}")
-        if candidate.resolve() in reserved:
+        identity = output_path_identity(candidate)
+        if identity in reserved:
             if fallback_base is None:
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                fallback_base = Path("results") / f"{command}_{timestamp}"
+                fallback_base = Path("results") / f"{command}_{timestamp}_{uuid4().hex}"
             candidate = fallback_base.with_suffix(f".{format_name}")
-        if candidate.resolve() in reserved or candidate.resolve() in selected_paths:
+            identity = output_path_identity(candidate)
+        if identity in reserved or identity in selected_paths:
             raise ValueError("Output paths for graph stages must be distinct")
         selected.append(str(candidate))
-        selected_paths.add(candidate.resolve())
+        selected_paths.add(identity)
     return selected
 
 
@@ -387,52 +414,34 @@ def save_output(
     )
     sarif_payload_local = sarif_payload
 
-    def _write_payload(path: Path, payload: object, label: str) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        write_json_atomic(path, payload, indent=4)
-        _record_output_artifact(path, output_format(path))
-        print_console(
-            f"[blue]{label} saved to {escape(str(path))}[/blue]",
-            quiet,
-        )
-
     for file_entry in files:
         output_path = Path(file_entry)
-        suffix = output_path.suffix.lower()
+        format_name = output_format(output_path)
 
-        if suffix == ".html":
-            html_path = export_html(
+        if format_name == "html":
+            report_path = export_html(
                 json_payload, output_path, REPORT_TEMPLATE, METIS_VERSION
             )
-            print_console(
-                f"[blue]HTML report saved to {escape(str(html_path))}[/blue]",
-                quiet,
-            )
-            _record_output_artifact(html_path, "html")
-            continue
-
-        if suffix == ".sarif":
-            sarif_path, sarif_payload_local = export_sarif(
+        elif format_name == "sarif":
+            report_path, sarif_payload_local = export_sarif(
                 data, output_path, sarif_payload_local
             )
+        elif format_name == "csv":
+            report_path = export_csv(json_payload, output_path)
+        else:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            write_json_atomic(output_path, json_payload, indent=4)
+            _record_output_artifact(output_path, format_name)
             print_console(
-                f"[blue]SARIF report saved to {escape(str(sarif_path))}[/blue]",
-                quiet,
+                f"[blue]Results saved to {escape(str(output_path))}[/blue]", quiet
             )
-            _record_output_artifact(sarif_path, "sarif")
             continue
 
-        if suffix == ".csv":
-            csv_path = export_csv(json_payload, output_path)
-            print_console(
-                f"[blue]CSV report saved to {escape(str(csv_path))}[/blue]",
-                quiet,
-            )
-            _record_output_artifact(csv_path, "csv")
-            continue
-
-        # default to JSON
-        _write_payload(output_path, json_payload, "Results")
+        print_console(
+            f"[blue]{format_name.upper()} report saved to {escape(str(report_path))}[/blue]",
+            quiet,
+        )
+        _record_output_artifact(report_path, format_name)
 
 
 def check_file_exists(file_path, quiet=False):

--- a/src/metis/configuration.py
+++ b/src/metis/configuration.py
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Mapping
+from contextlib import nullcontext
 import logging
 import os
+import sys
 from importlib.resources import as_file
 from importlib.resources import files
 from pathlib import Path
@@ -18,22 +21,215 @@ from metis.providers.registry import get_embedding_provider
 from metis.runtime_settings import ModelToolSettings
 from metis.runtime_settings import CapabilityRuntimeSettings
 from metis.runtime_settings import TriageOptions
-from metis.utils import string_list
 
 logger = logging.getLogger("metis")
 
 
+class _UniqueSafeLoader(yaml.SafeLoader):
+    def __init__(self, stream):
+        super().__init__(stream)
+        self._checked_mappings = set()
+
+    def construct_object(self, node, deep=False):
+        try:
+            return super().construct_object(node, deep=deep)
+        except (ValueError, OverflowError) as exc:
+            if not isinstance(node, yaml.ScalarNode):
+                raise
+            raise yaml.constructor.ConstructorError(
+                None, None, str(exc), node.start_mark
+            ) from exc
+
+    def flatten_mapping(self, node):
+        # Merged nodes can be flattened before construction. Validate each original
+        # mapping once, before flattening replaces its explicit keys with inherited ones.
+        if node not in self._checked_mappings:
+            self._checked_mappings.add(node)
+            keys = set()
+            for key_node, _ in node.value:
+                if key_node.tag == "tag:yaml.org,2002:value":
+                    key_node.tag = "tag:yaml.org,2002:str"
+                key = (
+                    (key_node.tag,)
+                    if key_node.tag == "tag:yaml.org,2002:merge"
+                    else self.construct_object(key_node)
+                )
+                try:
+                    duplicate = key in keys
+                    keys.add(key)
+                except TypeError:
+                    raise yaml.constructor.ConstructorError(
+                        "while constructing a mapping",
+                        node.start_mark,
+                        "found an unhashable key",
+                        key_node.start_mark,
+                    ) from None
+                if duplicate:
+                    raise yaml.constructor.ConstructorError(
+                        "while constructing a mapping",
+                        node.start_mark,
+                        f"found duplicate key {key!r}",
+                        key_node.start_mark,
+                    )
+        return super().flatten_mapping(node)
+
+
 def load_yaml(path):
-    with open(path, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+    stream = (
+        nullcontext(path)
+        if hasattr(path, "read")
+        else open(path, "r", encoding="utf-8")
+    )
+    with stream as handle:
+        loader = _UniqueSafeLoader(handle)
+        try:
+            return loader.get_single_data()
+        finally:
+            loader.dispose()
+
+
+def _deep_merge(
+    base: Mapping[str, Any],
+    overlay: Mapping[str, Any],
+    *,
+    replace_empty: bool = False,
+) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in overlay.items():
+        existing = merged.get(key)
+        if (
+            isinstance(existing, Mapping)
+            and isinstance(value, Mapping)
+            and (value or not replace_empty)
+        ):
+            merged[key] = _deep_merge(existing, value, replace_empty=replace_empty)
+        else:
+            merged[key] = value
+    return merged
 
 
 def load_runtime_config(config_path=None, enable_psql=False):
-    cfg = load_metis_config(config_path)
+    cfg = _required_mapping(
+        load_metis_config(config_path),
+        section="configuration",
+        allowed={
+            "metis_engine",
+            "llm_provider",
+            "embedding_provider",
+            "query",
+            "psql_database",
+            "memory",
+            "language_plugins",
+        },
+    )
+    for name in (
+        "llm_provider",
+        "embedding_provider",
+        "query",
+        "psql_database",
+        "language_plugins",
+    ):
+        if name in cfg:
+            _required_mapping(cfg[name], section=name)
+    engine_defaults = _packaged_engine_config()
+    configured_engine = _required_mapping(
+        cfg.get("metis_engine", {}),
+        section="metis_engine",
+        allowed=engine_defaults,
+    )
+    engine_cfg = {**engine_defaults, **configured_engine}
+    # Only shared settings inherit defaults; graphs and node-owned settings replace them.
+    for name in ("model_tools", "capabilities", "threat_model"):
+        value = configured_engine.get(name)
+        if isinstance(value, dict) and value:
+            engine_cfg[name] = _deep_merge(
+                engine_defaults[name], value, replace_empty=True
+            )
+    for name in (
+        "model_tools",
+        "capabilities",
+        "execution",
+        "codegraph",
+        "reachability",
+        "threat_model",
+        "triage",
+        "hnsw_kwargs",
+    ):
+        _required_mapping(engine_cfg[name], section=f"metis_engine.{name}")
+    hnsw_kwargs = engine_cfg["hnsw_kwargs"]
+    for name in ("hnsw_m", "hnsw_ef_construction", "hnsw_ef_search"):
+        if name in hnsw_kwargs:
+            _required_positive_int(
+                hnsw_kwargs, name, section="metis_engine.hnsw_kwargs"
+            )
+    for name in ("max_token_length", "max_workers", "embed_dim", "doc_chunk_size"):
+        _required_positive_int(engine_cfg, name, section="metis_engine")
+    for name in ("max_active_nodes", "max_concurrent_executions"):
+        if engine_cfg[name] is None:
+            engine_cfg[name] = engine_cfg["max_workers"]
+        _required_positive_int(engine_cfg, name, section="metis_engine")
+    for name in ("doc_chunk_overlap", "triage_checkpoint_every", "llm_max_retries"):
+        _required_positive_int(engine_cfg, name, section="metis_engine", minimum=0)
+    if engine_cfg["doc_chunk_overlap"] >= engine_cfg["doc_chunk_size"]:
+        raise ValueError(
+            "metis_engine.doc_chunk_overlap must be less than doc_chunk_size"
+        )
+    for name in ("review_code_include_paths", "review_code_exclude_paths"):
+        _required_string_list(engine_cfg[name], section=f"metis_engine.{name}")
+    metisignore_file = engine_cfg["metisignore_file"]
+    if metisignore_file is not None and not isinstance(metisignore_file, str):
+        raise ValueError("metis_engine.metisignore_file must be a string or null")
+    query_cfg = _required_mapping(
+        cfg.get("query", {}),
+        section="query",
+        allowed={
+            "model",
+            "temperature",
+            "max_tokens",
+            "reasoning_effort",
+            "similarity_top_k",
+        },
+    )
+    temperature = query_cfg.get("temperature")
+    if temperature is not None and (
+        isinstance(temperature, bool)
+        or not isinstance(temperature, (int, float))
+        or not 0 <= temperature <= sys.float_info.max
+    ):
+        raise ValueError("query.temperature must be a finite non-negative number")
+    if query_cfg.get("max_tokens") is not None:
+        _required_positive_int(query_cfg, "max_tokens", section="query")
+    _required_positive_int(query_cfg, "similarity_top_k", section="query", default=5)
+    db_cfg = _required_mapping(
+        cfg.get("psql_database", {}),
+        section="psql_database",
+        allowed={"provider", "credentials"},
+    )
+    if "credentials" in db_cfg:
+        _required_mapping(
+            db_cfg["credentials"],
+            section="psql_database.credentials",
+            allowed={"username", "password", "host", "port", "database_name"},
+        )
+    capability_settings = _capability_runtime_settings(engine_cfg)
+    threat_model_config = _threat_model_config(engine_cfg["threat_model"])
+    triage_options = _triage_options(engine_cfg["triage"])
+    execution_config = load_execution_config(engine_cfg["execution"])
+
+    # Engine imports this module, so resolve its schemas after module initialization.
+    from metis.engine.nodes.codegraph.annotations import CodeGraphConfiguration
+    from metis.engine.nodes.reachability.options import ReachabilityConfiguration
+
+    CodeGraphConfiguration.model_validate(engine_cfg["codegraph"])
+    ReachabilityConfiguration.model_validate(engine_cfg["reachability"])
+
+    review_checkpoints_enabled = engine_cfg.get("review_checkpoints", True)
+    if not isinstance(review_checkpoints_enabled, bool):
+        raise ValueError("metis_engine.review_checkpoints must be a boolean")
+    memory_config = _memory_config(cfg.get("memory"))
 
     runtime: dict[str, object] = {}
     if enable_psql:
-        db_cfg = cfg.get("psql_database", {})
         provider = db_cfg.get("provider", "config")
         if provider == "env":
             secrets = dict(
@@ -56,7 +252,7 @@ def load_runtime_config(config_path=None, enable_psql=False):
             pg_db_name=secrets.get("database_name"),
         )
 
-    llm_cfg = dict(cfg.get("llm_provider") or {})
+    llm_cfg = _required_mapping(cfg.get("llm_provider", {}), section="llm_provider")
     llm_provider_name = str(llm_cfg.get("name", "")).lower()
     runtime["llm_provider_name"] = llm_provider_name
     llm_provider_cls = _get_provider_cls(
@@ -70,32 +266,20 @@ def load_runtime_config(config_path=None, enable_psql=False):
         section="llm_provider",
     )
 
-    engine_cfg = cfg.get("metis_engine", {})
-    runtime["max_token_length"] = engine_cfg.get("max_token_length", 100000)
-    runtime["max_workers"] = _required_positive_int(
-        engine_cfg,
+    for name in (
+        "max_token_length",
         "max_workers",
-        section="metis_engine",
-        default=8,
-    )
-    runtime["embed_dim"] = engine_cfg.get("embed_dim", 1536)
-    runtime["doc_chunk_size"] = engine_cfg.get("doc_chunk_size", 1024)
-    runtime["doc_chunk_overlap"] = engine_cfg.get("doc_chunk_overlap", 200)
-    runtime["triage_checkpoint_every"] = engine_cfg.get("triage_checkpoint_every", 50)
-    review_checkpoints_enabled = engine_cfg.get("review_checkpoints", True)
-    if not isinstance(review_checkpoints_enabled, bool):
-        raise ValueError("metis_engine.review_checkpoints must be a boolean")
+        "max_active_nodes",
+        "max_concurrent_executions",
+        "embed_dim",
+        "doc_chunk_size",
+        "doc_chunk_overlap",
+        "triage_checkpoint_every",
+    ):
+        runtime[name] = engine_cfg[name]
     runtime["review_checkpoints_enabled"] = review_checkpoints_enabled
-    runtime["llm_max_retries"] = int(engine_cfg.get("llm_max_retries", 5))
-    runtime["hnsw_kwargs"] = engine_cfg.get(
-        "hnsw_kwargs",
-        {
-            "hnsw_m": 16,
-            "hnsw_ef_construction": 64,
-            "hnsw_ef_search": 40,
-            "hnsw_dist_method": "vector_cosine_ops",
-        },
-    )
+    runtime["llm_max_retries"] = engine_cfg["llm_max_retries"]
+    runtime["hnsw_kwargs"] = engine_cfg["hnsw_kwargs"]
     runtime["pgvector_use_halfvec"] = pgvector_use_halfvec_setting(
         engine_cfg.get("pgvector_use_halfvec", "auto"),
         runtime["embed_dim"],
@@ -107,32 +291,18 @@ def load_runtime_config(config_path=None, enable_psql=False):
     runtime["review_code_exclude_paths"] = engine_cfg.get(
         "review_code_exclude_paths", []
     )
-    runtime["capability_settings"] = _capability_runtime_settings(engine_cfg)
-    memory_cfg = cfg.get("memory")
-    runtime["memory"] = _memory_config(memory_cfg)
-    runtime["threat_model_config"] = _threat_model_config(
-        engine_cfg.get("threat_model")
-    )
-    runtime["triage_options"] = _triage_options(engine_cfg.get("triage"))
-    runtime["execution_config"] = load_execution_config(engine_cfg.get("execution"))
-    codegraph_cfg = engine_cfg.get("codegraph") or {}
-    if not isinstance(codegraph_cfg, dict):
-        raise ValueError("metis_engine.codegraph must be a mapping")
-    runtime["codegraph_config"] = dict(codegraph_cfg)
-    reachability_cfg = engine_cfg.get("reachability") or {}
-    if not isinstance(reachability_cfg, dict):
-        raise ValueError("metis_engine.reachability must be a mapping")
-    runtime["reachability_config"] = dict(reachability_cfg)
-    language_plugins = cfg.get("language_plugins")
-    if language_plugins is None:
-        language_plugins = {}
-    if not isinstance(language_plugins, dict):
-        raise ValueError("language_plugins must be a mapping")
+    runtime["capability_settings"] = capability_settings
+    runtime["memory"] = memory_config
+    runtime["threat_model_config"] = threat_model_config
+    runtime["triage_options"] = triage_options
+    runtime["execution_config"] = execution_config
+    runtime["codegraph_config"] = dict(engine_cfg["codegraph"])
+    runtime["reachability_config"] = dict(engine_cfg["reachability"])
+    language_plugins = cfg.get("language_plugins", {})
     plugin_config = load_plugin_config()
     if language_plugins:
         plugin_config["language_plugins"] = dict(language_plugins)
     runtime["plugin_config"] = plugin_config
-    query_cfg = cfg.get("query", {})
     llama_query_model = query_cfg.get("model") or llm_provider_config.get("model", "")
     llama_query_model = str(llama_query_model or "")
     runtime["model"] = llm_provider_config.get("model", "")
@@ -156,7 +326,7 @@ def load_runtime_config(config_path=None, enable_psql=False):
     runtime["llm_provider"] = llm_provider_config
 
     runtime["embedding_provider_raw_config"] = (
-        dict(cfg.get("embedding_provider") or {}) or None
+        dict(cfg.get("embedding_provider", {})) or None
     )
 
     return runtime
@@ -190,17 +360,10 @@ def _get_provider_cls(provider_name: str, section: str) -> type:
             return get_chat_provider(provider_name)
         return get_embedding_provider(provider_name)
     except ValueError as exc:
+        surface = "chat" if section == "llm_provider" else "embedding"
+        if str(exc) != f"Unsupported {surface} provider: {provider_name}":
+            raise
         raise ValueError(f"Unsupported {section} provider: {provider_name}") from exc
-
-
-def _positive_int(value: object, *, fallback: int) -> int:
-    try:
-        parsed = int(cast(Any, value))
-    except (TypeError, ValueError):
-        return fallback
-    if parsed <= 0:
-        return fallback
-    return parsed
 
 
 def _required_positive_int(
@@ -209,23 +372,44 @@ def _required_positive_int(
     *,
     section: str,
     default: int | None = None,
+    minimum: int = 1,
 ) -> int:
     value = values.get(key, default)
-    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        raise ValueError(f"{section}.{key} must be a positive integer")
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        requirement = "positive" if minimum else "non-negative"
+        raise ValueError(f"{section}.{key} must be a {requirement} integer")
     return value
 
 
-def _required_mapping(value: object, *, section: str) -> dict[str, Any]:
+def _required_string_list(value: object, *, section: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValueError(f"{section} must be a list of strings")
+    return value
+
+
+def _required_mapping(
+    value: object,
+    *,
+    section: str,
+    allowed: Mapping | set[str] | None = None,
+) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{section} must be a mapping")
+    if allowed is not None:
+        unknown = value.keys() - allowed
+        if unknown:
+            raise ValueError(
+                f"Unknown {section} settings: {', '.join(sorted(map(str, unknown)))}"
+            )
     return value
 
 
 def _triage_options(value: object) -> TriageOptions:
     if value is None:
         return TriageOptions()
-    configured = _required_mapping(value, section="metis_engine.triage")
+    configured = _required_mapping(
+        value, section="metis_engine.triage", allowed={"include_triaged"}
+    )
     include_triaged = configured.get("include_triaged", False)
     if not isinstance(include_triaged, bool):
         raise ValueError("metis_engine.triage.include_triaged must be a boolean")
@@ -242,6 +426,11 @@ def _capability_runtime_settings(
         model.update(
             _required_mapping(configured_model, section="metis_engine.model_tools")
         )
+    _required_mapping(
+        model,
+        section="metis_engine.model_tools",
+        allowed={"max_rounds", "max_contract_chars"},
+    )
     capabilities = _load_engine_mapping("capabilities", engine.get("capabilities"))
     configurations: dict[str, dict[str, Any]] = {}
     for name, value in capabilities.items():
@@ -295,17 +484,32 @@ def _memory_config(raw_config: object) -> dict[str, object]:
 
 
 def _threat_model_config(value: object) -> dict[str, object]:
-    config = value if isinstance(value, dict) else {}
-    history = config.get("history")
-    if not isinstance(history, dict):
-        history = {}
+    config = _required_mapping(
+        value,
+        section="metis_engine.threat_model",
+        allowed={"source_patterns", "history"},
+    )
+    patterns = _required_string_list(
+        config.get("source_patterns", []),
+        section="metis_engine.threat_model.source_patterns",
+    )
+    history = _required_mapping(
+        config.get("history", {}),
+        section="metis_engine.threat_model.history",
+        allowed={"enabled", "max_commits"},
+    )
+    enabled = history.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ValueError("metis_engine.threat_model.history.enabled must be a boolean")
     return {
-        "source_patterns": string_list(config.get("source_patterns")),
+        "source_patterns": list(patterns),
         "history": {
-            "enabled": history.get("enabled") is True,
-            "max_commits": _positive_int(
-                history.get("max_commits"),
-                fallback=500,
+            "enabled": enabled,
+            "max_commits": _required_positive_int(
+                history,
+                "max_commits",
+                section="metis_engine.threat_model.history",
+                default=500,
             ),
         },
     }
@@ -320,10 +524,13 @@ def _load_engine_mapping(name: str, value: object) -> dict[str, Any]:
         raise ValueError(f"metis_engine.{name} must be a mapping")
     if isinstance(value, dict):
         return dict(value)
+    return dict(_packaged_engine_config()[name])
+
+
+def _packaged_engine_config() -> dict[str, Any]:
     resource = files("metis") / "metis.yaml"
     with as_file(resource) as real_path:
-        packaged = load_yaml(real_path)
-    return dict(packaged["metis_engine"][name])
+        return {"triage": {}, **load_yaml(real_path)["metis_engine"]}
 
 
 def load_plugin_config(plugins_path: str | Path | None = None):

--- a/src/metis/engine/__init__.py
+++ b/src/metis/engine/__init__.py
@@ -1,7 +1,22 @@
 # SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from .core import MetisEngine
+from typing import TYPE_CHECKING
+from typing import Any
+
 from metis.runtime_settings import TriageOptions
 
-__all__ = ["MetisEngine", "TriageOptions"]
+if TYPE_CHECKING:
+    from .core import ExecutionGraphError
+    from .core import MetisEngine
+
+__all__ = ["ExecutionGraphError", "MetisEngine", "TriageOptions"]
+
+
+def __getattr__(name: str) -> Any:
+    # Contract imports must not initialize the engine and its built-in nodes.
+    if name in ("ExecutionGraphError", "MetisEngine"):
+        from . import core
+
+        return getattr(core, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/metis/engine/capabilities/builtins.py
+++ b/src/metis/engine/capabilities/builtins.py
@@ -69,6 +69,7 @@ def builtin_capability_registrations(
             _required_manifest("memory"),
             MemoryCapabilityConfiguration,
             build_memory,
+            close=lambda capability: cast(MemoryService, capability).close(),
         ),
     )
 

--- a/src/metis/engine/capabilities/catalog.py
+++ b/src/metis/engine/capabilities/catalog.py
@@ -10,7 +10,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
-import yaml
+from metis.configuration import load_yaml
 
 from .contracts import CapabilityRegistration
 from .manifest import CapabilityManifest
@@ -82,7 +82,7 @@ class CapabilityCatalog:
 
 def _load_yaml_mapping(resource: Any) -> dict[str, Any]:
     with resource.open("r", encoding="utf-8") as handle:
-        loaded = yaml.safe_load(handle) or {}
+        loaded = load_yaml(handle)
     if not isinstance(loaded, dict):
         raise ValueError(
             f"Capability manifest {resource.name!r} must contain a YAML mapping"

--- a/src/metis/engine/capabilities/contracts.py
+++ b/src/metis/engine/capabilities/contracts.py
@@ -33,6 +33,12 @@ CapabilityCloser = Callable[[object], None]
 
 @dataclass(frozen=True, slots=True)
 class CapabilityRegistration:
+    """An engine-shared resource whose methods must support concurrent callers.
+
+    Construction/cleanup are synchronized; operations own their synchronization.
+    Engine-owned work drains before close. Direct callers own their lifetime.
+    """
+
     manifest: CapabilityManifest
     configuration: type[BaseModel]
     factory: CapabilityFactory

--- a/src/metis/engine/capabilities/engine.py
+++ b/src/metis/engine/capabilities/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from types import MappingProxyType
+from threading import RLock
 
 from .catalog import CapabilityCatalog
 from .contracts import CapabilityCloser
@@ -25,7 +26,10 @@ class EngineCapabilities(Mapping[str, object]):
         self._catalog = catalog
         self._context = context
         self._instances: dict[str, object] = {}
+        self._constructing: set[str] = set()
         self._closers: list[tuple[object, CapabilityCloser]] = []
+        self._lock = RLock()
+        self._closed = False
 
     def __getitem__(self, name: str) -> object:
         if name not in self._selected:
@@ -42,28 +46,56 @@ class EngineCapabilities(Mapping[str, object]):
         return self._construct(name)
 
     def manifest(self, name: str) -> CapabilityManifest:
-        return self._catalog.resolve(name).manifest
+        with self._lock:
+            return self._catalog.resolve(name).manifest
 
     def _construct(self, name: str) -> object:
-        instance = self._instances.get(name)
-        if instance is not None:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Engine capabilities are closed")
+            if name in self._instances:
+                return self._instances[name]
+            if name in self._constructing:
+                raise RuntimeError(f"Capability {name!r} is already being constructed")
+            self._constructing.add(name)
+            try:
+                registration = self._catalog.resolve(name)
+                configuration = registration.configuration.model_validate(
+                    self._configurations.get(name, {})
+                )
+                instance = registration.factory(self._context, configuration)
+            finally:
+                self._constructing.remove(name)
+            if instance is None:
+                raise TypeError(f"Capability {name!r} factory returned None")
+            if self._closed:
+                error = RuntimeError(
+                    f"Capability {name!r} was constructed after its owner closed"
+                )
+                if registration.close is not None:
+                    try:
+                        registration.close(instance)
+                    except BaseException as cleanup_error:
+                        error.add_note(
+                            f"Capability cleanup also failed: {cleanup_error}"
+                        )
+                raise error
+            self._instances[name] = instance
+            if registration.close is not None:
+                self._closers.append((instance, registration.close))
             return instance
-        registration = self._catalog.resolve(name)
-        configuration = registration.configuration.model_validate(
-            self._configurations.get(name, {})
-        )
-        instance = registration.factory(self._context, configuration)
-        self._instances[name] = instance
-        if registration.close is not None:
-            self._closers.append((instance, registration.close))
-        return instance
 
     def close(self) -> None:
-        first_error: Exception | None = None
-        for instance, close in reversed(self._closers):
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            closers, self._closers = self._closers, []
+        first_error: BaseException | None = None
+        for instance, close in reversed(closers):
             try:
                 close(instance)
-            except Exception as exc:
+            except BaseException as exc:
                 if first_error is None:
                     first_error = exc
         if first_error is not None:

--- a/src/metis/engine/capabilities/index.py
+++ b/src/metis/engine/capabilities/index.py
@@ -65,33 +65,36 @@ class IndexCapability:
         self._search_configuration = search_configuration
         self._embed_model_code = self._get_backend_embed_model("embed_model_code")
         self._embed_model_docs = self._get_backend_embed_model("embed_model_docs")
-        self._retrievers_by_top_k = {}
+        self._retrievers_by_top_k: dict[int, tuple[Any, Any]] = {}
+        self._retriever_generation = 0
+        self._constructing_embeddings = False
         self._attach_embed_models_to_backend()
         self.indexing = IndexingService(
             config,
             state,
             repository,
             get_embedding_models=self.get_embedding_models,
+            clear_retriever_cache=self.clear_retriever_cache,
         )
 
     def create_retrievers(self, top_k: int):
-        self.get_embedding_models()
-        self._config.vector_backend.init()
-        retriever_code, retriever_docs = self._config.vector_backend.get_retrievers(
-            self._config.llm_provider,
-            top_k,
-            **self._config.usage_runtime.hooks.retriever_kwargs(),
-        )
-        if not retriever_code or not retriever_docs:
-            raise RetrieverInitError()
-        return retriever_code, retriever_docs
+        with self._state.retriever_lock:
+            generation = self._retriever_generation
+            self.get_embedding_models()
+            self._config.vector_backend.init()
+            retriever_code, retriever_docs = self._config.vector_backend.get_retrievers(
+                self._config.llm_provider,
+                top_k,
+                **self._config.usage_runtime.hooks.retriever_kwargs(),
+            )
+            # A backend callback may have reset the index on this thread.
+            if generation != self._retriever_generation:
+                raise RuntimeError("Index changed during retriever construction")
+            if not retriever_code or not retriever_docs:
+                raise RetrieverInitError()
+            return retriever_code, retriever_docs
 
     def get_retrievers(self):
-        if (
-            self._state.retriever_code is not None
-            and self._state.retriever_docs is not None
-        ):
-            return self._state.retriever_code, self._state.retriever_docs
         with self._state.retriever_lock:
             if (
                 self._state.retriever_code is not None
@@ -177,23 +180,36 @@ class IndexCapability:
         )
 
     def clear_retriever_cache(self) -> None:
-        self._state.retriever_code = None
-        self._state.retriever_docs = None
-        self._retrievers_by_top_k.clear()
+        with self._state.retriever_lock:
+            self._state.retriever_code = None
+            self._state.retriever_docs = None
+            self._retrievers_by_top_k.clear()
+            self._retriever_generation += 1
 
     def close(self) -> None:
-        self.clear_retriever_cache()
-        close_fn = getattr(self._config.vector_backend, "close", None)
-        if callable(close_fn):
-            close_fn()
+        try:
+            self.indexing.close()
+        finally:
+            self.clear_retriever_cache()
 
     def get_embedding_models(self):
-        if self._embed_model_code is None:
-            self._embed_model_code = self._build_embed_model("code")
-        if self._embed_model_docs is None:
-            self._embed_model_docs = self._build_embed_model("docs")
-        self._attach_embed_models_to_backend()
-        return self._embed_model_code, self._embed_model_docs
+        with self._state.retriever_lock:
+            if self._constructing_embeddings:
+                raise RuntimeError(
+                    "Index embedding models are already being constructed"
+                )
+            self._constructing_embeddings = True
+            try:
+                code, docs = self._embed_model_code, self._embed_model_docs
+                if code is None:
+                    code = self._build_embed_model("code")
+                if docs is None:
+                    docs = self._build_embed_model("docs")
+                self._embed_model_code, self._embed_model_docs = code, docs
+                self._attach_embed_models_to_backend()
+                return code, docs
+            finally:
+                self._constructing_embeddings = False
 
     def _build_embed_model(self, kind: str):
         provider = self._config.embedding_provider

--- a/src/metis/engine/capabilities/indexing.py
+++ b/src/metis/engine/capabilities/indexing.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from typing import Any
 
 import unidiff
@@ -31,11 +32,56 @@ class IndexingService:
         repository: EngineRepository,
         *,
         get_embedding_models: Callable[[], tuple[Any, Any]],
+        clear_retriever_cache: Callable[[], None] | None = None,
     ):
         self._config = config
         self._state = state
         self._repository = repository
         self._get_embedding_models = get_embedding_models
+        self._clear_retriever_cache = clear_retriever_cache
+        # Share publication/mutation ordering, including same-thread callbacks.
+        self._mutation_lock = state.retriever_lock
+        self._active_mutations = 0
+        self._closed = False
+
+    @contextmanager
+    def _mutation(self) -> Iterator[None]:
+        with self._mutation_lock:
+            if self._closed:
+                raise RuntimeError("Index capability is closed")
+            self._active_mutations += 1
+            failure: BaseException | None = None
+            try:
+                yield
+            except BaseException as exc:
+                failure = exc
+                raise
+            finally:
+                self._active_mutations -= 1
+                # A close requested from this backend call cannot wait for itself.
+                if self._closed and not self._active_mutations:
+                    try:
+                        self._close_backend()
+                    except BaseException as exc:
+                        if failure is None:
+                            raise
+                        failure.add_note(f"Index cleanup also failed: {exc}")
+
+    def close(self) -> None:
+        with self._mutation_lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self._active_mutations:
+                raise RuntimeError(
+                    "Cannot close the active index from its backend call"
+                )
+            self._close_backend()
+
+    def _close_backend(self) -> None:
+        close = getattr(self._config.vector_backend, "close", None)
+        if callable(close):
+            close()
 
     def _get_supported_input_files(
         self,
@@ -43,12 +89,15 @@ class IndexingService:
     ) -> list[str]:
         base_path = os.path.abspath(self._config.codebase_path)
         docs_supported = {ext.lower() for ext in docs_supported_exts}
+        metisignore_spec = self._repository.load_metisignore()
         selected = []
 
         for root, _, files in os.walk(base_path):
             for file_name in files:
                 full_path = os.path.join(root, file_name)
                 if os.path.islink(full_path) and not os.path.exists(full_path):
+                    continue
+                if self._repository.is_metisignored(full_path, spec=metisignore_spec):
                     continue
                 ext = os.path.splitext(file_name)[1].lower()
                 if (
@@ -61,37 +110,41 @@ class IndexingService:
         return selected
 
     def index_codebase(self) -> None:
-        self.index_prepare_nodes()
-        self.index_finalize_embeddings()
+        pending_before = self._state.pending_nodes
+        try:
+            self.index_prepare_nodes()
+            self.index_finalize_embeddings()
+        finally:
+            if self._state.pending_nodes is not pending_before:
+                self._state.pending_nodes = None
 
     def count_index_items(self) -> int:
         docs_exts = self._config.plugin_config.get("docs", {}).get(
             "supported_extensions", [".md"]
         )
-        code_count = len(self._repository.get_code_files(include_suffixed_sources=True))
-
-        doc_count = 0
-        base_path = os.path.abspath(self._config.codebase_path)
-        metisignore_spec = self._repository.load_metisignore()
-        for root, _, files in os.walk(base_path):
-            for file_name in files:
-                full_path = os.path.join(root, file_name)
-                if os.path.splitext(file_name)[1].lower() not in docs_exts:
-                    continue
-                if self._repository.is_metisignored(full_path, spec=metisignore_spec):
-                    continue
-                doc_count += 1
-
-        return code_count + doc_count
+        return len(self._get_supported_input_files(docs_exts))
 
     def index_prepare_nodes_iter(self):
+        """Prepare nodes for this thread's next finalize call without changing the index."""
+        if self._closed:
+            raise RuntimeError("Index capability is closed")
+        if self._state.pending_nodes is not None:
+            raise RuntimeError(
+                "Finish the pending index preparation before preparing again"
+            )
         self._get_embedding_models()
-        docs_supported_exts = self._config.plugin_config.get("docs", {}).get(
-            "supported_extensions", [".md"]
-        )
+        docs_supported_exts = [
+            ext.lower()
+            for ext in self._config.plugin_config.get("docs", {}).get(
+                "supported_extensions", [".md"]
+            )
+        ]
 
         logger.info(f"Indexing codebase at: {self._config.codebase_path}")
         input_files = self._get_supported_input_files(docs_supported_exts)
+        if not input_files:
+            self._state.pending_nodes = ([], [])
+            return
         reader = SimpleDirectoryReader(
             input_files=input_files,
             filename_as_id=True,
@@ -101,25 +154,19 @@ class IndexingService:
             f"Loaded {len(documents)} documents from {self._config.codebase_path}"
         )
 
-        self._config.vector_backend.init()
-        reset_index = getattr(self._config.vector_backend, "reset_index", None)
-        if callable(reset_index):
-            reset_index()
         doc_splitter = self._repository.get_doc_splitter()
-        metisignore_spec = self._repository.load_metisignore()
         base_path = os.path.abspath(self._config.codebase_path)
         parent_dir = os.path.dirname(base_path)
         code_docs = []
         doc_docs = []
         for doc in documents:
-            if self._repository.is_metisignored(doc.id_, spec=metisignore_spec):
-                continue
-            ext = os.path.splitext(doc.id_)[1].lower()
+            file_path = doc.metadata.get("file_path") or doc.id_
+            ext = os.path.splitext(file_path)[1].lower()
             new_id = os.path.relpath(doc.id_, parent_dir)
             doc.doc_id = new_id
             doc.id_ = new_id
 
-            language_name = self._repository.get_language_name_for_path(doc.id_)
+            language_name = self._repository.get_language_name_for_path(file_path)
             if ext in docs_supported_exts:
                 doc_docs.append(doc)
             elif language_name is not None:
@@ -141,82 +188,94 @@ class IndexingService:
 
     def index_finalize_embeddings(self):
         pending = self._state.pending_nodes
-        if not pending:
-            return
-        embed_model_code, embed_model_docs = self._get_embedding_models()
-        nodes_code, nodes_docs = pending
-        self._config.vector_backend.index_nodes(
-            nodes_code,
-            nodes_docs,
-            embed_model_code=embed_model_code,
-            embed_model_docs=embed_model_docs,
-            **self._config.usage_runtime.hooks.embed_model_kwargs(),
-        )
+        if pending is None:
+            raise RuntimeError("No pending index preparation for this thread")
         self._state.pending_nodes = None
+        with self._mutation():
+            embed_model_code, embed_model_docs = self._get_embedding_models()
+            nodes_code, nodes_docs = pending
+            self._config.vector_backend.init()
+            reset_index = getattr(self._config.vector_backend, "reset_index", None)
+            if callable(reset_index):
+                if self._clear_retriever_cache is not None:
+                    self._clear_retriever_cache()
+                try:
+                    reset_index()
+                finally:
+                    if self._clear_retriever_cache is not None:
+                        self._clear_retriever_cache()
+            self._config.vector_backend.index_nodes(
+                nodes_code,
+                nodes_docs,
+                embed_model_code=embed_model_code,
+                embed_model_docs=embed_model_docs,
+                **self._config.usage_runtime.hooks.embed_model_kwargs(),
+            )
 
     def update_index(self, patch_text):
-        embed_model_code, embed_model_docs = self._get_embedding_models()
-        try:
-            patch_set = unidiff.PatchSet.from_string(patch_text)
-            logger.info("Parsed the provided patch string successfully.")
-        except Exception as e:
-            raise ParsingError(f"Error parsing patch string: {e}")
-        self._config.vector_backend.init()
+        with self._mutation():
+            embed_model_code, embed_model_docs = self._get_embedding_models()
+            try:
+                patch_set = unidiff.PatchSet.from_string(patch_text)
+                logger.info("Parsed the provided patch string successfully.")
+            except Exception as e:
+                raise ParsingError(f"Error parsing patch string: {e}")
+            self._config.vector_backend.init()
 
-        index_code, index_docs = self._config.vector_backend.get_index_handles(
-            embed_model_code=embed_model_code,
-            embed_model_docs=embed_model_docs,
-            **self._config.usage_runtime.hooks.embed_model_kwargs(),
-        )
-
-        doc_splitter = self._repository.get_doc_splitter()
-
-        for diff_file in patch_set:
-            if diff_file.is_binary_file:
-                continue
-            doc_id = os.path.join(
-                os.path.basename(os.path.abspath(self._config.codebase_path)),
-                diff_file.path,
+            index_code, index_docs = self._config.vector_backend.get_index_handles(
+                embed_model_code=embed_model_code,
+                embed_model_docs=embed_model_docs,
+                **self._config.usage_runtime.hooks.embed_model_kwargs(),
             )
-            language_name = self._repository.get_language_name_for_path(doc_id)
-            target_index = index_code if language_name is not None else index_docs
 
-            if diff_file.is_removed_file:
-                target_index.delete_ref_doc(doc_id, delete_from_docstore=True)
-            else:
-                file_path = os.path.join(self._config.codebase_path, diff_file.path)
-                file_content = read_file_content(file_path)
-                if not file_content and diff_file.is_added_file:
-                    file_content = extract_content_from_diff(diff_file)
-                if not file_content:
-                    logger.warning("No content available for %s", diff_file.path)
+            doc_splitter = self._repository.get_doc_splitter()
+
+            for diff_file in patch_set:
+                if diff_file.is_binary_file:
                     continue
-                doc = Document(
-                    text=file_content,
-                    metadata={"file_name": diff_file.path},
-                    id_=doc_id,
+                doc_id = os.path.join(
+                    os.path.basename(os.path.abspath(self._config.codebase_path)),
+                    diff_file.path,
                 )
+                language_name = self._repository.get_language_name_for_path(doc_id)
+                target_index = index_code if language_name is not None else index_docs
 
-                if diff_file.is_added_file:
-                    if language_name is not None:
-                        plugin = self._repository.get_plugin_for_path(doc_id)
-                        if not plugin:
-                            continue
-                        splitter = self._repository.get_splitter_cached(plugin)
-                        try:
-                            nodes = splitter.get_nodes_from_documents([doc])
-                        except Exception as e:
-                            logger.warning(
-                                "Could not parse code with language %s for file %s: %s",
-                                plugin.get_name(),
-                                doc.id_,
-                                e,
-                            )
-                            continue
-                    else:
-                        nodes = doc_splitter.get_nodes_from_documents([doc])
-                    target_index.insert_nodes(nodes)
+                if diff_file.is_removed_file:
+                    target_index.delete_ref_doc(doc_id, delete_from_docstore=True)
                 else:
-                    target_index.update_ref_doc(doc)
-                target_index.docstore.set_document_hash(doc.id_, doc.hash)
-        logger.info("Index update complete based on the provided patch diff.")
+                    file_path = os.path.join(self._config.codebase_path, diff_file.path)
+                    file_content = read_file_content(file_path)
+                    if not file_content and diff_file.is_added_file:
+                        file_content = extract_content_from_diff(diff_file)
+                    if not file_content:
+                        logger.warning("No content available for %s", diff_file.path)
+                        continue
+                    doc = Document(
+                        text=file_content,
+                        metadata={"file_name": diff_file.path},
+                        id_=doc_id,
+                    )
+
+                    if diff_file.is_added_file:
+                        if language_name is not None:
+                            plugin = self._repository.get_plugin_for_path(doc_id)
+                            if not plugin:
+                                continue
+                            splitter = self._repository.get_splitter_cached(plugin)
+                            try:
+                                nodes = splitter.get_nodes_from_documents([doc])
+                            except Exception as e:
+                                logger.warning(
+                                    "Could not parse code with language %s for file %s: %s",
+                                    plugin.get_name(),
+                                    doc.id_,
+                                    e,
+                                )
+                                continue
+                        else:
+                            nodes = doc_splitter.get_nodes_from_documents([doc])
+                        target_index.insert_nodes(nodes)
+                    else:
+                        target_index.update_ref_doc(doc)
+                    target_index.docstore.set_document_hash(doc.id_, doc.hash)
+            logger.info("Index update complete based on the provided patch diff.")

--- a/src/metis/engine/capabilities/manifest.py
+++ b/src/metis/engine/capabilities/manifest.py
@@ -4,14 +4,18 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Any
 
 
 def _as_tuple(values: Iterable[Any] | None) -> tuple[str, ...]:
-    return tuple(
-        str(value).strip().lower() for value in values or () if str(value).strip()
-    )
+    if values is None:
+        return ()
+    if not isinstance(values, (list, tuple)) or any(
+        not isinstance(value, str) for value in values
+    ):
+        raise ValueError("Capability operation surfaces must be a list of strings")
+    return tuple(value.strip().lower() for value in values if value.strip())
 
 
 def _as_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
@@ -33,7 +37,17 @@ class CapabilityOperationManifest:
     status: str = "active"
 
     def __post_init__(self) -> None:
-        capability_id = str(self.id or "").strip().lower()
+        for key in ("id", "name", "description", "status"):
+            if not isinstance(getattr(self, key), str):
+                raise ValueError(f"Capability operation {key} must be a string")
+        if self.operation is not None and not isinstance(self.operation, str):
+            raise ValueError("Capability operation operation must be a string")
+        object.__setattr__(
+            self,
+            "input_schema",
+            _as_mapping(self.input_schema, field_name="input_schema"),
+        )
+        capability_id = self.id.strip()
         name = str(self.name or "").strip()
         if not capability_id:
             raise ValueError("Capability operation id is required")
@@ -48,17 +62,13 @@ class CapabilityOperationManifest:
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "CapabilityOperationManifest":
-        return cls(
-            id=str(data.get("id") or ""),
-            name=str(data.get("name") or ""),
-            description=str(data.get("description") or ""),
-            surfaces=tuple(data.get("surfaces") or ()),
-            operation=data.get("operation"),
-            input_schema=_as_mapping(
-                data.get("input_schema"), field_name="input_schema"
-            ),
-            status=str(data.get("status") or "active"),
-        )
+        data = _as_mapping(data, field_name="manifest")
+        unknown = data.keys() - {item.name for item in fields(cls)}
+        if unknown:
+            raise ValueError(
+                f"Unknown capability operation settings: {', '.join(sorted(map(str, unknown)))}"
+            )
+        return cls(**{"id": "", "name": "", **data})
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,7 +79,22 @@ class CapabilityManifest:
     operations: tuple[CapabilityOperationManifest, ...] = ()
 
     def __post_init__(self) -> None:
-        name = str(self.name or "").strip().lower()
+        if not isinstance(self.name, str) or not isinstance(self.status, str):
+            raise ValueError("Capability manifest name and status must be strings")
+        if not isinstance(self.contracts, Mapping) or any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in self.contracts.items()
+        ):
+            raise ValueError("Capability manifest contracts must map names to strings")
+        if not isinstance(self.operations, (list, tuple)) or any(
+            not isinstance(operation, CapabilityOperationManifest)
+            for operation in self.operations
+        ):
+            raise ValueError(
+                "Capability manifest operations must be operation manifests"
+            )
+        object.__setattr__(self, "operations", tuple(self.operations))
+        name = self.name.strip()
         if not name:
             raise ValueError("Capability manifest name is required")
         object.__setattr__(self, "name", name)
@@ -86,13 +111,23 @@ class CapabilityManifest:
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "CapabilityManifest":
-        operations = tuple(
-            CapabilityOperationManifest.from_mapping(item)
-            for item in data.get("operations") or ()
-        )
+        if not isinstance(data, Mapping):
+            raise ValueError("Capability manifest must be a mapping")
+        unknown = data.keys() - {item.name for item in fields(cls)}
+        if unknown:
+            raise ValueError(
+                f"Unknown capability manifest settings: {', '.join(sorted(map(str, unknown)))}"
+            )
+        operations = data.get("operations", ())
+        if not isinstance(operations, (list, tuple)):
+            raise ValueError("Capability manifest operations must be a list")
         return cls(
-            name=str(data.get("name") or ""),
-            status=str(data.get("status") or "active"),
-            contracts=dict(data.get("contracts") or {}),
-            operations=operations,
+            **{
+                "name": "",
+                **data,
+                "operations": tuple(
+                    CapabilityOperationManifest.from_mapping(item)
+                    for item in operations
+                ),
+            }
         )

--- a/src/metis/engine/capabilities/navigation.py
+++ b/src/metis/engine/capabilities/navigation.py
@@ -16,7 +16,7 @@ from pydantic import ConfigDict
 from pydantic import Field
 
 from metis.engine.source import SourceMap
-from metis.utils import resolve_path_within_root
+from metis.utils import resolve_path_within_root, source_lines
 
 _PYTHON_REGEX_REWRITES = (
     ("[[:space:]]", r"\s"),
@@ -111,7 +111,7 @@ class NavigationCapability:
                 text = file_path.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue
-            for lineno, line in enumerate(text.splitlines(), start=1):
+            for lineno, line in enumerate(source_lines(text), start=1):
                 if regex.search(line):
                     lines.append(f"{rel}:{lineno}:{line}")
                     if sum(len(x) + 1 for x in lines) >= self.max_chars:
@@ -161,7 +161,7 @@ class NavigationCapability:
         target = self._resolve_path(path)
         if not target.is_file():
             raise FileNotFoundError(str(target))
-        lines = target.read_text(encoding="utf-8", errors="ignore").splitlines()
+        lines = source_lines(target.read_text(encoding="utf-8", errors="ignore"))
         start_idx = max(0, start_line - 1)
         end_idx = min(len(lines), end_line)
         body = "\n".join(lines[start_idx:end_idx])

--- a/src/metis/engine/codegraph/models.py
+++ b/src/metis/engine/codegraph/models.py
@@ -478,6 +478,18 @@ class CodeGraph:
                     f"Code graph node {node_id!r} belongs to unrequested file "
                     f"{node.file_path!r}"
                 )
+            if not isinstance(node.call_sites, (list, tuple)) or not all(
+                isinstance(call, CallSite) for call in node.call_sites
+            ):
+                raise ValueError(
+                    f"Code graph node {node_id!r} has invalid call metadata"
+                )
+            if not isinstance(node.references, (list, tuple)) or not all(
+                isinstance(reference, SymbolReference) for reference in node.references
+            ):
+                raise ValueError(
+                    f"Code graph node {node_id!r} has invalid reference metadata"
+                )
             expected_name_index.setdefault(node.name, []).append(node_id)
             invalid_targets = [
                 target for target in node.resolved_calls if target not in self.nodes
@@ -506,6 +518,13 @@ class CodeGraph:
             if construct.unique_name != global_id:
                 raise ValueError(
                     f"Code graph global index corruption for ID {global_id!r}"
+                )
+            if not isinstance(construct.references, (list, tuple)) or not all(
+                isinstance(reference, SymbolReference)
+                for reference in construct.references
+            ):
+                raise ValueError(
+                    f"Code graph global {global_id!r} has invalid reference metadata"
                 )
             invalid_targets = [
                 target

--- a/src/metis/engine/concurrency.py
+++ b/src/metis/engine/concurrency.py
@@ -10,7 +10,9 @@ from collections.abc import Sequence
 from concurrent.futures import CancelledError
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from contextvars import Context
+from contextvars import ContextVar
 from contextvars import copy_context
 from dataclasses import dataclass
 from dataclasses import field
@@ -24,6 +26,17 @@ if TYPE_CHECKING:
     from metis.engine.execution.contracts import NodeJobs
 
 
+def _validate_worker_limit(value: int, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+
+
+@dataclass(eq=False, slots=True)
+class _JobQuota:
+    limit: int
+    active: int = 0
+
+
 @dataclass(eq=False, slots=True)
 class _JobRun[JobT, ResultT]:
     pending: deque[JobT]
@@ -31,15 +44,19 @@ class _JobRun[JobT, ResultT]:
     max_concurrency: int
     context: Context
     cancellation: threading.Event | None
+    parents: tuple[threading.Event, ...]
+    quotas: tuple[_JobQuota, ...]
     total: int
     active: dict[Future[ResultT], JobT] = field(default_factory=dict)
     completed: deque[tuple[JobT, Future[ResultT]]] = field(default_factory=deque)
     collecting: bool = False
     cancelled: bool = False
+    failure: BaseException | None = None
 
 
 class JobScheduler:
     def __init__(self, max_workers: int) -> None:
+        _validate_worker_limit(max_workers, "max_workers")
         self._max_workers = max_workers
         self._executor = ThreadPoolExecutor(
             max_workers=max_workers,
@@ -50,14 +67,21 @@ class JobScheduler:
         self._active_workers = 0
         self._cursor = 0
         self._closed = False
+        self._dispatching = False
+        self._in_worker: ContextVar[threading.Event | None] = ContextVar(
+            "metis_scheduler_worker", default=None
+        )
 
     def limit(self, max_concurrency: int) -> "NodeJobs":
-        return _NodeJobs(self, self._max_workers, None).limit(max_concurrency)
+        return _NodeJobs(self, self._max_workers, threading.Event()).limit(
+            max_concurrency
+        )
 
     def close(self) -> None:
+        active_worker = self._in_worker.get()
+        if active_worker is not None and active_worker.is_set():
+            raise RuntimeError("Cannot close a job scheduler from its own worker")
         with self._condition:
-            if self._closed:
-                return
             self._closed = True
             for run in tuple(self._runs):
                 self._cancel_locked(run)
@@ -73,23 +97,45 @@ class JobScheduler:
         label: str | None,
         result_key: Callable[[JobT], object],
         on_complete: Callable[[JobT, int, int], None] | None,
+        parents: tuple[threading.Event, ...] = (),
+        quotas: tuple[_JobQuota, ...] = (),
     ) -> list[ResultT]:
+        _validate_worker_limit(max_concurrency, "max_concurrency")
+        active_worker = self._in_worker.get()
+        if active_worker is not None and active_worker.is_set():
+            raise RuntimeError("Nested jobs on the same scheduler are not supported")
+        with self._condition:
+            if self._closed:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            if (cancellation is not None and cancellation.is_set()) or any(
+                parent.is_set() for parent in parents
+            ):
+                raise CancelledError("Concurrent jobs were cancelled")
         if not jobs:
             return []
 
         def invoke_worker(job: JobT) -> ResultT:
-            if label is None:
-                return worker(job)
-            key = result_key(job)
-            with runlog.span(
-                "task",
-                label,
-                {"kind": "concurrent_job", "key": key},
-            ) as task_span:
-                runlog.bump("tasks")
-                result = worker(job)
-                task_span.end(attributes={"result": result})
-                return result
+            active_worker = threading.Event()
+            active_worker.set()
+            token = self._in_worker.set(active_worker)
+            try:
+                if run.cancelled:
+                    raise CancelledError("Concurrent jobs were cancelled")
+                if label is None:
+                    return worker(job)
+                key = result_key(job)
+                with runlog.span(
+                    "task",
+                    label,
+                    {"kind": "concurrent_job", "key": key},
+                ) as task_span:
+                    runlog.bump("tasks")
+                    result = worker(job)
+                    task_span.end(attributes={"result": result})
+                    return result
+            finally:
+                active_worker.clear()
+                self._in_worker.reset(token)
 
         run = _JobRun(
             pending=deque(jobs),
@@ -97,17 +143,22 @@ class JobScheduler:
             max_concurrency=min(max_concurrency, self._max_workers),
             context=copy_context(),
             cancellation=cancellation,
+            parents=parents,
+            quotas=quotas,
             total=len(jobs),
         )
-        self._register(run)
         results: list[ResultT] = []
         completed_count = 0
         try:
+            self._register(run)
             while completed_count < run.total:
                 with self._condition:
                     self._condition.wait_for(
-                        lambda: bool(run.completed) or run.cancelled
+                        lambda: bool(run.completed) or run.cancelled,
+                        timeout=0.1 if cancellation is not None or parents else None,
                     )
+                    if self._is_cancelled(run):
+                        self._cancel_locked(run)
                     completed = tuple(run.completed)
                     run.completed.clear()
                     cancelled = run.cancelled
@@ -115,12 +166,16 @@ class JobScheduler:
                 if cancelled:
                     with self._condition:
                         self._condition.wait_for(lambda: not run.active)
+                    if run.failure is not None:
+                        raise run.failure
                     raise CancelledError("Concurrent jobs were cancelled")
                 for job, future in completed:
                     results.append(future.result())
                     completed_count += 1
                     if on_complete is not None:
                         on_complete(job, completed_count, run.total)
+                    if run.cancelled or self._is_cancelled(run):
+                        raise CancelledError("Concurrent jobs were cancelled")
                 with self._condition:
                     run.collecting = False
                     self._dispatch_locked()
@@ -128,7 +183,9 @@ class JobScheduler:
         except BaseException:
             with self._condition:
                 self._cancel_locked(run)
-                self._condition.wait_for(lambda: not run.active)
+                while run.active:
+                    with suppress(BaseException):
+                        self._condition.wait_for(lambda: not run.active)
             raise
         finally:
             self._remove(run)
@@ -137,14 +194,14 @@ class JobScheduler:
         cancellation.set()
         with self._condition:
             for run in tuple(self._runs):
-                if run.cancellation is cancellation:
+                if run.cancellation is cancellation or cancellation in run.parents:
                     self._cancel_locked(run)
 
     def _register(self, run: _JobRun[Any, Any]) -> None:
         with self._condition:
             if self._closed:
                 raise RuntimeError("cannot schedule new futures after shutdown")
-            if run.cancellation is not None and run.cancellation.is_set():
+            if self._is_cancelled(run):
                 raise CancelledError("Concurrent jobs were cancelled")
             self._runs.append(run)
             self._cursor = len(self._runs) - 1
@@ -168,51 +225,73 @@ class JobScheduler:
         if run.cancelled:
             return
         run.cancelled = True
+        if run.cancellation is not None:
+            run.cancellation.set()
         run.pending.clear()
         for future in tuple(run.active):
             future.cancel()
         self._condition.notify_all()
 
+    @staticmethod
+    def _is_cancelled(run: _JobRun[Any, Any]) -> bool:
+        return (run.cancellation is not None and run.cancellation.is_set()) or any(
+            parent.is_set() for parent in run.parents
+        )
+
     def _dispatch_locked(self) -> None:
-        available = self._max_workers - self._active_workers
-        while not self._closed and available > 0:
-            run = self._next_run_locked()
-            if run is None:
-                return
-            job = run.pending.popleft()
-            future = self._executor.submit(
-                run.context.copy().run,
-                run.worker,
-                job,
-            )
-            run.active[future] = job
-            self._active_workers += 1
-            available -= 1
-            future.add_done_callback(partial(self._complete, run))
+        if self._dispatching:
+            return
+        self._dispatching = True
+        try:
+            while not self._closed and self._active_workers < self._max_workers:
+                run = self._next_run_locked()
+                if run is None:
+                    return
+                job = run.pending.popleft()
+                try:
+                    future = self._executor.submit(
+                        run.context.copy().run,
+                        run.worker,
+                        job,
+                    )
+                except BaseException as error:
+                    run.failure = error
+                    self._cancel_locked(run)
+                    continue
+                run.active[future] = job
+                self._active_workers += 1
+                for quota in run.quotas:
+                    quota.active += 1
+                future.add_done_callback(partial(self._complete, run))
+        finally:
+            self._dispatching = False
 
     def _next_run_locked(self) -> _JobRun[Any, Any] | None:
         for run in self._runs:
-            if run.cancellation is not None and run.cancellation.is_set():
+            if self._is_cancelled(run):
                 self._cancel_locked(run)
-        eligible = [
-            run
-            for run in self._runs
-            if not run.cancelled
-            and run.pending
-            and not run.completed
-            and not run.collecting
-            and len(run.active) < run.max_concurrency
-        ]
-        if not eligible:
+        # Prefer less active runs, breaking ties from the rotating cursor.
+        index = min(
+            (
+                index
+                for index, run in enumerate(self._runs)
+                if not run.cancelled
+                and run.pending
+                and not run.completed
+                and not run.collecting
+                and len(run.active) < run.max_concurrency
+                and all(quota.active < quota.limit for quota in run.quotas)
+            ),
+            key=lambda index: (
+                len(self._runs[index].active),
+                (index - self._cursor) % len(self._runs),
+            ),
+            default=None,
+        )
+        if index is None:
             return None
-        minimum_active = min(len(run.active) for run in eligible)
-        for offset in range(len(self._runs)):
-            index = (self._cursor + offset) % len(self._runs)
-            run = self._runs[index]
-            if run in eligible and len(run.active) == minimum_active:
-                self._cursor = (index + 1) % len(self._runs)
-                return run
-        raise AssertionError("Fair job scheduler could not select an eligible run")
+        self._cursor = (index + 1) % len(self._runs)
+        return self._runs[index]
 
     def _complete(
         self,
@@ -222,7 +301,10 @@ class JobScheduler:
         with self._condition:
             job = run.active.pop(future)
             self._active_workers -= 1
+            for quota in run.quotas:
+                quota.active -= 1
             run.completed.append((job, future))
+            self._dispatch_locked()
             self._condition.notify_all()
 
 
@@ -232,22 +314,45 @@ class _NodeJobs:
         scheduler: JobScheduler,
         max_concurrency: int,
         cancellation: threading.Event | None,
+        parents: tuple[threading.Event, ...] = (),
+        quotas: tuple[_JobQuota, ...] = (),
+        explicit_cancellation: bool = False,
     ) -> None:
         self._scheduler = scheduler
         self._max_concurrency = max_concurrency
         self._cancellation = cancellation
+        self._parents = parents
+        self._quotas = quotas
+        self._explicit_cancellation = explicit_cancellation
 
     def limit(self, max_concurrency: int) -> "_NodeJobs":
-        if max_concurrency < 1:
-            raise ValueError("max_concurrency must be positive")
+        _validate_worker_limit(max_concurrency, "max_concurrency")
+        maximum = min(max_concurrency, self._max_concurrency)
+        quotas = self._quotas
+        if not quotas or maximum < self._max_concurrency:
+            quotas = (*quotas, _JobQuota(maximum))
         return _NodeJobs(
             self._scheduler,
-            min(max_concurrency, self._max_concurrency),
+            maximum,
             self._cancellation,
+            self._parents,
+            quotas,
+            self._explicit_cancellation,
         )
 
     def with_cancellation(self, cancellation: threading.Event) -> "_NodeJobs":
-        return _NodeJobs(self._scheduler, self._max_concurrency, cancellation)
+        """Inherit parent cancellation; cancelling this scope leaves parents intact."""
+        parents = self._parents
+        if self._cancellation is not None and self._cancellation is not cancellation:
+            parents = (*parents, self._cancellation)
+        return _NodeJobs(
+            self._scheduler,
+            self._max_concurrency,
+            cancellation,
+            parents,
+            self._quotas,
+            True,
+        )
 
     def cancel(self) -> None:
         if self._cancellation is not None:
@@ -262,14 +367,22 @@ class _NodeJobs:
         result_key: Callable[[JobT], object],
         on_complete: Callable[[JobT, int, int], None] | None = None,
     ) -> list[ResultT]:
+        cancellation = self._cancellation
+        parents = self._parents
+        if not self._explicit_cancellation:
+            if cancellation is not None:
+                parents = (*parents, cancellation)
+            cancellation = threading.Event()
         return self._scheduler.run(
             jobs,
             worker,
             max_concurrency=self._max_concurrency,
-            cancellation=self._cancellation,
+            cancellation=cancellation,
             label=label,
             result_key=result_key,
             on_complete=on_complete,
+            parents=parents,
+            quotas=self._quotas,
         )
 
 
@@ -279,7 +392,7 @@ def serialized_progress_callback(callback):
     if getattr(callback, "_metis_serialized_progress_callback", False):
         return callback
 
-    lock = threading.Lock()
+    lock = threading.RLock()
 
     def _serialized(event):
         with lock:

--- a/src/metis/engine/core.py
+++ b/src/metis/engine/core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from pathlib import Path
+from threading import RLock
 from typing import Any
 from typing import Literal
 from typing import cast
@@ -13,6 +14,7 @@ from typing import cast
 from metis import runlog
 from metis.chat_model_options import merge_chat_model_kwargs
 from metis.configuration import _required_positive_int
+from metis.configuration import _required_string_list
 from metis.configuration import load_execution_config
 from metis.configuration import load_plugin_config
 from metis.plugins.c_family.codegraph import CFamilyCodeGraphProvider
@@ -52,6 +54,22 @@ from .tools.index import index_model_tools
 logger = logging.getLogger("metis")
 
 
+class ExecutionGraphError(RuntimeError):
+    """A failed execution, including validated outputs and structured diagnostics."""
+
+    def __init__(self, result: ExecutionResult) -> None:
+        self.result = ExecutionResult(
+            status=result.status,
+            outputs={
+                name: _execution_value(value, strict=False)
+                for name, value in result.outputs.items()
+            },
+            diagnostics=result.diagnostics,
+        )
+        details = "; ".join(diagnostic.message for diagnostic in result.diagnostics)
+        super().__init__(f"Execution graph failed: {details or result.status.value}")
+
+
 class MetisEngine:
     def __init__(
         self,
@@ -64,6 +82,9 @@ class MetisEngine:
     ) -> None:
         self.codebase_path = codebase_path
         self._runlog = runlog
+        self._close_lock = RLock()
+        self._closed = False
+        self._triage_classifier = None
 
         required_keys = [
             "max_workers",
@@ -81,6 +102,19 @@ class MetisEngine:
             "max_workers",
             section="MetisEngine",
         )
+        for name in ("max_active_nodes", "max_concurrent_executions"):
+            if kwargs.get(name) is None:
+                kwargs[name] = max_workers
+            _required_positive_int(kwargs, name, section="MetisEngine")
+        for name in ("review_code_include_paths", "review_code_exclude_paths"):
+            _required_string_list(kwargs.get(name, []), section=f"MetisEngine.{name}")
+        metisignore_file = kwargs.get("metisignore_file")
+        if metisignore_file is not None and not isinstance(
+            metisignore_file, (str, Path)
+        ):
+            raise ValueError(
+                "MetisEngine.metisignore_file must be a string, Path, or null"
+            )
         max_token_length = cast(int, kwargs["max_token_length"])
         llama_query_model = cast(str, kwargs["llama_query_model"])
         similarity_top_k = cast(int, kwargs["similarity_top_k"])
@@ -130,6 +164,8 @@ class MetisEngine:
             custom_prompt_text=kwargs.get("custom_prompt_text"),
             custom_guidance_precedence=custom_guidance_precedence,
             max_workers=max_workers,
+            max_active_nodes=kwargs["max_active_nodes"],
+            max_concurrent_executions=kwargs["max_concurrent_executions"],
             max_token_length=max_token_length,
             llama_query_model=llama_query_model,
             chat_model_kwargs=chat_model_kwargs,
@@ -168,24 +204,24 @@ class MetisEngine:
             ),
         )
         self._config.memory_service = None
-        codegraphs = CodeGraphService(
-            self._config,
-            self.repository,
-            discover_provider_factories(
-                {
-                    "c": CFamilyCodeGraphProvider,
-                    "cpp": CFamilyCodeGraphProvider,
-                },
-            ),
-            annotation_settings=codegraph_config,
-            semantics=CodeGraphSemanticsCatalog(
-                providers={
-                    "c": CFamilyCodeGraphSemantics(),
-                    "cpp": CFamilyCodeGraphSemantics(),
-                },
-            ),
-        )
         try:
+            codegraphs = CodeGraphService(
+                self._config,
+                self.repository,
+                discover_provider_factories(
+                    {
+                        "c": CFamilyCodeGraphProvider,
+                        "cpp": CFamilyCodeGraphProvider,
+                    },
+                ),
+                annotation_settings=codegraph_config,
+                semantics=CodeGraphSemanticsCatalog(
+                    providers={
+                        "c": CFamilyCodeGraphSemantics(),
+                        "cpp": CFamilyCodeGraphSemantics(),
+                    },
+                ),
+            )
             builtin_execution = build_builtin_execution(
                 execution_config,
                 engine_config=self._config,
@@ -197,13 +233,16 @@ class MetisEngine:
                 reachability_settings=reachability_settings,
                 review_graph_factory=self._get_review_graph,
             )
-        except Exception:
-            self.capabilities.close()
+            self.execution = builtin_execution.execution
+            self._triage_service = builtin_execution.triage_service
+            self._triage_classifier = builtin_execution.triage_classifier
+            self._config.memory_service = self.capabilities.get("memory")
+        except BaseException as exc:
+            try:
+                self.close()
+            except BaseException as cleanup_error:
+                exc.add_note(f"Engine cleanup also failed: {cleanup_error}")
             raise
-        self.execution = builtin_execution.execution
-        self._triage_service = builtin_execution.triage_service
-        self._triage_classifier = builtin_execution.triage_classifier
-        self._config.memory_service = self.capabilities.get("memory")
 
     @contextlib.contextmanager
     def _execution_span(self, name: str, attributes: dict[str, object] | None = None):
@@ -409,20 +448,46 @@ class MetisEngine:
             return _execution_value(triage)
 
     def close(self):
-        self.execution.close()
-        if self._triage_classifier is not None:
-            self._triage_classifier.close()
-        self.capabilities.close()
+        execution = getattr(self, "execution", None)
+        first_error: BaseException | None = None
+        if execution is not None:
+            execution.check_can_close()
+            try:
+                execution.close()
+            except BaseException as exc:
+                first_error = exc
+        with self._close_lock:
+            resources = (
+                () if self._closed else (self._triage_classifier, self.capabilities)
+            )
+            self._closed = True
+        for resource in resources:
+            if resource is None:
+                continue
+            try:
+                resource.close()
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
 
 
-def _execution_value(value):
-    model_dump = getattr(value, "model_dump", None)
-    if callable(model_dump):
-        return model_dump(mode="json", by_alias=True)
-    if isinstance(value, dict):
-        return {key: _execution_value(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_execution_value(item) for item in value]
+def _execution_value(value, *, strict: bool = True):
+    try:
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            return model_dump(mode="json", by_alias=True)
+        if isinstance(value, dict):
+            return {
+                key: _execution_value(item, strict=strict)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [_execution_value(item, strict=strict) for item in value]
+    except Exception:
+        if strict:
+            raise
     return value
 
 
@@ -432,6 +497,4 @@ def _require_execution_outputs(result):
             log = logger.warning if diagnostic.severity == "warning" else logger.error
             log(diagnostic.message)
         return result.outputs
-    details = "; ".join(diagnostic.message for diagnostic in result.diagnostics)
-    message = details or result.status.value
-    raise RuntimeError(f"Execution graph failed: {message}")
+    raise ExecutionGraphError(result)

--- a/src/metis/engine/execution/compiler.py
+++ b/src/metis/engine/execution/compiler.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from collections.abc import Sequence
 from dataclasses import dataclass
+from copy import deepcopy
 from types import MappingProxyType
-from types import UnionType
 from typing import Any
-from typing import Union
+from typing import Literal
+from typing import NewType
+from typing import Tuple
 from typing import get_args
 from typing import get_origin
 
@@ -19,6 +22,9 @@ from .contracts import CapabilityRequirement
 from .contracts import NodeRegistration
 from .contracts import StageName
 from .contracts import annotation_allows_none
+from .contracts import annotation_adapter
+from .contracts import annotation_members
+from .contracts import collection_item_annotation
 from .graph import ConfiguredNode
 from .graph import InputBinding
 from .graph import StageConfiguration
@@ -31,6 +37,7 @@ class _PlannedNode:
     definition: ConfiguredNode
     registration: NodeRegistration
     configuration: BaseModel
+    configuration_values: Mapping[str, object]
     input_bindings: Mapping[str, InputBinding]
     dependencies: frozenset[str]
     required_dependencies: frozenset[str]
@@ -52,6 +59,14 @@ def compile_stage(
     initial_inputs: Mapping[str, Any],
     capabilities: Mapping[str, object] | None = None,
 ) -> StagePlan:
+    for input_name, annotation in initial_inputs.items():
+        try:
+            annotation_adapter(annotation)
+        except Exception as exc:
+            raise TypeError(
+                f"Execution stage {stage_name!r} input {input_name!r} has an "
+                f"unsupported annotation: {annotation!r}"
+            ) from exc
     available_capabilities = capabilities or MappingProxyType({})
     unknown_configuration = set(configuration) - set(stage.nodes)
     if unknown_configuration:
@@ -91,8 +106,9 @@ def compile_stage(
                 f"Execution node {stage_name}.{name} requested unavailable "
                 f"capabilities: {names}"
             )
+        configuration_values = deepcopy(dict(configuration.get(name, {})))
         node_configuration = registration.configuration.model_validate(
-            configuration.get(name, {})
+            deepcopy(configuration_values)
         )
         unknown_inputs = set(definition.inputs) - set(registration.inputs)
         if unknown_inputs:
@@ -111,7 +127,10 @@ def compile_stage(
             input_name
             for input_name, annotation in registration.inputs.items()
             if input_name not in input_bindings
-            and input_name not in initial_inputs
+            and (
+                input_name not in initial_inputs
+                or initial_inputs[input_name] is type(None)
+            )
             and not annotation_allows_none(annotation)
         }
         if missing_inputs:
@@ -133,6 +152,14 @@ def compile_stage(
         required_dependencies = set(definition.depends_on)
         for input_name, binding in input_bindings.items():
             collection = isinstance(binding, tuple)
+            if (
+                collection
+                and collection_item_annotation(registration.inputs[input_name]) is None
+            ):
+                raise ValueError(
+                    f"Execution node {stage_name}.{name} input {input_name!r} "
+                    "does not accept multiple sources"
+                )
             for source in _sources(binding):
                 if source.startswith("$inputs."):
                     stage_input = source.removeprefix("$inputs.")
@@ -152,8 +179,9 @@ def compile_stage(
                     continue
                 producer_name, _, _output_name = source.partition(".")
                 dependencies.add(producer_name)
-                if not collection and not annotation_allows_none(
-                    registration.inputs[input_name]
+                if input_name in registration.required_when_bound or (
+                    not collection
+                    and not annotation_allows_none(registration.inputs[input_name])
                 ):
                     required_dependencies.add(producer_name)
         planned[name] = _PlannedNode(
@@ -161,6 +189,7 @@ def compile_stage(
             definition,
             registration,
             node_configuration,
+            MappingProxyType(configuration_values),
             MappingProxyType(input_bindings),
             frozenset(dependencies),
             frozenset(required_dependencies),
@@ -184,13 +213,14 @@ def compile_stage(
             for source in _sources(binding):
                 if source.startswith("$inputs."):
                     continue
-                _validate_reference(
+                _validate_input_annotation(
                     stage_name,
                     name,
                     input_name,
-                    source,
-                    registrations,
+                    _reference_annotation(stage_name, source, registrations),
+                    registrations[name].inputs[input_name],
                     collection=isinstance(binding, tuple),
+                    source_name=source,
                 )
     output_bindings = (
         dict(stage.outputs)
@@ -236,8 +266,9 @@ def _infer_input_bindings(
     for input_name, annotation in registration.inputs.items():
         if input_name in bindings or input_name in initial_inputs:
             continue
-        collection = get_origin(annotation) is tuple
-        target = get_args(annotation)[0] if collection else annotation
+        item = collection_item_annotation(annotation)
+        collection = item is not None
+        target = item if collection else annotation
         compatible = tuple(
             f"{producer_name}.{output_name}"
             for producer_name, producer in registrations.items()
@@ -256,31 +287,6 @@ def _infer_input_bindings(
                 f"matches multiple outputs: {sources}"
             )
     return bindings
-
-
-def _validate_reference(
-    stage_name: StageName,
-    node_name: str,
-    input_name: str,
-    source: str,
-    registrations: Mapping[str, NodeRegistration],
-    *,
-    collection: bool = False,
-) -> None:
-    source_annotation = _reference_annotation(stage_name, source, registrations)
-    target = registrations[node_name].inputs[input_name]
-    if collection:
-        if get_origin(target) is not tuple:
-            raise ValueError(
-                f"Execution node {stage_name}.{node_name} input {input_name!r} "
-                "does not accept multiple sources"
-            )
-        target = get_args(target)[0]
-    if not _annotations_compatible(source_annotation, target):
-        raise ValueError(
-            f"Execution node {stage_name}.{node_name} input {input_name!r} is not "
-            f"compatible with {source!r}"
-        )
 
 
 def _reference_annotation(
@@ -317,18 +323,24 @@ def _validate_input_annotation(
     target: Any,
     *,
     collection: bool = False,
+    source_name: str | None = None,
 ) -> None:
     if collection:
-        if get_origin(target) is not tuple:
+        item = collection_item_annotation(target)
+        if item is None:
             raise ValueError(
                 f"Execution node {stage_name}.{node_name} input {input_name!r} "
                 "does not accept multiple sources"
             )
-        target = get_args(target)[0]
+        target = item
     if not _annotations_compatible(source, target):
-        raise ValueError(
-            f"Execution node {stage_name}.{node_name} input {input_name!r} "
+        reason = (
             "is incompatible with the stage input"
+            if source_name is None
+            else f"is not compatible with {source_name!r}"
+        )
+        raise ValueError(
+            f"Execution node {stage_name}.{node_name} input {input_name!r} {reason}"
         )
 
 
@@ -336,47 +348,101 @@ def _sources(binding: str | tuple[str, ...]) -> tuple[str, ...]:
     return binding if isinstance(binding, tuple) else (binding,)
 
 
-def _annotations_compatible(source: Any, target: Any) -> bool:
-    if target is Any:
+def _annotations_compatible(
+    source: Any,
+    target: Any,
+    _active_pairs: tuple[tuple[Any, Any], ...] = (),
+) -> bool:
+    pair = (source, target)
+    if pair in _active_pairs:
+        # Close this recursive branch; its other members still need checking.
         return True
-    if source is Any:
-        return False
-    source_members = (
-        get_args(source) if get_origin(source) in {Union, UnionType} else (source,)
-    )
-    target_members = (
-        get_args(target) if get_origin(target) in {Union, UnionType} else (target,)
-    )
-    return all(
-        any(_member_compatible(s, t) for t in target_members) for s in source_members
-    )
+    active_pairs = (*_active_pairs, pair)
+    source_members = annotation_members(source)
+    target_members = annotation_members(target)
+    for member in source_members:
+        if get_origin(member) is Literal:
+            for value in get_args(member):
+                if not any(
+                    any(
+                        type(value) is type(candidate) and value == candidate
+                        for candidate in get_args(target)
+                    )
+                    if get_origin(target) is Literal
+                    else _member_compatible(type(value), target, active_pairs)
+                    for target in target_members
+                ):
+                    return False
+        elif not any(
+            _member_compatible(member, target, active_pairs)
+            for target in target_members
+        ):
+            return False
+    return True
 
 
-def _member_compatible(source: Any, target: Any) -> bool:
+def _member_compatible(
+    source: Any, target: Any, active_pairs: tuple[tuple[Any, Any], ...]
+) -> bool:
+    source = tuple if source is Tuple else tuple[()] if source == Tuple[()] else source
+    target = tuple if target is Tuple else tuple[()] if target == Tuple[()] else target
     if source == target or target is Any:
         return True
+    if isinstance(source, NewType):
+        return _annotations_compatible(source.__supertype__, target, active_pairs)
     if source is Any:
         return False
     source_origin = get_origin(source)
     target_origin = get_origin(target)
-    if source_origin is None and target_origin is None:
-        return (
-            isinstance(source, type)
-            and isinstance(target, type)
-            and issubclass(source, target)
-        )
-    if target_origin is None:
-        return (
-            isinstance(target, type)
-            and isinstance(source_origin, type)
-            and (issubclass(source_origin, target))
-        )
-    if source_origin is not target_origin:
-        return False
     source_args = get_args(source)
     target_args = get_args(target)
+    if target_origin is Literal:
+        return source is type(None) and None in target_args
+    if source is bool and target in (int, float):
+        return False
+    source_type = source_origin or source
+    target_type = target_origin or target
+    if not isinstance(source_type, type) or not isinstance(target_type, type):
+        return False
+    try:
+        if not issubclass(source_type, target_type):
+            return False
+    except TypeError:
+        return False
+    if target == tuple[()]:
+        return source == tuple[()]
+    if target_origin is None or not target_args:
+        return True
+    if source_origin is None:
+        return False
+    if source_origin is tuple and target_origin is Sequence:
+        values = (
+            source_args[:1]
+            if len(source_args) == 2 and source_args[1] is Ellipsis
+            else source_args
+        )
+        return (
+            bool(source_args)
+            and all(
+                _annotations_compatible(item, target_args[0], active_pairs)
+                for item in values
+            )
+            or source == tuple[()]
+        )
+    if source_origin is tuple and target_origin is tuple:
+        source_collection = len(source_args) == 2 and source_args[1] is Ellipsis
+        target_collection = len(target_args) == 2 and target_args[1] is Ellipsis
+        if target_collection:
+            values = source_args[:1] if source_collection else source_args
+            return all(
+                _annotations_compatible(item, target_args[0], active_pairs)
+                for item in values
+            )
+        if source_collection:
+            return False
     if len(source_args) != len(target_args):
         return False
-    if source_origin is not tuple:
-        return source_args == target_args
-    return all(_annotations_compatible(s, t) for s, t in zip(source_args, target_args))
+    return all(
+        _annotations_compatible(s, t, active_pairs)
+        for s, t in zip(source_args, target_args)
+    )

--- a/src/metis/engine/execution/contracts.py
+++ b/src/metis/engine/execution/contracts.py
@@ -9,18 +9,35 @@ from collections.abc import Sequence
 from concurrent.futures import CancelledError
 from dataclasses import dataclass
 from dataclasses import field
+from dataclasses import is_dataclass
+from dataclasses import replace
 from enum import Enum
+from operator import getitem
 from threading import Event
 from types import MappingProxyType
+from types import UnionType
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Annotated
 from typing import Literal
+from typing import NewType
+from typing import ParamSpec
 from typing import Protocol
 from typing import TypeAlias
+from typing import TypeAliasType
+from typing import TypeVarTuple
+from typing import Unpack
+from typing import Union
 from typing import get_args
+from typing import get_origin
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import InstanceOf
+from pydantic import PydanticUserError
+from pydantic import TypeAdapter
+from pydantic_core import SchemaValidator
+from pydantic_core import core_schema
 
 from metis.engine.codegraph import CodeGraph
 from metis.engine.codegraph import CodeGraphDiagnostic
@@ -29,6 +46,7 @@ from metis.engine.llm_runner import JsonPromptRequest
 from metis.utils import count_tokens
 
 if TYPE_CHECKING:
+    from metis.engine.source import ProfiledSourceArtifact
     from metis.engine.stages.triage.contracts import TriageAdjudicator
 
 StageName: TypeAlias = str
@@ -37,8 +55,279 @@ ResultFormat = Literal["sarif", "json", "html", "csv"]
 NodeHandler = Callable[["NodeInvocation"], "NodeResult"]
 
 
+def annotation_members(
+    annotation: Any, _aliases: tuple[Any, ...] = ()
+) -> tuple[Any, ...]:
+    if annotation is None:
+        annotation = type(None)
+    if isinstance(annotation, TypeAliasType):
+        if annotation in _aliases:
+            return ()
+        return annotation_members(annotation.__value__, (*_aliases, annotation))
+    origin = get_origin(annotation)
+    if isinstance(origin, TypeAliasType):
+        if annotation in _aliases:
+            return ()
+        return annotation_members(_alias_value(annotation), (*_aliases, annotation))
+    if get_origin(annotation) is Annotated:
+        return annotation_members(get_args(annotation)[0], _aliases)
+    if get_origin(annotation) in {Union, UnionType}:
+        return tuple(
+            member
+            for argument in get_args(annotation)
+            for member in annotation_members(argument, _aliases)
+        )
+    return (annotation,)
+
+
+def _alias_value(annotation: Any) -> Any:
+    origin = get_origin(annotation)
+    if origin is None:
+        return annotation.__value__
+    # Python substitutes declaration-order, unused and variadic parameters.
+    parameters = tuple(
+        Unpack[parameter] if isinstance(parameter, TypeVarTuple) else parameter
+        for parameter in origin.__type_params__
+    )
+    bound = tuple.__class_getitem__((*parameters, origin.__value__))[
+        get_args(annotation)
+    ]
+    return get_args(bound)[-1]
+
+
+def _concrete_tuple_annotations(annotation: Any) -> Any:
+    recursive: set[int] = set()
+
+    def normalize(candidate: Any, aliases: tuple[Any, ...] = ()) -> Any:
+        origin = get_origin(candidate)
+        if isinstance(candidate, TypeAliasType) or isinstance(origin, TypeAliasType):
+            if candidate in aliases:
+                recursive.update(map(id, aliases[aliases.index(candidate) :]))
+                return candidate
+            value = _alias_value(candidate)
+            normalized = normalize(value, (*aliases, candidate))
+            alias = origin if origin is not None else candidate
+            variadic = any(
+                isinstance(parameter, TypeVarTuple)
+                for parameter in alias.__type_params__
+            )
+            if normalized != value or variadic:
+                if id(candidate) in recursive:
+                    raise TypeError(
+                        "Recursive tuple unpack annotations are unsupported"
+                    )
+                return normalized
+            return candidate
+        if isinstance(candidate, NewType):
+            normalized = normalize(candidate.__supertype__, aliases)
+            return candidate if normalized == candidate.__supertype__ else normalized
+        if origin is None or origin is Literal:
+            return candidate
+        if origin is Unpack:
+            raise TypeError("Tuple unpack must appear inside a tuple annotation")
+        arguments = get_args(candidate)
+        if origin is Annotated:
+            normalized = (normalize(arguments[0], aliases), *arguments[1:])
+        elif origin is Callable and len(arguments) == 2:
+            parameters, result = arguments
+            normalized = (
+                [normalize(item, aliases) for item in parameters]
+                if isinstance(parameters, list)
+                else parameters,
+                normalize(result, aliases),
+            )
+        else:
+            expanded: list[Any] = []
+            for argument in arguments:
+                if origin is tuple and (
+                    get_origin(argument) is Unpack
+                    or getattr(argument, "__unpacked__", False)
+                ):
+                    unpacked = (
+                        get_args(argument)[0]
+                        if get_origin(argument) is Unpack
+                        else argument
+                    )
+                    unpacked = normalize(unpacked, aliases)
+                    if get_origin(unpacked) is not tuple:
+                        raise TypeError("Tuple unpack must contain a concrete tuple")
+                    items = get_args(unpacked)
+                    if Ellipsis in items and len(arguments) != 1:
+                        raise TypeError(
+                            "Mixed variable-length tuple unpack is unsupported"
+                        )
+                    expanded.extend(items)
+                else:
+                    expanded.append(normalize(argument, aliases))
+            normalized = tuple(expanded)
+        if normalized == arguments:
+            return candidate
+        if origin in (Union, UnionType):
+            return Union[normalized]
+        if origin is Annotated:
+            return getitem(Annotated, normalized)
+        if hasattr(candidate, "copy_with"):
+            return candidate.copy_with(normalized)
+        return origin[normalized]
+
+    return normalize(annotation)
+
+
 def annotation_allows_none(annotation: Any) -> bool:
-    return type(None) in get_args(annotation)
+    return any(
+        member is Any
+        or member is type(None)
+        or (get_origin(member) is Literal and None in get_args(member))
+        for member in annotation_members(annotation)
+    )
+
+
+def collection_item_annotation(annotation: Any) -> Any | None:
+    members = tuple(
+        member
+        for member in annotation_members(annotation)
+        if member is not type(None) and member != Literal[None]
+    )
+    if len(members) == 1 and get_origin(members[0]) is tuple:
+        arguments = get_args(members[0])
+        if len(arguments) == 2 and arguments[1] is Ellipsis:
+            return type(None) if arguments[0] is None else arguments[0]
+    return None
+
+
+def annotation_adapter(annotation: Any) -> SchemaValidator:
+    # arbitrary_types_allowed also accepts arbitrary *values* as unchecked Any.
+    # Reject those before Pydantic builds a permissive schema for a malformed port.
+    pending: list[tuple[Any, frozenset[int]]] = [(annotation, frozenset())]
+    seen: set[tuple[int, frozenset[int]]] = set()
+    while pending:
+        candidate, bound_parameters = pending.pop()
+        key = (id(candidate), bound_parameters)
+        if key in seen or id(candidate) in bound_parameters:
+            continue
+        seen.add(key)
+        if candidate is None or isinstance(candidate, type):
+            continue
+        if isinstance(candidate, TypeAliasType):
+            pending.append((candidate.__value__, bound_parameters))
+            continue
+        if isinstance(candidate, NewType):
+            pending.append((candidate.__supertype__, bound_parameters))
+            continue
+        origin = get_origin(candidate)
+        if origin is None or isinstance(origin, ParamSpec):
+            raise TypeError(f"Expected a concrete port type, got {candidate!r}")
+        if origin is Literal:
+            continue
+        arguments = get_args(candidate)
+        if origin is Annotated:
+            pending.append((arguments[0], bound_parameters))
+            continue
+        if isinstance(origin, TypeAliasType):
+            parameters = origin.__type_params__
+            pending.append(
+                (origin.__value__, bound_parameters | frozenset(map(id, parameters)))
+            )
+            for index, argument in enumerate(arguments):
+                if index < len(parameters) and isinstance(parameters[index], ParamSpec):
+                    # A ParamSpec supplies a Callable's argument list through an alias.
+                    if argument is Ellipsis:
+                        continue
+                    if isinstance(argument, (list, tuple)):
+                        pending.extend((item, bound_parameters) for item in argument)
+                        continue
+                pending.append((argument, bound_parameters))
+            continue
+        if origin is Callable and len(arguments) == 2:
+            parameters, result = arguments
+            pending.append((result, bound_parameters))
+            if parameters is not Ellipsis:
+                pending.extend(
+                    (item, bound_parameters)
+                    for item in (
+                        parameters if isinstance(parameters, list) else (parameters,)
+                    )
+                )
+            continue
+        if origin is tuple and len(arguments) == 2 and arguments[1] is Ellipsis:
+            arguments = arguments[:1]
+        pending.extend((argument, bound_parameters) for argument in arguments)
+    annotation = _concrete_tuple_annotations(annotation)
+    try:
+        adapter = TypeAdapter(
+            annotation, config=ConfigDict(arbitrary_types_allowed=True)
+        )
+    except PydanticUserError as exc:
+        if exc.code != "type-adapter-config-unused":
+            raise
+        base = (
+            get_args(annotation)[0]
+            if get_origin(annotation) is Annotated
+            else annotation
+        )
+        if is_dataclass(base):
+            instance_annotation = InstanceOf.__class_getitem__(base)
+            if base is not annotation:
+                instance_annotation = getitem(
+                    Annotated, (instance_annotation, *get_args(annotation)[1:])
+                )
+            adapter = TypeAdapter(instance_annotation)
+        else:
+            adapter = TypeAdapter(annotation)
+    adapter.rebuild(raise_errors=True)
+    return SchemaValidator(_strict_port_schema(adapter.core_schema))
+
+
+def _strict_port_schema(schema: Any) -> Any:
+    # Work on Pydantic's resolved schema, including generic/recursive definitions.
+    # Copy schema structures only; defaults, metadata and cached model schemas stay intact.
+    if isinstance(schema, list):
+        return [_strict_port_schema(item) for item in schema]
+    if isinstance(schema, tuple):
+        return tuple(_strict_port_schema(item) for item in schema)
+    if not isinstance(schema, dict):
+        return schema
+    inner = schema
+    while inner.get("type") in ("function-before", "function-after", "function-wrap"):
+        inner = inner["schema"]
+    guard: core_schema.CoreSchema
+    if inner.get("type") == "model":
+        guard = core_schema.is_instance_schema(
+            inner["cls"], cls_repr=inner["cls"].__name__
+        )
+    elif schema.get("type") == "float":
+        guard = core_schema.is_instance_schema(float)
+    elif schema.get("type") == "literal":
+
+        def exact_literal(value: object) -> object:
+            if not any(
+                type(value) is type(expected) and value == expected
+                for expected in schema["expected"]
+            ):
+                raise ValueError("literal type and value must match")
+            return value
+
+        guard = core_schema.no_info_plain_validator_function(exact_literal)
+    else:
+        return {
+            key: value
+            if isinstance(schema.get("type"), str)
+            and key
+            in {
+                "metadata",
+                "config",
+                "serialization",
+                "default",
+                "expected",
+                "function",
+            }
+            else _strict_port_schema(value)
+            for key, value in schema.items()
+        }
+    original = dict(schema)
+    # References must resolve to the guarded branch, including recursive model ports.
+    reference = original.pop("ref", None)
+    return core_schema.chain_schema([guard, original], ref=reference)
 
 
 class NodeRepository(Protocol):
@@ -55,6 +344,8 @@ class NodeRepository(Protocol):
     def get_language_name_for_path(self, path: str) -> str | None: ...
 
     def source_profile_applies_to_path(self, path: str) -> bool: ...
+
+    def install_profiled_source(self, artifact: ProfiledSourceArtifact) -> None: ...
 
 
 class NodePromptRunner(Protocol):
@@ -73,6 +364,12 @@ class NodeCodeGraphs(Protocol):
 
 
 class NodeJobs(Protocol):
+    """Bounded jobs; child cancellation inherits parents without cancelling them.
+
+    with_cancellation binds the supplied Event; cancel must set that Event and
+    discard queued work. run drains active work before returning or raising.
+    """
+
     def limit(self, max_concurrency: int) -> "NodeJobs": ...
 
     def with_cancellation(self, cancellation: Event) -> "NodeJobs": ...
@@ -121,6 +418,11 @@ DiagnosticCallback = Callable[[ExecutionDiagnostic], None]
 
 @dataclass(frozen=True, slots=True)
 class NodeCallbacks:
+    """Inline callbacks; only progress is serialized within one execution.
+
+    Callers synchronize other callbacks and callbacks shared across executions.
+    """
+
     progress: ProgressCallback | None = None
     debug: DebugCallback | None = None
     checkpoint: CheckpointCallback | None = None
@@ -156,6 +458,21 @@ class NodeRuntime:
             self,
             "chat_model_kwargs",
             MappingProxyType(dict(self.chat_model_kwargs)),
+        )
+
+    def _with_cancellation(self) -> NodeRuntime:
+        """Own a child signal shared by the runtime and its job handle."""
+        if self.jobs is None:
+            raise RuntimeError("Node job scheduler is unavailable")
+        cancellation = Event()
+
+        def is_cancelled() -> bool:
+            return cancellation.is_set() or self.is_cancelled()
+
+        return replace(
+            self,
+            jobs=self.jobs.with_cancellation(cancellation),
+            is_cancelled=is_cancelled,
         )
 
 
@@ -216,13 +533,19 @@ class NodeRegistration:
     outputs: Mapping[str, Any]
     execute: NodeHandler
     capabilities: Mapping[str, CapabilityRequirement] = field(default_factory=dict)
+    # Nullable inputs can still require a configured producer to finish successfully.
+    required_when_bound: frozenset[str] = frozenset()
 
     def __post_init__(self) -> None:
-        if not self.name:
+        if not isinstance(self.name, str) or not self.name:
             raise ValueError("Execution node name must not be empty")
         if not self.name.isidentifier():
             raise ValueError(f"Execution node name {self.name!r} must be an identifier")
-        if not self.stage or not self.stage.isidentifier():
+        if (
+            not isinstance(self.stage, str)
+            or not self.stage
+            or not self.stage.isidentifier()
+        ):
             raise ValueError(f"Invalid execution stage: {self.stage!r}")
         if not isinstance(self.configuration, type) or not issubclass(
             self.configuration, BaseModel
@@ -230,13 +553,34 @@ class NodeRegistration:
             raise TypeError("Execution node configuration must be a Pydantic model")
         if not callable(self.execute):
             raise TypeError(f"Execution node {self.name!r} handler is not callable")
+        if not all(
+            isinstance(ports, Mapping)
+            for ports in (self.inputs, self.outputs, self.capabilities)
+        ):
+            raise TypeError(
+                "Execution node inputs, outputs and capabilities must be mappings"
+            )
         for port in (*self.inputs, *self.outputs):
-            if not port.isidentifier():
+            if not isinstance(port, str) or not port.isidentifier():
                 raise ValueError(
                     f"Execution node {self.name!r} has invalid port {port!r}"
                 )
+        for port, annotation in (*self.inputs.items(), *self.outputs.items()):
+            try:
+                annotation_adapter(annotation)
+            except Exception as exc:
+                raise TypeError(
+                    f"Execution node {self.name!r} port {port!r} has an unsupported "
+                    f"annotation: {annotation!r}"
+                ) from exc
+        if isinstance(self.required_when_bound, (str, bytes)):
+            raise TypeError("Required-when-bound ports must be a collection of names")
+        required_when_bound = frozenset(self.required_when_bound)
+        if not required_when_bound <= self.inputs.keys():
+            raise ValueError("Required-when-bound ports must be declared node inputs")
+        object.__setattr__(self, "required_when_bound", required_when_bound)
         for capability, requirement in self.capabilities.items():
-            if not capability.isidentifier():
+            if not isinstance(capability, str) or not capability.isidentifier():
                 raise ValueError(
                     f"Execution node {self.name!r} has invalid capability "
                     f"{capability!r}"

--- a/src/metis/engine/execution/runner.py
+++ b/src/metis/engine/execution/runner.py
@@ -4,19 +4,18 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import suppress
 from concurrent.futures import CancelledError
 from concurrent.futures import FIRST_COMPLETED
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait
 from dataclasses import dataclass
+from copy import deepcopy
 from dataclasses import replace
-from threading import Event
 from time import perf_counter
 from typing import Any
-from typing import get_origin
 
-from pydantic import TypeAdapter
 from pydantic import ValidationError
 
 from metis import runlog
@@ -32,6 +31,7 @@ from .contracts import NodeRegistration
 from .contracts import NodeResult
 from .contracts import StageName
 from .contracts import annotation_allows_none
+from .contracts import annotation_adapter
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +46,8 @@ def run_stage(
     planned: StagePlan,
     context: NodeContext,
     initial_inputs: Mapping[str, object],
+    *,
+    executor: ThreadPoolExecutor | None = None,
 ) -> StageRun:
     with runlog.span(
         "stage",
@@ -71,28 +73,25 @@ def run_stage(
         completed: set[str] = set()
         pending = {node.name for node in planned.nodes}
         stage_started = perf_counter()
-        cancellation = Event()
-        stage_jobs = context.jobs.with_cancellation(cancellation)
-        stage_context = replace(
-            context,
-            runtime=replace(
-                context.runtime,
-                jobs=stage_jobs,
-                is_cancelled=cancellation.is_set,
-            ),
-        )
+        if context.runtime.is_cancelled():
+            raise CancelledError("Execution stage was cancelled")
+        stage_context = replace(context, runtime=context.runtime._with_cancellation())
         _progress(
             stage_context,
             {"event": "execution_stage_start", "stage": stage_name},
         )
-        worker_count = min(context.runtime.max_workers, len(planned.nodes))
-        executor = ThreadPoolExecutor(
-            max_workers=worker_count,
-            thread_name_prefix="metis-node",
-        )
+        owns_executor = executor is None
+        if executor is None:
+            executor = ThreadPoolExecutor(
+                max_workers=min(context.runtime.max_workers, len(planned.nodes)),
+                thread_name_prefix="metis-node",
+            )
         running: dict[Future[NodeResult], _PlannedNode] = {}
+        failure: BaseException | None = None
         try:
             while pending or running:
+                if stage_context.runtime.is_cancelled():
+                    raise CancelledError("Execution stage was cancelled")
                 for node in planned.nodes:
                     if node.name not in pending or not node.dependencies <= completed:
                         continue
@@ -120,6 +119,7 @@ def run_stage(
                 finished, _unfinished = wait(
                     tuple(running),
                     return_when=FIRST_COMPLETED,
+                    timeout=0.1,
                 )
                 for future in finished:
                     node = running.pop(future)
@@ -135,14 +135,32 @@ def run_stage(
                         and status is ExecutionStatus.OK
                     ):
                         status = ExecutionStatus.INCONCLUSIVE
-        except BaseException:
-            cancellation.set()
-            stage_jobs.cancel()
-            for future in running:
-                future.cancel()
-            raise
+            if stage_context.runtime.is_cancelled():
+                raise CancelledError("Execution stage was cancelled")
+        except BaseException as exc:
+            failure = exc
         finally:
-            executor.shutdown(wait=True, cancel_futures=True)
+            while True:
+                try:
+                    if failure is not None:
+                        stage_context.jobs.cancel()
+                        for future in running:
+                            future.cancel()
+                    # Drain only this stage, for either executor ownership path.
+                    # done() includes cancelled futures removed from the work queue.
+                    for future in running:
+                        while not future.done():
+                            with suppress(BaseException):
+                                future.result()
+                    if owns_executor:
+                        executor.shutdown(wait=True, cancel_futures=True)
+                    break
+                except BaseException as exc:
+                    # Shutdown is idempotent; finish cleanup before raising the first error.
+                    if failure is None:
+                        failure = exc
+        if failure is not None:
+            raise failure
         diagnostics = [
             diagnostic
             for node in planned.nodes
@@ -152,8 +170,9 @@ def run_stage(
             tolerated_failures = {
                 source.partition(".")[0]
                 for node in planned.nodes
-                for binding in node.input_bindings.values()
+                for input_name, binding in node.input_bindings.items()
                 if isinstance(binding, tuple)
+                and input_name not in node.registration.required_when_bound
                 for source in binding
                 if not source.startswith("$inputs.")
             }
@@ -187,10 +206,14 @@ def run_stage(
                 "duration_seconds": perf_counter() - stage_started,
             },
         )
+        if stage_context.runtime.is_cancelled():
+            raise CancelledError("Execution stage was cancelled")
         stage_span.end(
             status=status.value,
             attributes={"outputs": stage_outputs, "diagnostics": diagnostics},
         )
+        if stage_context.runtime.is_cancelled():
+            raise CancelledError("Execution stage was cancelled")
         return StageRun(status, stage_outputs, tuple(diagnostics))
 
 
@@ -248,7 +271,9 @@ def _run_node(
                 callbacks=(
                     replace(
                         context.callbacks,
-                        progress=lambda event: progress({**event, "node": node.name}),
+                        progress=lambda event: progress(
+                            {**event, "stage": stage_name, "node": node.name}
+                        ),
                     )
                     if progress is not None
                     else context.callbacks
@@ -263,17 +288,36 @@ def _run_node(
                         else context.runtime.token_counter
                     ),
                     jobs=context.jobs.limit(max_concurrency),
-                ),
+                )._with_cancellation(),
             )
             result = node.registration.execute(
                 NodeInvocation(
-                    configuration=node.configuration,
+                    configuration=node.registration.configuration.model_validate(
+                        deepcopy(dict(node.configuration_values))
+                    ),
                     inputs=inputs,
                     context=node_context,
                     formats=node.definition.formats,
                     filename=node.definition.filename,
                 )
             )
+            if not isinstance(result, NodeResult):
+                raise TypeError("handler must return a NodeResult")
+            if not isinstance(result.status, ExecutionStatus):
+                raise TypeError("NodeResult status must be an ExecutionStatus")
+            if not isinstance(result.outputs, Mapping):
+                raise TypeError("NodeResult outputs must be a mapping")
+            if not isinstance(result.diagnostics, tuple) or not all(
+                isinstance(diagnostic, ExecutionDiagnostic)
+                and isinstance(diagnostic.code, str)
+                and isinstance(diagnostic.message, str)
+                and isinstance(diagnostic.severity, str)
+                and diagnostic.severity in ("warning", "error")
+                for diagnostic in result.diagnostics
+            ):
+                raise TypeError(
+                    "NodeResult diagnostics must be ExecutionDiagnostic values"
+                )
             diagnostics = result.diagnostics
             node_status = result.status
             if node_status is not ExecutionStatus.ERROR:
@@ -281,6 +325,10 @@ def _run_node(
                     node.registration,
                     result.outputs,
                 )
+                if node_context.runtime.is_cancelled():
+                    raise CancelledError("Execution node was cancelled")
+        except CancelledError:
+            raise
         except Exception as exc:
             node_error = exc
             node_status = ExecutionStatus.ERROR
@@ -304,15 +352,26 @@ def _run_node(
         if context.callbacks.diagnostic is not None:
             for diagnostic in diagnostics:
                 context.callbacks.diagnostic(diagnostic)
+        # Job failures also signal their scope; preserve those as node errors.
+        if (
+            node_status is not ExecutionStatus.ERROR
+            and node_context.runtime.is_cancelled()
+        ):
+            raise CancelledError("Execution node was cancelled")
         node_span.end(
             status=node_status.value,
             attributes={
                 "inputs": inputs,
-                "outputs": result.outputs if result is not None else {},
+                "outputs": node_outputs,
                 "diagnostics": diagnostics,
             },
             exc=node_error,
         )
+        if (
+            node_status is not ExecutionStatus.ERROR
+            and node_context.runtime.is_cancelled()
+        ):
+            raise CancelledError("Execution node was cancelled")
         return NodeResult(node_outputs, node_status, diagnostics)
 
 
@@ -367,7 +426,7 @@ def _resolve_inputs(
                 if item.startswith("$inputs.") or _source_is_available(item, outputs)
             )
         elif source.startswith("$inputs."):
-            value = initial_inputs[source.removeprefix("$inputs.")]
+            value = initial_inputs.get(source.removeprefix("$inputs."))
         elif not _source_is_available(source, outputs) and annotation_allows_none(
             annotation
         ):
@@ -375,7 +434,7 @@ def _resolve_inputs(
         else:
             value = _resolve_source(source, outputs, initial_inputs)
         if (
-            get_origin(annotation) is tuple
+            isinstance(source, tuple)
             and not value
             and not annotation_allows_none(annotation)
         ):
@@ -404,15 +463,7 @@ def _validate_outputs(
 
 
 def _validate_value(annotation: Any, value: object) -> object:
-    if annotation is Any:
-        return value
-    if get_origin(annotation) is None and isinstance(annotation, type):
-        if not isinstance(value, annotation):
-            raise ValueError(
-                f"expected {annotation.__name__}, got {type(value).__name__}"
-            )
-        return value
-    return TypeAdapter(annotation).validate_python(value)
+    return annotation_adapter(annotation).validate_python(value, strict=True)
 
 
 def _resolve_source(
@@ -421,7 +472,7 @@ def _resolve_source(
     initial_inputs: Mapping[str, object],
 ) -> object:
     if source.startswith("$inputs."):
-        return initial_inputs[source.removeprefix("$inputs.")]
+        return initial_inputs.get(source.removeprefix("$inputs."))
     producer_name, separator, output_name = source.partition(".")
     producer_outputs = outputs[producer_name]
     if not separator:

--- a/src/metis/engine/external_stages/schemas.py
+++ b/src/metis/engine/external_stages/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, constr
+from pydantic import BaseModel, ConfigDict, Field, constr, field_validator
 
 from metis.engine.stages.triage.models import TriageDecisionModel
 
@@ -15,10 +15,18 @@ VALIDATION_RESULT_CONTRACT_VERSION = "metis.external.validation-result/v1"
 
 
 class ExternalStageCommandModel(BaseModel):
-    command: list[constr(strip_whitespace=True, min_length=1)] = Field(
-        description="Command argv template. Placeholders are expanded by Metis."
+    command: list[str] = Field(
+        min_length=1,
+        description="Command argv template. Placeholders are expanded by Metis.",
     )
     timeout_seconds: int = Field(default=3600, gt=0)
+
+    @field_validator("command")
+    @classmethod
+    def validate_executable(cls, command: list[str]) -> list[str]:
+        if not command[0].strip():
+            raise ValueError("Command executable must be nonempty")
+        return command
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/metis/engine/external_stages/service.py
+++ b/src/metis/engine/external_stages/service.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from metis.sarif.triage import apply_triage_result
 from metis.sarif.triage import load_sarif_file
@@ -116,6 +117,10 @@ class ExternalStageService:
         resolved_run_dir.mkdir(parents=True, exist_ok=True)
         codebase = _resolve_codebase_path(codebase_path or self.codebase_path)
         output_sarif = resolved_run_dir / "analysis.sarif"
+        if output_sarif.exists():
+            raise FileExistsError(
+                f"External stage output already exists: {output_sarif}"
+            )
         request_path = resolved_run_dir / "analysis-request.json"
         request = AnalysisRequestModel(
             run_id=resolved_run_dir.name,
@@ -125,7 +130,7 @@ class ExternalStageService:
             prompt=prompt,
             output_sarif=str(output_sarif),
         )
-        _write_json(request_path, request.model_dump(mode="json"))
+        _write_json(request_path, request.model_dump(mode="json"), exclusive=True)
         bindings = {
             "codebase_path": codebase,
             "request_path": request_path,
@@ -165,6 +170,9 @@ class ExternalStageService:
         validate_metis_sarif(load_sarif_file(input_sarif_path))
         output_decision = resolved_run_dir / "validation-decision.json"
         validated_sarif = resolved_run_dir / "validated.sarif"
+        for output in (output_decision, validated_sarif):
+            if output.exists():
+                raise FileExistsError(f"External stage output already exists: {output}")
         request_path = resolved_run_dir / "validation-request.json"
         request = ValidationRequestModel(
             run_id=resolved_run_dir.name,
@@ -173,7 +181,7 @@ class ExternalStageService:
             commit=None,
             output_decision=str(output_decision),
         )
-        _write_json(request_path, request.model_dump(mode="json"))
+        _write_json(request_path, request.model_dump(mode="json"), exclusive=True)
         bindings = {
             "codebase_path": codebase,
             "input_sarif": input_sarif_path,
@@ -356,12 +364,16 @@ def _resolve_run_dir(run_dir: str | Path | None) -> Path:
     if run_dir is not None:
         return Path(run_dir).resolve()
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    return (Path.cwd() / "results" / "external_stages" / stamp).resolve()
+    return (
+        Path.cwd() / "results" / "external_stages" / f"{stamp}_{uuid4().hex}"
+    ).resolve()
 
 
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
+def _write_json(
+    path: Path, payload: dict[str, Any], *, exclusive: bool = False
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
+    with path.open("x" if exclusive else "w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
 
 

--- a/src/metis/engine/llm_runner.py
+++ b/src/metis/engine/llm_runner.py
@@ -148,6 +148,11 @@ class JsonPromptRunner:
             if request.model_tools
             else None
         )
+        # Template errors are configuration failures, not provider retry failures.
+        prompt = _json_chat_prompt(
+            request.system_prompt, request.user_prompt, request.model_tools
+        )
+        prompt.invoke(request.variables)
         for attempt in range(self._max_attempts):
             response_text: Any = None
             parsed: Any = None
@@ -184,12 +189,13 @@ class JsonPromptRunner:
                         params["temperature"] = request.temperature
                     chat = self._llm_provider.get_chat_model(**params)
                     active_tools = request.model_tools if not tool_evidence else ()
-                    prompt = _json_chat_prompt(
-                        request.system_prompt,
-                        request.user_prompt,
-                        request.model_tools,
-                        tool_evidence,
-                    )
+                    if tool_evidence:
+                        prompt = _json_chat_prompt(
+                            request.system_prompt,
+                            request.user_prompt,
+                            request.model_tools,
+                            tool_evidence,
+                        )
                     used_structured_output = False
                     structured_output = getattr(chat, "with_structured_output", None)
                     if (

--- a/src/metis/engine/nodes/builtins.py
+++ b/src/metis/engine/nodes/builtins.py
@@ -123,24 +123,24 @@ def build_builtin_execution(
         else None
     )
     triage_classifier = None
-    if ("triage", "triage") in selected_nodes:
-        triage_classifier = TriageClassifierService(
-            llm_provider=engine_config.llm_provider,
-            model=engine_config.llama_query_model,
-            chat_model_kwargs=engine_config.chat_model_kwargs,
-            plugin_config=engine_config.plugin_config,
-            get_plugin_for_path=repository.get_plugin_for_path,
-            get_language_name_for_path=repository.get_language_name_for_path,
-            normalize_path=repository.normalize_match_path,
-            usage_hooks=engine_config.usage_runtime.hooks,
-            model_tool_max_contract_chars=(
-                engine_config.capability_settings.model_tools.max_contract_chars
-            ),
-            navigation_manifest=capabilities.manifest("navigation"),
-        )
-        registrations.append(triage_node.create_node(triage_classifier))
-
     try:
+        if ("triage", "triage") in selected_nodes:
+            triage_classifier = TriageClassifierService(
+                llm_provider=engine_config.llm_provider,
+                model=engine_config.llama_query_model,
+                chat_model_kwargs=engine_config.chat_model_kwargs,
+                plugin_config=engine_config.plugin_config,
+                get_plugin_for_path=repository.get_plugin_for_path,
+                get_language_name_for_path=repository.get_language_name_for_path,
+                normalize_path=repository.normalize_match_path,
+                usage_hooks=engine_config.usage_runtime.hooks,
+                model_tool_max_contract_chars=(
+                    engine_config.capability_settings.model_tools.max_contract_chars
+                ),
+                navigation_manifest=capabilities.manifest("navigation"),
+            )
+            registrations.append(triage_node.create_node(triage_classifier))
+
         execution = ExecutionGraphService(
             configuration,
             engine_config=engine_config,
@@ -155,8 +155,11 @@ def build_builtin_execution(
             triage_options=triage_options,
             registrations=registrations,
         )
-    except Exception:
+    except BaseException as exc:
         if triage_classifier is not None:
-            triage_classifier.close()
+            try:
+                triage_classifier.close()
+            except BaseException as cleanup_error:
+                exc.add_note(f"Triage classifier cleanup also failed: {cleanup_error}")
         raise
     return BuiltinExecution(execution, triage_service, triage_classifier)

--- a/src/metis/engine/nodes/codegraph/registration.py
+++ b/src/metis/engine/nodes/codegraph/registration.py
@@ -43,4 +43,5 @@ registration = NodeRegistration(
     inputs={"profiled_source": ProfiledSourceReference | None},
     outputs={"codegraph": CodeGraphReference},
     execute=execute,
+    required_when_bound=frozenset({"profiled_source"}),
 )

--- a/src/metis/engine/nodes/codegraph/service.py
+++ b/src/metis/engine/nodes/codegraph/service.py
@@ -11,6 +11,7 @@ import threading
 from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Mapping
+from concurrent.futures import CancelledError
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -32,6 +33,7 @@ from .progress import CODEGRAPH_START
 from .provider import normalize_provider_name
 from .semantics import CodeGraphSemanticsCatalog
 from .store import SQLiteCodeGraphStore
+from .store import _DIAGNOSTIC
 
 if TYPE_CHECKING:
     from metis.engine.repository import EngineRepository
@@ -91,16 +93,15 @@ class CodeGraphService:
                     _replay_diagnostics(completed, diagnostic_callback)
                     return completed
             self._materialize_active = True
+        completed = None
         try:
             completed = self._materialize(
                 progress_callback=progress_callback,
                 diagnostic_callback=diagnostic_callback,
             )
-        except Exception:
-            self._finish_materialization(None)
-            raise
-        self._finish_materialization(completed)
-        return completed
+            return completed
+        finally:
+            self._finish_materialization(completed)
 
     def _finish_materialization(
         self,
@@ -422,6 +423,8 @@ class CodeGraphService:
                 raise ValueError(f"Unknown CodeGraph provider: {key!r}") from exc
             try:
                 provider = factory(self._provider_context)
+            except CancelledError:
+                raise
             except Exception as exc:
                 raise RuntimeError(
                     f"CodeGraph provider {key!r} failed to initialize: {exc}"
@@ -450,6 +453,8 @@ class CodeGraphService:
                 files=requested_files,
                 progress_callback=progress_callback,
             )
+        except CancelledError:
+            raise
         except Exception as exc:
             raise RuntimeError(
                 f"CodeGraph provider {provider_name!r} failed: {exc}"
@@ -466,14 +471,20 @@ class CodeGraphService:
             raise RuntimeError(
                 f"CodeGraph provider {provider_name!r} returned an invalid result"
             )
-        if any(
-            not isinstance(diagnostic, CodeGraphDiagnostic)
-            or diagnostic.severity not in {"warning", "error"}
-            for diagnostic in result.diagnostics
-        ):
-            raise RuntimeError(
-                f"CodeGraph provider {provider_name!r} returned an invalid diagnostic"
-            )
+        for diagnostic in result.diagnostics:
+            if not isinstance(diagnostic, CodeGraphDiagnostic):
+                raise RuntimeError(
+                    f"CodeGraph provider {provider_name!r} returned an invalid diagnostic"
+                )
+            try:
+                # Existing dataclass instances skip field checks; validate the stored shape.
+                _DIAGNOSTIC.validate_json(
+                    _DIAGNOSTIC.dump_json(diagnostic, warnings="error"), strict=True
+                )
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"CodeGraph provider {provider_name!r} returned an invalid diagnostic: {exc}"
+                ) from exc
         errors = [
             diagnostic
             for diagnostic in result.diagnostics

--- a/src/metis/engine/nodes/codegraph/store.py
+++ b/src/metis/engine/nodes/codegraph/store.py
@@ -50,29 +50,34 @@ class SQLiteCodeGraphStore:
         with self._lock:
             try:
                 with closing(_connect(self.location)) as connection:
-                    row = connection.execute(
+                    latest = None
+                    for row in connection.execute(
                         """
                         SELECT revision
                         FROM canonical_codegraph
                         WHERE fingerprint = ?
+                        ORDER BY revision DESC
                         """,
                         (fingerprint,),
-                    ).fetchone()
-                    if row is None:
-                        return None
-                    try:
-                        stored = _read_stored_graph(
-                            connection,
-                            codebase_path=codebase_path,
-                            revision=int(row[0]),
-                        )
-                    except RuntimeError:
-                        return None
+                    ):
+                        try:
+                            stored = _read_stored_graph(
+                                connection,
+                                codebase_path=codebase_path,
+                                revision=int(row[0]),
+                            )
+                        except RuntimeError:
+                            continue
+                        if stored is not None:
+                            if not stored.reference.failed_files:
+                                return stored.reference
+                            if latest is None:
+                                latest = stored.reference
             except sqlite3.Error as exc:
                 raise RuntimeError(
                     f"Unable to read CodeGraph store {self.location!r}: {exc}"
                 ) from exc
-        return None if stored is None else stored.reference
+        return latest
 
     def save(
         self,
@@ -95,18 +100,6 @@ class SQLiteCodeGraphStore:
             try:
                 with closing(_connect(self.location)) as connection:
                     connection.execute("BEGIN IMMEDIATE")
-                    current = connection.execute(
-                        """
-                        SELECT revision FROM canonical_codegraph
-                        WHERE fingerprint = ?
-                        """,
-                        (fingerprint,),
-                    ).fetchone()
-                    if current is not None:
-                        connection.execute(
-                            "DELETE FROM canonical_codegraph WHERE revision = ?",
-                            (int(current[0]),),
-                        )
                     cursor = connection.execute(
                         """
                         INSERT INTO canonical_codegraph (
@@ -134,18 +127,19 @@ class SQLiteCodeGraphStore:
                             )
                         ),
                     )
+                    reference = CodeGraphReference(
+                        revision=revision,
+                        fingerprint=fingerprint,
+                        producer_version=producer_version,
+                        failed_files=failed_files,
+                        diagnostics=diagnostics,
+                    )
                     connection.commit()
             except sqlite3.Error as exc:
                 raise RuntimeError(
                     f"Unable to persist CodeGraph store {self.location!r}: {exc}"
                 ) from exc
-        return CodeGraphReference(
-            revision=revision,
-            fingerprint=fingerprint,
-            producer_version=producer_version,
-            failed_files=failed_files,
-            diagnostics=diagnostics,
-        )
+        return reference
 
     def load(
         self,
@@ -174,14 +168,27 @@ class SQLiteCodeGraphStore:
         try:
             os.makedirs(directory, exist_ok=True)
             with closing(_connect(self.location)) as connection:
-                current_version = int(
-                    connection.execute("PRAGMA user_version").fetchone()[0]
-                )
-                if current_version != _STORE_SCHEMA_VERSION:
-                    _drop_store_tables(connection)
-                _create_store_tables(connection)
-                connection.execute(f"PRAGMA user_version = {_STORE_SCHEMA_VERSION}")
-                connection.commit()
+                connection.execute("PRAGMA foreign_keys = OFF")
+                with connection:
+                    connection.execute("BEGIN IMMEDIATE")
+                    current_version = int(
+                        connection.execute("PRAGMA user_version").fetchone()[0]
+                    )
+                    if current_version > _STORE_SCHEMA_VERSION:
+                        raise RuntimeError(
+                            f"CodeGraph store {self.location!r} uses a newer schema "
+                            f"({current_version}); this version supports {_STORE_SCHEMA_VERSION}"
+                        )
+                    if current_version != _STORE_SCHEMA_VERSION:
+                        _drop_store_tables(connection)
+                    _create_store_tables(connection)
+                    _retain_graph_revisions(connection)
+                    connection.execute(
+                        "CREATE INDEX IF NOT EXISTS codegraph_by_fingerprint "
+                        "ON canonical_codegraph(fingerprint, revision)"
+                    )
+                    connection.execute(f"PRAGMA user_version = {_STORE_SCHEMA_VERSION}")
+                connection.execute("PRAGMA foreign_keys = ON")
         except (OSError, sqlite3.Error) as exc:
             raise RuntimeError(
                 f"Unable to initialize CodeGraph store {self.location!r}: {exc}"
@@ -194,6 +201,8 @@ def _read_stored_graph(
     codebase_path: str,
     revision: int,
 ) -> StoredCodeGraph | None:
+    if revision > 2**63 - 1:
+        return None
     metadata = connection.execute(
         """
         SELECT revision, fingerprint, producer_version, content_hash
@@ -298,7 +307,7 @@ def _graph_records(
     for unique_name, construct in graph.globals.items():
         yield "global", unique_name, _GLOBAL_CONSTRUCT.dump_json(construct)
     for name, locations in graph.public_declarations.items():
-        for location in locations:
+        for location in locations or ("",):
             yield "declaration", name, location.encode("utf-8")
     for path in processed_files:
         yield "processed", path, b""
@@ -348,29 +357,32 @@ def _update_hash(
 
 
 def _drop_store_tables(connection: sqlite3.Connection) -> None:
-    connection.executescript(
-        """
-        DROP TABLE IF EXISTS codegraph_records;
-        DROP TABLE IF EXISTS codegraph_diagnostics;
-        DROP TABLE IF EXISTS codegraph_failed_files;
-        DROP TABLE IF EXISTS codegraph_processed_files;
-        DROP TABLE IF EXISTS codegraph_public_declarations;
-        DROP TABLE IF EXISTS codegraph_globals;
-        DROP TABLE IF EXISTS codegraph_nodes;
-        DROP TABLE IF EXISTS canonical_codegraph;
-        """
-    )
+    for table in (
+        "codegraph_records",
+        "codegraph_diagnostics",
+        "codegraph_failed_files",
+        "codegraph_processed_files",
+        "codegraph_public_declarations",
+        "codegraph_globals",
+        "codegraph_nodes",
+        "canonical_codegraph",
+    ):
+        connection.execute(f"DROP TABLE IF EXISTS {table}")
 
 
 def _create_store_tables(connection: sqlite3.Connection) -> None:
-    connection.executescript(
+    connection.execute(
         """
         CREATE TABLE IF NOT EXISTS canonical_codegraph (
             revision INTEGER PRIMARY KEY AUTOINCREMENT,
-            fingerprint TEXT NOT NULL UNIQUE,
+            fingerprint TEXT NOT NULL,
             producer_version TEXT NOT NULL,
             content_hash TEXT NOT NULL
-        );
+        )
+        """
+    )
+    connection.execute(
+        """
         CREATE TABLE IF NOT EXISTS codegraph_records (
             graph_revision INTEGER NOT NULL REFERENCES canonical_codegraph(revision)
                 ON DELETE CASCADE,
@@ -384,10 +396,43 @@ def _create_store_tables(connection: sqlite3.Connection) -> None:
             identity TEXT NOT NULL,
             payload BLOB NOT NULL,
             PRIMARY KEY (graph_revision, position)
-        );
+        )
+        """
+    )
+    connection.execute(
+        """
         CREATE INDEX IF NOT EXISTS codegraph_records_by_kind
         ON codegraph_records(graph_revision, kind, position);
         """
+    )
+
+
+def _retain_graph_revisions(connection: sqlite3.Connection) -> None:
+    # The v2 record format is unchanged; remove its old one-revision constraint.
+    if not any(
+        row[2] for row in connection.execute("PRAGMA index_list(canonical_codegraph)")
+    ):
+        return
+    connection.execute(
+        """
+        CREATE TABLE canonical_codegraph_revisions (
+            revision INTEGER PRIMARY KEY AUTOINCREMENT,
+            fingerprint TEXT NOT NULL,
+            producer_version TEXT NOT NULL,
+            content_hash TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO canonical_codegraph_revisions
+        SELECT revision, fingerprint, producer_version, content_hash
+        FROM canonical_codegraph
+        """
+    )
+    connection.execute("DROP TABLE canonical_codegraph")
+    connection.execute(
+        "ALTER TABLE canonical_codegraph_revisions RENAME TO canonical_codegraph"
     )
 
 

--- a/src/metis/engine/nodes/finding_dedup/registration.py
+++ b/src/metis/engine/nodes/finding_dedup/registration.py
@@ -25,7 +25,7 @@ from .core import DeduplicationDecision
 from .core import consolidate_result
 
 logger = logging.getLogger(__name__)
-SYSTEM_PROMPT = get_engine_prompts("finding_dedup")["system"]
+SYSTEM_PROMPT = get_engine_prompts("finding_dedup", required=("system",))["system"]
 USER_PROMPT = "Candidate findings JSON:\n{candidate_findings}"
 
 

--- a/src/metis/engine/nodes/reachability/incremental_review.py
+++ b/src/metis/engine/nodes/reachability/incremental_review.py
@@ -68,7 +68,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SOURCE_PLACEHOLDER = "[[METIS_FRONTIER_SOURCE]]"
-_PROMPTS = get_engine_prompts("reachability_incremental_review")
+_PROMPTS = get_engine_prompts(
+    "reachability_incremental_review",
+    required=("discovery_graph_guidance", "omission_convention"),
+)
 
 
 class _NecessaryConditionModel(BaseModel):

--- a/src/metis/engine/nodes/threat_model/history.py
+++ b/src/metis/engine/nodes/threat_model/history.py
@@ -21,7 +21,10 @@ from metis.utils import parse_json_output
 from metis.utils import split_snippet
 
 logger = logging.getLogger("metis")
-_PROMPTS = get_engine_prompts("threat_context")
+_PROMPTS = get_engine_prompts(
+    "threat_context",
+    required=("history_distillation_system", "history_distillation_user"),
+)
 
 
 class _HistoryLessonModel(BaseModel):

--- a/src/metis/engine/nodes/threat_model/service.py
+++ b/src/metis/engine/nodes/threat_model/service.py
@@ -37,7 +37,15 @@ from .history import write_history_records
 logger = logging.getLogger("metis")
 
 THREAT_MODEL_NAMESPACE = ("repo", "threat_model")
-_PROMPTS = get_engine_prompts("threat_context")
+_PROMPTS = get_engine_prompts(
+    "threat_context",
+    required=(
+        "source_distillation_system",
+        "source_distillation_user",
+        "source_reduction_system",
+        "source_reduction_user",
+    ),
+)
 
 
 @dataclass(frozen=True)

--- a/src/metis/engine/prompt_catalog.py
+++ b/src/metis/engine/prompt_catalog.py
@@ -11,7 +11,9 @@ from metis.configuration import load_yaml
 
 
 @cache
-def get_engine_prompts(name: str) -> Mapping[str, str]:
+def get_engine_prompts(
+    name: str, *, required: tuple[str, ...] = ()
+) -> Mapping[str, str]:
     resource = files("metis.engine").joinpath("prompts", f"{name}.yaml")
     with as_file(resource) as path:
         payload = load_yaml(path)
@@ -24,5 +26,14 @@ def get_engine_prompts(name: str) -> Mapping[str, str]:
             raise TypeError(
                 f"Engine prompt resource {name!r} must map names to strings"
             )
+        if not value.strip():
+            raise ValueError(
+                f"Engine prompt resource {name!r} has blank prompt {key!r}"
+            )
         prompts[key] = value
+    missing = set(required) - prompts.keys()
+    if missing:
+        raise ValueError(
+            f"Engine prompt resource {name!r} is missing: {', '.join(sorted(missing))}"
+        )
     return MappingProxyType(prompts)

--- a/src/metis/engine/runtime.py
+++ b/src/metis/engine/runtime.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from threading import Lock
+from threading import Lock, RLock, local
 from typing import Any
 
 from metis.usage import UsageRuntime
@@ -22,6 +22,8 @@ class EngineConfig:
     custom_prompt_text: str | None
     custom_guidance_precedence: str
     max_workers: int
+    max_active_nodes: int
+    max_concurrent_executions: int
     max_token_length: int
     llama_query_model: str
     chat_model_kwargs: dict[str, Any]
@@ -49,6 +51,14 @@ class EngineState:
     ask_graph: Any | None = None
     retriever_code: Any | None = None
     retriever_docs: Any | None = None
-    pending_nodes: tuple[Any, Any] | None = None
-    retriever_lock: Lock = field(default_factory=Lock)
+    _index_preparation: local = field(default_factory=local, repr=False)
+    retriever_lock: RLock = field(default_factory=RLock)
     review_graph_lock: Lock = field(default_factory=Lock)
+
+    @property
+    def pending_nodes(self) -> tuple[Any, Any] | None:
+        return getattr(self._index_preparation, "nodes", None)
+
+    @pending_nodes.setter
+    def pending_nodes(self, value: tuple[Any, Any] | None) -> None:
+        self._index_preparation.nodes = value

--- a/src/metis/engine/stages/catalog.py
+++ b/src/metis/engine/stages/catalog.py
@@ -26,6 +26,7 @@ class StageCatalog:
             if entry_points is None
             else entry_points
         )
+        self._registrations: dict[str, StageRegistration] = {}
         self._entry_points: dict[str, list[metadata.EntryPoint]] = {}
         for entry_point in discovered:
             if entry_point.name.isidentifier():
@@ -38,6 +39,8 @@ class StageCatalog:
             )
 
     def resolve(self, name: str) -> StageRegistration:
+        if name in self._registrations:
+            return self._registrations[name]
         candidates = self._entry_points.get(name, [])
         if name in self._builtin_names:
             raise ValueError(f"Execution stage {name!r} is built in")
@@ -66,5 +69,6 @@ class StageCatalog:
                 f"Execution stage entry point {name!r} returned registration "
                 f"{registration.name!r}"
             )
+        self._registrations[name] = registration
         self._entry_points.pop(name, None)
         return registration

--- a/src/metis/engine/stages/configuration.py
+++ b/src/metis/engine/stages/configuration.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import RootModel
+from pydantic import PrivateAttr
 from pydantic import model_validator
 
 from metis.engine.codegraph import CodeGraphReference
@@ -133,6 +134,10 @@ class ExecutionInputs(BaseModel):
 
 
 class ExecutionConfiguration(BaseModel):
+    _resolved_contracts: dict[StageName, _ResolvedStageContract] | None = PrivateAttr(
+        default=None
+    )
+
     inputs: ExecutionInputs = Field(default_factory=ExecutionInputs)
     stages: ExecutionStages
     node_configuration: dict[str, dict[str, dict[str, Any]]] = Field(
@@ -188,25 +193,6 @@ class ExecutionConfiguration(BaseModel):
                     f"Execution stage {name!r} depends on unavailable stages: "
                     f"{unavailable}"
                 )
-        initialize = self.stages.initialize
-        if (
-            initialize is not None
-            and "compilation_profile" in initialize.nodes
-            and "codegraph" in initialize.nodes
-            and "compilation_profile" not in initialize.nodes["codegraph"].depends_on
-        ):
-            raise ValueError("Initialize codegraph must depend on compilation_profile")
-        review = self.stages.review
-        if review is not None and "reachability" in review.nodes:
-            source = review.inputs.get("codegraph", "")
-            source_stage, separator, _output = source.partition(".")
-            if not separator or source_stage != "initialize":
-                raise ValueError("Reachability requires a CodeGraph from Initialize")
-            binding = review.nodes["reachability"].inputs.get("codegraph")
-            if binding not in (None, "$inputs.codegraph"):
-                raise ValueError(
-                    "Reachability must consume the Review stage CodeGraph input"
-                )
         for name, stage in configured_stages:
             configured_filenames = [
                 node_name
@@ -218,10 +204,17 @@ class ExecutionConfiguration(BaseModel):
                     f"Execution stage {name!r} configures multiple filenames"
                 )
             if configured_filenames:
-                if configured_filenames[0] != "result":
+                if isinstance(stage.outputs, dict):
+                    filename_source = stage.outputs.get("filename", "")
+                else:
+                    filename_source = "filename" if "filename" in stage.outputs else ""
+                if not stage.outputs:
+                    filename_source = "result.filename"
+                if configured_filenames[0] != filename_source.partition(".")[0]:
                     raise ValueError(
                         f"Execution stage {name!r} filename must be "
-                        "configured on its result node"
+                        "configured on its result node "
+                        "(the producer of its filename output)"
                     )
             for stage_input_name, source in stage.inputs.items():
                 if source.startswith("$inputs."):
@@ -278,9 +271,9 @@ class ExecutionConfiguration(BaseModel):
         )
 
     def stage_contracts(self) -> Mapping[StageName, _ResolvedStageContract]:
-        catalog = StageCatalog(BUILTIN_STAGE_CONTRACTS)
-        return MappingProxyType(
-            {
+        if self._resolved_contracts is None:
+            catalog = StageCatalog(BUILTIN_STAGE_CONTRACTS)
+            self._resolved_contracts = {
                 name: (
                     BUILTIN_STAGE_CONTRACTS[name]
                     if name in BUILTIN_STAGE_CONTRACTS
@@ -288,7 +281,7 @@ class ExecutionConfiguration(BaseModel):
                 )
                 for name, _stage in self.stages.configured()
             }
-        )
+        return MappingProxyType(self._resolved_contracts)
 
     def selected_nodes(self) -> set[tuple[StageName, str]]:
         return {

--- a/src/metis/engine/stages/contracts.py
+++ b/src/metis/engine/stages/contracts.py
@@ -9,6 +9,8 @@ from dataclasses import field
 from types import MappingProxyType
 from typing import Any
 
+from ..execution.contracts import annotation_adapter
+
 
 @dataclass(frozen=True, slots=True)
 class StageContract:
@@ -17,8 +19,16 @@ class StageContract:
 
     def __post_init__(self) -> None:
         for port in (*self.inputs, *self.required_outputs):
-            if not port.isidentifier():
+            if not isinstance(port, str) or not port.isidentifier():
                 raise ValueError(f"Execution stage contract has invalid port {port!r}")
+        for port, annotation in (*self.inputs.items(), *self.required_outputs.items()):
+            try:
+                annotation_adapter(annotation)
+            except Exception as exc:
+                raise TypeError(
+                    f"Execution stage contract port {port!r} has an unsupported "
+                    f"annotation: {annotation!r}"
+                ) from exc
         object.__setattr__(
             self,
             "inputs",
@@ -37,7 +47,7 @@ class StageRegistration:
     contract: StageContract
 
     def __post_init__(self) -> None:
-        if not self.name or not self.name.isidentifier():
+        if not isinstance(self.name, str) or not self.name.isidentifier():
             raise ValueError(f"Invalid execution stage name: {self.name!r}")
         if not isinstance(self.contract, StageContract):
             raise TypeError("Execution stage contract must be a StageContract")

--- a/src/metis/engine/stages/review/checkpoints.py
+++ b/src/metis/engine/stages/review/checkpoints.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Mapping
+from concurrent.futures import CancelledError
 from threading import Lock
+from threading import RLock
 from typing import Any
 
 from metis.engine.execution.contracts import NodeCallbacks
@@ -16,15 +19,26 @@ class ReviewCheckpointSession:
         self._producer = producer
         self._callback = callbacks.checkpoint
         self._lock = Lock()
+        self._write_lock = RLock()
+        self._pending: deque[tuple[dict[str, Any], int]] = deque()
         self._records: dict[str, dict[str, Any]] = {}
         if callbacks.resume is None:
             return
         try:
             records = callbacks.resume(producer)
+            if isinstance(records, Mapping):
+                for key, record in records.items():
+                    if isinstance(key, str) and isinstance(record, Mapping):
+                        try:
+                            self._records[key] = dict(record)
+                        except CancelledError:
+                            raise
+                        except Exception:
+                            continue
+        except CancelledError:
+            raise
         except Exception:
             return
-        if records is not None:
-            self._records.update({key: dict(record) for key, record in records.items()})
 
     def get(self, key: str) -> Mapping[str, Any] | None:
         with self._lock:
@@ -32,25 +46,35 @@ class ReviewCheckpointSession:
             return dict(record) if record is not None else None
 
     def put(self, key: str, record: Mapping[str, Any]) -> None:
-        with self._lock:
-            self._records[key] = dict(record)
-            if self._callback is None:
+        # Keep durable writes in session order without locking out callback reads.
+        with self._write_lock:
+            with self._lock:
+                self._records[key] = dict(record)
+                if self._callback is None:
+                    return
+                checkpoint = {
+                    "metis_version": METIS_VERSION,
+                    "producer": self._producer,
+                    "key": key,
+                    "record": dict(record),
+                }
+                count = len(self._records)
+            # Keep the active entry queued so reentrant puts only append.
+            self._pending.append((checkpoint, count))
+            if len(self._pending) > 1:
                 return
-            checkpoint = {
-                "metis_version": METIS_VERSION,
-                "producer": self._producer,
-                "key": key,
-                "record": dict(record),
-            }
-            count = len(self._records)
             try:
-                self._callback(
-                    checkpoint,
-                    count,
-                    count,
-                )
-            except Exception:
-                return
+                while self._pending:
+                    checkpoint, count = self._pending[0]
+                    try:
+                        self._callback(checkpoint, count, count)
+                    except CancelledError:
+                        raise
+                    except Exception:
+                        pass
+                    self._pending.popleft()
+            finally:
+                self._pending.clear()
 
     @property
     def has_records(self) -> bool:

--- a/src/metis/engine/stages/service.py
+++ b/src/metis/engine/stages/service.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from collections.abc import Mapping
+from concurrent.futures import CancelledError
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 from functools import partial
+from threading import Condition
+from threading import Event
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -32,8 +37,9 @@ from ..execution.contracts import NodeContext
 from ..execution.contracts import NodeRegistration
 from ..execution.contracts import NodeRuntime
 from ..execution.contracts import StageName
-from ..execution.graph import StageConfiguration
+from ..execution.contracts import annotation_allows_none
 from ..execution.runner import run_stage
+from ..execution.runner import _validate_value
 from .configuration import ExecutionConfiguration
 from .review.models import ReviewCommand
 from .triage.contracts import TriageAdjudicator
@@ -44,6 +50,11 @@ if TYPE_CHECKING:
 
     from metis.engine.repository import EngineRepository
     from metis.engine.runtime import EngineConfig
+
+
+_active_services: ContextVar[tuple[tuple[ExecutionGraphService, Event], ...]] = (
+    ContextVar("metis_active_execution_services", default=())
+)
 
 
 class ExecutionGraphService:
@@ -62,6 +73,12 @@ class ExecutionGraphService:
         entry_points: tuple[metadata.EntryPoint, ...] | None = None,
     ) -> None:
         self.configuration = configuration
+        self._stages = {
+            name: stage.model_copy(deep=True)
+            for name, stage in configuration.stages.configured()
+        }
+        self._stage_order = configuration.stage_order()
+        self._inputs = configuration.inputs.model_copy(deep=True)
         self._engine_config = engine_config
         self._repository = repository
         self._prompt_runner = prompt_runner
@@ -72,31 +89,60 @@ class ExecutionGraphService:
         self._plans: dict[StageName, StagePlan] = {}
         self._contracts = configuration.stage_contracts()
         self._validate_configuration(catalog, capabilities)
+        self._node_executor = ThreadPoolExecutor(
+            max_workers=engine_config.max_active_nodes,
+            thread_name_prefix="metis-node",
+        )
         self._scheduler = JobScheduler(engine_config.max_workers)
         self._jobs = self._scheduler.limit(engine_config.max_workers)
+        self._condition = Condition()
+        self._closed = False
+        self._active_executions: set[Event] = set()
+
+    def _check_reentry(self, action: str) -> None:
+        # Called with the lifecycle condition held. Context markers only guard
+        # reentry; cancellation is owned by each execution's Event.
+        if any(
+            service is self and execution in self._active_executions
+            for service, execution in _active_services.get()
+        ):
+            raise RuntimeError(
+                f"Cannot {action} the execution service from an active execution"
+            )
+
+    def check_can_close(self) -> None:
+        with self._condition:
+            self._check_reentry("close")
 
     def close(self) -> None:
-        self._scheduler.close()
+        self.check_can_close()
+        with self._condition:
+            self._closed = True
+            for cancellation in self._active_executions:
+                cancellation.set()
+            self._condition.notify_all()
+        first_error: BaseException | None = None
+        while True:
+            try:
+                self._scheduler.close()
+                with self._condition:
+                    self._condition.wait_for(lambda: not self._active_executions)
+                self._node_executor.shutdown(wait=True, cancel_futures=True)
+            except BaseException as exc:
+                # Shutdown is idempotent; finish draining before callers close capabilities.
+                if first_error is None:
+                    first_error = exc
+            else:
+                break
+        if first_error is not None:
+            raise first_error
 
     def execute_initialize(
         self,
         *,
         callbacks: Mapping[str, object] | None = None,
     ) -> ExecutionResult:
-        stage = self.configuration.stages.initialize
-        if stage is None:
-            return _unavailable_stage("initialize")
-        run = run_stage(
-            "initialize",
-            self._plans["initialize"],
-            self._context("initialize", callbacks=callbacks),
-            {},
-        )
-        return ExecutionResult(
-            run.status,
-            {"initialize": run.outputs},
-            run.diagnostics,
-        )
+        return self._execute_target("initialize", callbacks=callbacks)
 
     def execute_review(
         self,
@@ -104,38 +150,8 @@ class ExecutionGraphService:
         *,
         callbacks: Mapping[str, object] | None = None,
     ) -> ExecutionResult:
-        stage = self.configuration.stages.review
-        if stage is None:
-            return _unavailable_stage("review")
-        requires_initialize = "initialize" in stage.depends_on or any(
-            source.startswith("initialize.") for source in stage.inputs.values()
-        )
-        if not requires_initialize:
-            return self._execute_configured_stage(
-                "review", {}, callbacks=callbacks, initial_inputs={"request": command}
-            )
-        initialized = self.execute_initialize(callbacks=callbacks)
-        if initialized.status is ExecutionStatus.ERROR:
-            return ExecutionResult(
-                initialized.status,
-                {},
-                initialized.diagnostics,
-            )
-        reviewed = self._execute_configured_stage(
-            "review",
-            initialized.outputs,
-            callbacks=callbacks,
-            initial_inputs={"request": command},
-        )
-        return ExecutionResult(
-            (
-                ExecutionStatus.INCONCLUSIVE
-                if initialized.status is ExecutionStatus.INCONCLUSIVE
-                and reviewed.status is ExecutionStatus.OK
-                else reviewed.status
-            ),
-            reviewed.outputs,
-            (*initialized.diagnostics, *reviewed.diagnostics),
+        return self._execute_target(
+            "review", callbacks=callbacks, initial_inputs={"request": command}
         )
 
     def execute_triage(
@@ -146,31 +162,15 @@ class ExecutionGraphService:
         include_triaged: bool | None = None,
         callbacks: Mapping[str, object] | None = None,
     ) -> ExecutionResult:
-        stage = self.configuration.stages.triage
-        if stage is None:
-            return _unavailable_stage("triage")
-        callbacks = callbacks or {}
-        payload = SarifPayload.model_validate(sarif)
-        include_triaged = (
-            self._triage_options.include_triaged
-            if include_triaged is None
-            else include_triaged
-        )
-        triage_run = TriageRun.from_payload(
-            payload,
-            include_triaged=include_triaged,
-        )
-        run = run_stage(
+        return self._execute_target(
             "triage",
-            self._plans["triage"],
-            self._context("triage", callbacks=callbacks),
-            {
-                "sarif": payload,
-                "request": triage_run,
+            callbacks=callbacks,
+            initial_inputs={
+                "sarif": SarifPayload.model_validate(sarif),
                 "codegraph": codegraph,
             },
+            include_triaged=include_triaged,
         )
-        return ExecutionResult(run.status, {"triage": run.outputs}, run.diagnostics)
 
     def execute_graph(
         self,
@@ -178,47 +178,105 @@ class ExecutionGraphService:
         include_triaged: bool | None = None,
         callbacks: Mapping[str, object] | None = None,
     ) -> ExecutionResult:
-        runlog.event(
-            "execution.topology",
-            {
-                "stage_order": self.configuration.stage_order(),
-                "configuration": self.configuration,
-            },
+        return self._execute_stages(
+            self._stage_order,
+            callbacks=callbacks,
+            include_triaged=include_triaged,
         )
-        outputs: dict[str, Any] = {}
-        diagnostics: list[ExecutionDiagnostic] = []
-        status = ExecutionStatus.OK
-        for stage_name in self.configuration.stage_order():
-            if stage_name == "initialize":
-                result = self.execute_initialize(callbacks=callbacks)
-            elif stage_name == "review":
+
+    def _execute_target(
+        self,
+        target: StageName,
+        *,
+        callbacks: Mapping[str, object] | None,
+        initial_inputs: Mapping[str, Any] | None = None,
+        include_triaged: bool | None = None,
+    ) -> ExecutionResult:
+        if target not in self._stages:
+            return _unavailable_stage(target)
+        selected: set[StageName] = set()
+        pending = [target]
+        while pending:
+            name = pending.pop()
+            if name in selected:
+                continue
+            selected.add(name)
+            stage = self._stages[name]
+            pending.extend(stage.depends_on)
+            pending.extend(
+                source.partition(".")[0]
+                for port, source in stage.inputs.items()
+                if not source.startswith("$inputs.")
+                and not (name == target and port in (initial_inputs or {}))
+            )
+        return self._execute_stages(
+            tuple(name for name in self._stage_order if name in selected),
+            callbacks=callbacks,
+            include_triaged=include_triaged,
+            overrides={target: initial_inputs or {}},
+        )
+
+    def _execute_stages(
+        self,
+        stage_order: tuple[StageName, ...],
+        *,
+        callbacks: Mapping[str, object] | None,
+        include_triaged: bool | None,
+        overrides: Mapping[StageName, Mapping[str, Any]] | None = None,
+    ) -> ExecutionResult:
+        cancellation = Event()
+        with self._condition:
+            self._check_reentry("start nested execution on")
+            self._condition.wait_for(
+                lambda: (
+                    self._closed
+                    or len(self._active_executions)
+                    < self._engine_config.max_concurrent_executions
+                )
+            )
+            if self._closed:
+                raise RuntimeError("Execution service is closed")
+            self._active_executions.add(cancellation)
+        token = _active_services.set((*_active_services.get(), (self, cancellation)))
+        try:
+            runlog.event(
+                "execution.topology",
+                {"stage_order": stage_order, "configuration": self.configuration},
+            )
+            outputs: dict[str, Any] = {}
+            diagnostics: list[ExecutionDiagnostic] = []
+            status = ExecutionStatus.OK
+            for stage_name in stage_order:
+                if cancellation.is_set():
+                    raise CancelledError("Execution was cancelled")
                 result = self._execute_configured_stage(
                     stage_name,
                     outputs,
                     callbacks=callbacks,
-                    initial_inputs={
-                        "request": self.configuration.inputs.review_request
-                    },
-                )
-            elif stage_name == "triage":
-                result = self._execute_configured_triage(
-                    outputs,
+                    initial_inputs=(overrides or {}).get(stage_name),
                     include_triaged=include_triaged,
-                    callbacks=callbacks,
+                    cancellation=cancellation,
                 )
-            else:
-                result = self._execute_configured_stage(
-                    stage_name,
-                    outputs,
-                    callbacks=callbacks,
+                diagnostics.extend(result.diagnostics)
+                # Failed stages can still publish validated independent outputs.
+                outputs.update(
+                    (name, values)
+                    for name, values in result.outputs.items()
+                    if values or result.status is not ExecutionStatus.ERROR
                 )
-            diagnostics.extend(result.diagnostics)
-            if result.status is ExecutionStatus.ERROR:
-                return ExecutionResult(result.status, outputs, tuple(diagnostics))
-            outputs.update(result.outputs)
-            if result.status is ExecutionStatus.INCONCLUSIVE:
-                status = ExecutionStatus.INCONCLUSIVE
-        return ExecutionResult(status, outputs, tuple(diagnostics))
+                if result.status is ExecutionStatus.ERROR:
+                    return ExecutionResult(result.status, outputs, tuple(diagnostics))
+                if result.status is ExecutionStatus.INCONCLUSIVE:
+                    status = ExecutionStatus.INCONCLUSIVE
+            if cancellation.is_set():
+                raise CancelledError("Execution was cancelled")
+            return ExecutionResult(status, outputs, tuple(diagnostics))
+
+        finally:
+            _active_services.reset(token)
+            with self._condition:
+                self._active_executions.remove(cancellation)
+                self._condition.notify_all()
 
     def _execute_configured_stage(
         self,
@@ -227,44 +285,99 @@ class ExecutionGraphService:
         *,
         callbacks: Mapping[str, object] | None,
         initial_inputs: Mapping[str, Any] | None = None,
+        include_triaged: bool | None = None,
+        cancellation: Event,
     ) -> ExecutionResult:
-        stage = self.configuration.stages.get(stage_name)
-        if stage is None:
-            return _unavailable_stage(stage_name)
-        inputs = {
-            name: _resolve_stage_input(binding, outputs, self.configuration.inputs)
-            for name, binding in stage.inputs.items()
+        stage = self._stages[stage_name]
+        overrides = initial_inputs or {}
+        inputs: dict[str, Any] = {
+            name: None
+            for name, annotation in self._contracts[stage_name].stage_inputs.items()
+            if annotation_allows_none(annotation)
         }
+        inputs.update(
+            (name, _resolve_stage_input(binding, outputs, self._inputs))
+            for name, binding in stage.inputs.items()
+            if name not in overrides
+        )
+        if stage_name == "review":
+            inputs["request"] = self._inputs.review_request
+        inputs.update(overrides)
+        for name, annotation in self._contracts[stage_name].stage_inputs.items():
+            try:
+                inputs[name] = _validate_value(annotation, inputs[name])
+            except CancelledError:
+                raise
+            except Exception as exc:
+                return ExecutionResult(
+                    ExecutionStatus.ERROR,
+                    {stage_name: {}},
+                    (
+                        ExecutionDiagnostic(
+                            code="execution.stage_input_invalid",
+                            message=(
+                                f"Execution stage {stage_name!r} input {name!r} "
+                                f"is invalid: {exc}"
+                            ),
+                        ),
+                    ),
+                )
+        if stage_name == "triage":
+            inputs["request"] = TriageRun.from_payload(
+                cast(SarifPayload, inputs["sarif"]),
+                include_triaged=(
+                    self._triage_options.include_triaged
+                    if include_triaged is None
+                    else include_triaged
+                ),
+            )
         run = run_stage(
             stage_name,
             self._plans[stage_name],
-            self._context(stage_name, callbacks=callbacks),
-            {**(initial_inputs or {}), **inputs},
+            self._context(stage_name, callbacks=callbacks, cancellation=cancellation),
+            inputs,
+            executor=self._node_executor,
         )
-        return ExecutionResult(run.status, {stage_name: run.outputs}, run.diagnostics)
+        stage_outputs = dict(run.outputs)
+        diagnostics = list(run.diagnostics)
+        status = run.status
+        for name, annotation in self._contracts[stage_name].required_outputs.items():
+            if name not in stage_outputs:
+                continue
+            try:
+                stage_outputs[name] = _validate_value(annotation, stage_outputs[name])
+            except CancelledError:
+                raise
+            except Exception as exc:
+                del stage_outputs[name]
+                status = ExecutionStatus.ERROR
+                diagnostics.append(
+                    ExecutionDiagnostic(
+                        code="execution.stage_output_invalid",
+                        message=(
+                            f"Execution stage {stage_name!r} output {name!r} "
+                            f"is invalid: {exc}"
+                        ),
+                    )
+                )
+        return ExecutionResult(status, {stage_name: stage_outputs}, tuple(diagnostics))
 
     def _validate_configuration(
         self,
         catalog: NodeCatalog,
         capabilities: Mapping[str, object],
     ) -> None:
-        stage_order = self.configuration.stage_order()
-        for stage_name in stage_order:
+        for stage_name in self._stage_order:
             contract = self._contracts[stage_name]
-            stage = cast(StageConfiguration, self.configuration.stages.get(stage_name))
+            stage = self._stages[stage_name]
             initial_inputs = dict(contract.initial_inputs)
             for name in contract.stage_inputs:
                 source = stage.inputs.get(name)
                 if source is None:
-                    initial_inputs.pop(name, None)
+                    initial_inputs[name] = type(None)
                 elif source.startswith("$inputs."):
-                    value = getattr(
-                        self.configuration.inputs, source.removeprefix("$inputs.")
-                    )
-                    if value is None:
-                        initial_inputs.pop(name, None)
-                    else:
-                        initial_inputs[name] = type(value)
+                    value = getattr(self._inputs, source.removeprefix("$inputs."))
+                    initial_inputs[name] = type(value)
                 else:
                     source_stage, _, source_output = source.partition(".")
                     source_plan = self._plans.get(source_stage)
@@ -292,7 +405,13 @@ class ExecutionGraphService:
                 raise ValueError(
                     f"Execution stage {stage_name!r} must declare outputs: {names}"
                 )
-            for output_name, annotation in required_outputs.items():
+            expected_outputs = dict(required_outputs)
+            if (
+                stage_name in {"review", "triage"}
+                and "filename" in plan.output_annotations
+            ):
+                expected_outputs["filename"] = str | None
+            for output_name, annotation in expected_outputs.items():
                 if not _annotations_compatible(
                     plan.output_annotations[output_name],
                     annotation,
@@ -327,6 +446,7 @@ class ExecutionGraphService:
         stage: StageName,
         *,
         callbacks: Mapping[str, object] | None = None,
+        cancellation: Event,
     ) -> NodeContext:
         llm_provider = self._engine_config.llm_provider
 
@@ -356,43 +476,11 @@ class ExecutionGraphService:
                     self._engine_config.capability_settings.model_tools.max_rounds
                 ),
                 chat_model_kwargs=dict(self._engine_config.chat_model_kwargs),
-                jobs=self._jobs,
+                jobs=self._jobs.with_cancellation(cancellation),
+                is_cancelled=cancellation.is_set,
             ),
             callbacks=_node_callbacks(stage, callbacks),
             triage=self._triage_adjudicator,
-        )
-
-    def _execute_configured_triage(
-        self,
-        outputs: Mapping[str, Any],
-        *,
-        include_triaged: bool | None,
-        callbacks: Mapping[str, object] | None,
-    ) -> ExecutionResult:
-        stage = cast(StageConfiguration, self.configuration.stages.triage)
-        sarif = cast(
-            SarifPayload,
-            _resolve_stage_input(
-                stage.inputs["sarif"],
-                outputs,
-                self.configuration.inputs,
-            ),
-        )
-        codegraph = None
-        if codegraph_binding := stage.inputs.get("codegraph"):
-            codegraph = cast(
-                CodeGraphReference | None,
-                _resolve_stage_input(
-                    codegraph_binding,
-                    outputs,
-                    self.configuration.inputs,
-                ),
-            )
-        return self.execute_triage(
-            sarif,
-            codegraph=codegraph,
-            include_triaged=include_triaged,
-            callbacks=callbacks,
         )
 
 

--- a/src/metis/execution_nodes.py
+++ b/src/metis/execution_nodes.py
@@ -26,6 +26,8 @@ from metis.engine.execution.contracts import NodeRegistration
 from metis.engine.execution.contracts import NodeResult
 from metis.engine.execution.contracts import NodeRuntime
 from metis.engine.execution.contracts import NodeCallbacks
+from metis.engine.llm_runner import JsonPromptRequest
+from metis.engine.stages.review.models import FinalReviewRun
 from metis.engine.stages.review.models import PatchReviewResult
 from metis.engine.stages.review.models import ReviewCommand
 from metis.engine.stages.review.models import ReviewResult
@@ -49,6 +51,8 @@ __all__ = [
     "EmptyNodeConfiguration",
     "ExecutionDiagnostic",
     "ExecutionStatus",
+    "FinalReviewRun",
+    "JsonPromptRequest",
     "NodeContext",
     "NodeCodeGraphs",
     "NodeInvocation",

--- a/src/metis/json_io.py
+++ b/src/metis/json_io.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import TextIO
 
 
 def write_json_atomic(
@@ -15,35 +19,40 @@ def write_json_atomic(
     *,
     indent: int,
     ensure_ascii: bool = True,
-    allow_nan: bool = True,
+    allow_nan: bool = False,
     mode: int | None = None,
 ) -> None:
+    with atomic_text_writer(path, mode=0o600 if mode is None else mode) as handle:
+        json.dump(
+            payload,
+            handle,
+            indent=indent,
+            ensure_ascii=ensure_ascii,
+            allow_nan=allow_nan,
+        )
+
+
+@contextmanager
+def atomic_text_writer(
+    path: str | Path, *, mode: int | None = None, newline: str | None = None
+) -> Iterator[TextIO]:
+    """Replace a text output only after its complete contents reach disk."""
     target = Path(path)
-    temporary: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=target.parent,
-            prefix=f".{target.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as handle:
-            temporary = Path(handle.name)
-            json.dump(
-                payload,
-                handle,
-                indent=indent,
-                ensure_ascii=ensure_ascii,
-                allow_nan=allow_nan,
-            )
+    if mode is None:
+        try:
+            mode = stat.S_IMODE(target.stat().st_mode)
+        except FileNotFoundError:
+            pass
+    with tempfile.TemporaryDirectory(
+        dir=target.parent, prefix=".metis-", suffix=".tmp"
+    ) as directory:
+        temporary_directory = Path(directory)
+        temporary_directory.chmod(0o700)
+        temporary = temporary_directory / "report"
+        with temporary.open("w", encoding="utf-8", newline=newline) as handle:
+            yield handle
             handle.flush()
             os.fsync(handle.fileno())
         if mode is not None:
             temporary.chmod(mode)
         os.replace(temporary, target)
-        if mode is not None:
-            target.chmod(mode)
-    finally:
-        if temporary is not None:
-            temporary.unlink(missing_ok=True)

--- a/src/metis/memory/base.py
+++ b/src/metis/memory/base.py
@@ -17,6 +17,21 @@ Namespace = tuple[str, ...]
 JsonValue = dict[str, Any]
 
 
+def _validate_namespace(namespace: Namespace, *, allow_empty: bool = False) -> None:
+    if not isinstance(namespace, tuple):
+        raise ValueError("Memory namespace must be a tuple of string labels")
+    if not namespace and not allow_empty:
+        raise ValueError("Memory namespace cannot be empty")
+    if any(
+        not isinstance(label, str) or not label or "." in label for label in namespace
+    ):
+        raise ValueError(
+            "Memory namespace labels must be non-empty strings without periods"
+        )
+    if namespace and namespace[0] == "langgraph":
+        raise ValueError('Memory namespace root cannot be "langgraph"')
+
+
 class StoreLike(Protocol):
     def batch(self, ops: Iterable[Op]) -> list[Result]: ...
 

--- a/src/metis/memory/schemas.py
+++ b/src/metis/memory/schemas.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
@@ -59,11 +60,13 @@ class MemoryRecord:
         )
 
     def to_store_value(self) -> dict[str, Any]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if field.name not in _STORE_METADATA_FIELDS
-        }
+        return deepcopy(
+            {
+                field.name: getattr(self, field.name)
+                for field in fields(self)
+                if field.name not in _STORE_METADATA_FIELDS
+            }
+        )
 
     @classmethod
     def from_store_value(
@@ -74,11 +77,13 @@ class MemoryRecord:
         value: dict[str, Any],
         created_at: str,
     ) -> "MemoryRecord":
-        values = {
-            field.name: value[field.name]
-            for field in fields(cls)
-            if field.name not in _STORE_METADATA_FIELDS and field.name in value
-        }
+        values = deepcopy(
+            {
+                field.name: value[field.name]
+                for field in fields(cls)
+                if field.name not in _STORE_METADATA_FIELDS and field.name in value
+            }
+        )
         return cls(
             namespace=namespace,
             key=key,

--- a/src/metis/memory/service.py
+++ b/src/metis/memory/service.py
@@ -7,15 +7,25 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from datetime import datetime
 from datetime import timezone
+from threading import Lock, RLock
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from langgraph.store.base import PutOp
+from langgraph.store.memory import InMemoryStore
 
 from metis.version import __version__ as METIS_VERSION
 
 from .base import Namespace
+from .base import _validate_namespace
 from .base import StoreLike
 from .schemas import MemoryRecord
+
+
+_IN_MEMORY_REPLACEMENT_LOCKS: WeakKeyDictionary[InMemoryStore, RLock] = (
+    WeakKeyDictionary()
+)
+_IN_MEMORY_REPLACEMENT_LOCKS_GUARD = Lock()
 
 
 class MemoryService:
@@ -29,6 +39,11 @@ class MemoryService:
         self.store = store
         self.repo_root = repo_root
         self.tool_version = tool_version
+
+    def close(self) -> None:
+        close = getattr(self.store, "close", None)
+        if callable(close):
+            close()
 
     def put_record(self, record: MemoryRecord) -> None:
         self.store.put(record.namespace, record.key, record.to_store_value())
@@ -111,20 +126,30 @@ class MemoryService:
         namespace_prefix: Namespace,
         records: Iterable[MemoryRecord],
     ) -> int:
+        _validate_namespace(namespace_prefix, allow_empty=True)
         replacement = list(records)
-        if any(
-            record.namespace[: len(namespace_prefix)] != namespace_prefix
-            for record in replacement
-        ):
-            raise ValueError("Replacement records must stay under namespace_prefix")
-        existing = list(self.iter_records(namespace_prefix))
-        operations = [PutOp(record.namespace, record.key, None) for record in existing]
-        operations.extend(
+        for record in replacement:
+            _validate_namespace(record.namespace)
+            if record.namespace[: len(namespace_prefix)] != namespace_prefix:
+                raise ValueError("Replacement records must stay under namespace_prefix")
+        operations = [
             PutOp(record.namespace, record.key, record.to_store_value())
             for record in replacement
-        )
-        self.store.batch(operations)
-        return len(existing)
+        ]
+        replace = getattr(self.store, "replace_records", None)
+        if callable(replace):
+            return replace(namespace_prefix, operations)
+        if isinstance(self.store, InMemoryStore):
+            with _IN_MEMORY_REPLACEMENT_LOCKS_GUARD:
+                lock = _IN_MEMORY_REPLACEMENT_LOCKS.setdefault(self.store, RLock())
+            with lock:
+                existing = list(self.iter_records(namespace_prefix))
+                self.store.batch(
+                    [PutOp(record.namespace, record.key, None) for record in existing]
+                    + operations
+                )
+                return len(existing)
+        raise TypeError("Memory backend must support atomic namespace replacement")
 
     def delete_stale_records(
         self,

--- a/src/metis/memory/sqlite_store.py
+++ b/src/metis/memory/sqlite_store.py
@@ -23,6 +23,7 @@ from langgraph.store.base import Result
 from langgraph.store.base import SearchItem
 from langgraph.store.base import SearchOp
 
+from .base import _validate_namespace
 from .schemas import utc_now_iso
 from .sqlite_records import fts_column_values
 from .sqlite_records import MemoryRecordsTable
@@ -45,6 +46,39 @@ class SQLiteMemoryStore(BaseStore):
                 results = [self._execute_op(conn, op) for op in ops]
                 conn.commit()
                 return results
+
+    def replace_records(
+        self,
+        namespace_prefix: tuple[str, ...],
+        records: Iterable[PutOp],
+    ) -> int:
+        _validate_namespace(namespace_prefix, allow_empty=True)
+        replacement = list(records)
+        for record in replacement:
+            _validate_namespace(record.namespace)
+            if record.value is None or not _namespace_startswith(
+                record.namespace, namespace_prefix
+            ):
+                raise ValueError("Replacement records must stay under namespace_prefix")
+        with self._lock:
+            self._ensure_schema()
+            with closing(self._connect()) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                existing = [
+                    row
+                    for row in self._records.rows(conn)
+                    if _namespace_startswith(
+                        _decode_namespace(str(row["namespace"])), namespace_prefix
+                    )
+                ]
+                for row in existing:
+                    self._delete(
+                        conn, _decode_namespace(str(row["namespace"])), str(row["key"])
+                    )
+                for record in replacement:
+                    self._execute_op(conn, record)
+                conn.commit()
+                return len(existing)
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
         return await asyncio.to_thread(self.batch, list(ops))
@@ -104,6 +138,7 @@ class SQLiteMemoryStore(BaseStore):
         key: str,
         value: dict[str, Any],
     ) -> None:
+        _validate_namespace(namespace)
         namespace_json = _encode_namespace(namespace)
         now = utc_now_iso()
         existing_created_at = self._records.created_at(

--- a/src/metis/metis.yaml
+++ b/src/metis/metis.yaml
@@ -1,10 +1,24 @@
 metis_engine:
   max_token_length: 250000
   max_workers: 5
+  # Null inherits max_workers. Both limits apply across one engine.
+  max_active_nodes: null
+  max_concurrent_executions: null
   triage_checkpoint_every: 50
   review_checkpoints: true
   llm_max_retries: 5
   embed_dim: 3072
+  doc_chunk_size: 1024
+  doc_chunk_overlap: 200
+  pgvector_use_halfvec: auto
+  hnsw_kwargs:
+    hnsw_m: 16
+    hnsw_ef_construction: 64
+    hnsw_ef_search: 40
+    hnsw_dist_method: vector_cosine_ops
+  metisignore_file: null
+  review_code_include_paths: []
+  review_code_exclude_paths: []
   model_tools:
     max_rounds: 6
     max_contract_chars: 6000

--- a/src/metis/plugins/registry.py
+++ b/src/metis/plugins/registry.py
@@ -8,13 +8,14 @@ import importlib
 import inspect
 import logging
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from importlib import metadata
 from importlib.resources import files
 from threading import RLock
 from typing import Any
 
-import yaml
+from metis.configuration import _deep_merge
+from metis.configuration import load_yaml
 
 
 logger = logging.getLogger("metis")
@@ -24,7 +25,13 @@ _LANGUAGE_PLUGIN_ENTRY_POINT_GROUP = "metis.language_plugins"
 
 
 def _as_tuple(values: Iterable[Any] | None) -> tuple[str, ...]:
-    return tuple(str(value).lower() for value in (values or ()) if str(value).strip())
+    if values is None:
+        return ()
+    if not isinstance(values, (list, tuple)) or any(
+        not isinstance(value, str) for value in values
+    ):
+        raise ValueError("Language plugin manifest lists must contain strings")
+    return tuple(value.strip().lower() for value in values if value.strip())
 
 
 def _normalise_resource(resource: str | None) -> str | None:
@@ -34,7 +41,7 @@ def _normalise_resource(resource: str | None) -> str | None:
 
 
 def _load_yaml_mapping(handle: Any, *, resource: str) -> dict[str, Any]:
-    loaded = yaml.safe_load(handle) or {}
+    loaded = load_yaml(handle)
     if not isinstance(loaded, dict):
         raise ValueError(f"Plugin resource {resource!r} must contain a YAML mapping")
     return loaded
@@ -48,17 +55,6 @@ def _load_yaml_resource(resource: str) -> dict[str, Any]:
         target = files(_PLUGIN_PACKAGE).joinpath(resource)
     with target.open("r", encoding="utf-8") as handle:
         return _load_yaml_mapping(handle, resource=resource)
-
-
-def _deep_merge(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
-    merged = dict(base)
-    for key, value in overlay.items():
-        existing = merged.get(key)
-        if isinstance(existing, Mapping) and isinstance(value, Mapping):
-            merged[key] = _deep_merge(existing, value)
-        else:
-            merged[key] = value
-    return merged
 
 
 def _matches_suffix_pattern(name: str, pattern: str) -> bool:
@@ -84,7 +80,21 @@ class LanguagePluginManifest:
     priority: int = 0
 
     def __post_init__(self) -> None:
-        name = str(self.name or "").strip().lower()
+        for key in ("name", "implementation", "config_resource"):
+            if not isinstance(getattr(self, key), str):
+                raise ValueError(f"Language plugin manifest {key} must be a string")
+        if self.prompt_profile is not None and not isinstance(self.prompt_profile, str):
+            raise ValueError("Language plugin manifest prompt_profile must be a string")
+        if isinstance(self.priority, bool) or not isinstance(self.priority, int):
+            raise ValueError("Language plugin manifest priority must be an integer")
+        if not isinstance(self.capabilities, Mapping) or any(
+            not isinstance(key, str) or not isinstance(value, (Mapping, bool))
+            for key, value in self.capabilities.items()
+        ):
+            raise ValueError(
+                "Language plugin manifest capabilities must map names to booleans or mappings"
+            )
+        name = self.name.strip().lower()
         if not name:
             raise ValueError("Language plugin manifest name is required")
         object.__setattr__(self, "name", name)
@@ -107,8 +117,8 @@ class LanguagePluginManifest:
             self,
             "capabilities",
             {
-                str(key): dict(value) if isinstance(value, Mapping) else bool(value)
-                for key, value in dict(self.capabilities or {}).items()
+                key: dict(value) if isinstance(value, Mapping) else value
+                for key, value in self.capabilities.items()
             },
         )
         self.codegraph_registration_name()
@@ -126,19 +136,14 @@ class LanguagePluginManifest:
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "LanguagePluginManifest":
-        return cls(
-            name=str(data.get("name") or ""),
-            implementation=str(data.get("implementation") or ""),
-            extensions=tuple(data.get("extensions") or ()),
-            source_extensions=tuple(data.get("source_extensions") or ()),
-            header_extensions=tuple(data.get("header_extensions") or ()),
-            filename_patterns=tuple(data.get("filename_patterns") or ()),
-            aliases=tuple(data.get("aliases") or ()),
-            capabilities=dict(data.get("capabilities") or {}),
-            config_resource=str(data.get("config_resource") or ""),
-            prompt_profile=data.get("prompt_profile"),
-            priority=int(data.get("priority") or 0),
-        )
+        if not isinstance(data, Mapping):
+            raise ValueError("Language plugin manifest must be a mapping")
+        unknown = data.keys() - {item.name for item in fields(cls)}
+        if unknown:
+            raise ValueError(
+                f"Unknown language plugin manifest settings: {', '.join(sorted(map(str, unknown)))}"
+            )
+        return cls(**{"name": "", **data})
 
     def with_overrides(self, data: Mapping[str, Any]) -> "LanguagePluginManifest":
         merged = {
@@ -155,7 +160,6 @@ class LanguagePluginManifest:
             "priority": self.priority,
         }
         merged.update(data)
-        merged["name"] = str(merged.get("name") or self.name)
         return LanguagePluginManifest.from_mapping(merged)
 
     def codegraph_registration_name(self) -> str | None:
@@ -184,7 +188,10 @@ class LanguagePluginHandle:
         self._lock = RLock()
 
     def _load_profile(self, profile_name: str) -> dict[str, Any]:
-        return _load_yaml_resource(f"profiles/{profile_name}.yaml")
+        resource = (
+            profile_name if ":" in profile_name else f"profiles/{profile_name}.yaml"
+        )
+        return _load_yaml_resource(resource)
 
     def _load_language_config(self) -> dict[str, Any]:
         loaded = _load_yaml_resource(self.manifest.config_resource)
@@ -193,6 +200,12 @@ class LanguagePluginHandle:
         ).strip()
         if profile_name:
             loaded = _deep_merge(self._load_profile(profile_name), loaded)
+        for section in ("splitting", "prompts"):
+            if section in loaded and not isinstance(loaded[section], Mapping):
+                raise ValueError(
+                    f"Language plugin {self.manifest.name!r} resource "
+                    f"{self.manifest.config_resource!r}: {section} must be a mapping"
+                )
         loaded["supported_extensions"] = [
             *self.manifest.extensions,
             *self.manifest.filename_patterns,
@@ -254,10 +267,18 @@ class LanguagePluginHandle:
         return self._plugin
 
 
-class _LazyPluginSections(dict):
+class _LazyPluginSections(Mapping):
     def __init__(self, handle: LanguagePluginHandle):
-        super().__init__()
         self._handle = handle
+
+    def __iter__(self):
+        yield self._handle.manifest.name
+
+    def __len__(self):
+        return 1
+
+    def copy(self):
+        return dict(self)
 
     def get(self, key, default=None):
         if str(key or "").lower() == self._handle.manifest.name:
@@ -291,6 +312,8 @@ class LanguagePluginRegistry:
                 if isinstance(item, LanguagePluginManifest)
                 else LanguagePluginManifest.from_mapping(item)
             )
+            if manifest.name in self._handles:
+                raise ValueError(f"Duplicate language plugin name {manifest.name!r}")
             self._handles[manifest.name] = LanguagePluginHandle(
                 manifest,
                 plugin_config=self._plugin_config,
@@ -326,10 +349,12 @@ class LanguagePluginRegistry:
         handle = self._handles.get(key)
         if handle is not None:
             return handle
-        for candidate in self._handles.values():
-            if key in candidate.manifest.aliases:
-                return candidate
-        return None
+        manifest = _select_manifest(
+            candidate.manifest
+            for candidate in self._handles.values()
+            if key in candidate.manifest.aliases
+        )
+        return self._handles[manifest.name] if manifest is not None else None
 
     def _manifests(self) -> list[LanguagePluginManifest]:
         return [handle.manifest for handle in self._handles.values()]
@@ -506,11 +531,23 @@ def _apply_manifest_overrides(
 ) -> list[LanguagePluginManifest]:
     overrides = plugin_config.get("language_plugins", {})
     if not isinstance(overrides, Mapping):
-        return manifests
+        raise ValueError("language_plugins must be a mapping")
 
-    overrides_by_name = {
-        str(name or "").lower(): override for name, override in overrides.items()
-    }
+    overrides_by_name = {}
+    for name, override in overrides.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("language_plugins keys must be non-empty names")
+        if not isinstance(override, Mapping):
+            raise ValueError(f"language_plugins.{name} must be a mapping")
+        key = name.strip().lower()
+        if "name" in override and (
+            not isinstance(override["name"], str)
+            or override["name"].strip().lower() != key
+        ):
+            raise ValueError(f"language_plugins.{name}.name must match {key!r}")
+        if key in overrides_by_name:
+            raise ValueError(f"Duplicate language plugin override {key!r}")
+        overrides_by_name[key] = override
     existing_names = {manifest.name for manifest in manifests}
     resolved = []
     for manifest in manifests:
@@ -523,10 +560,7 @@ def _apply_manifest_overrides(
     for name, override in overrides_by_name.items():
         if name in existing_names:
             continue
-        if not isinstance(override, Mapping):
-            continue
         data = dict(override)
         data.setdefault("name", name)
-        if data.get("implementation"):
-            resolved.append(LanguagePluginManifest.from_mapping(data))
+        resolved.append(LanguagePluginManifest.from_mapping(data))
     return resolved

--- a/src/metis/providers/config.py
+++ b/src/metis/providers/config.py
@@ -103,12 +103,12 @@ def _resolve_api_key(
         env_var = provider_config.get(config_env_key)
         if isinstance(env_var, str) and env_var.strip():
             value = os.environ.get(env_var)
-            if value:
+            if value and value.strip():
                 return value
 
     for env_var in sources.env_vars:
         value = os.environ.get(env_var)
-        if value:
+        if value and value.strip():
             return value
 
     if not sources.required or _optional_condition_matches(

--- a/src/metis/providers/openai.py
+++ b/src/metis/providers/openai.py
@@ -6,10 +6,6 @@ from metis.providers.openai_compatible import OpenAICompatibleEmbeddingProvider
 from metis.providers.config import ApiKeySources
 from metis.providers.config import ProviderConfigSpec
 
-import logging
-
-logger = logging.getLogger(__name__)
-
 
 class OpenAIProvider(OpenAICompatibleChatProvider):
     CONFIG_SPEC = ProviderConfigSpec(

--- a/src/metis/providers/registry.py
+++ b/src/metis/providers/registry.py
@@ -27,6 +27,7 @@ class ProviderLoader:
 
 
 _PROVIDER_LOADERS: dict[str, ProviderLoader] = {}
+_PROVIDER_LOADER_ERRORS: dict[str, str] = {}
 
 
 def _register_provider_loader(
@@ -63,6 +64,8 @@ def _get_provider(
     if provider_cls := providers.get(key):
         return provider_cls
     _discover_provider_loaders()
+    if key in _PROVIDER_LOADER_ERRORS:
+        raise ValueError(_PROVIDER_LOADER_ERRORS[key])
     loader = _PROVIDER_LOADERS.get(key)
     dotted_path = getattr(loader, surface) if loader else None
     if not dotted_path:
@@ -79,6 +82,11 @@ def _get_provider(
             f"{surface.capitalize()} provider '{name}' is registered but required "
             "dependencies are missing."
         ) from exc
+    expected = ChatProvider if surface == "chat" else EmbeddingProvider
+    if not isinstance(provider_cls, type) or not issubclass(provider_cls, expected):
+        raise TypeError(
+            f"{surface.capitalize()} provider {name!r} must be a {expected.__name__} subclass"
+        )
     providers[key] = provider_cls
     return provider_cls
 
@@ -91,11 +99,15 @@ def _discover_provider_loaders() -> None:
     for entry_point in metadata.entry_points().select(
         group=_PROVIDER_ENTRY_POINT_GROUP
     ):
-        provider_name, surface = _parse_provider_entry_point_name(entry_point.name)
-        if surface == "chat":
-            _register_provider_loader(provider_name, chat=entry_point.value)
-        else:
-            _register_provider_loader(provider_name, embedding=entry_point.value)
+        provider_name = entry_point.name.rpartition(".")[0] or entry_point.name
+        try:
+            provider_name, surface = _parse_provider_entry_point_name(entry_point.name)
+            if surface == "chat":
+                _register_provider_loader(provider_name, chat=entry_point.value)
+            else:
+                _register_provider_loader(provider_name, embedding=entry_point.value)
+        except ValueError as exc:
+            _PROVIDER_LOADER_ERRORS[provider_name.lower()] = str(exc)
 
     _PROVIDER_LOADERS_DISCOVERED = True
 

--- a/src/metis/runlog/encoding.py
+++ b/src/metis/runlog/encoding.py
@@ -170,7 +170,11 @@ class PayloadEncoder:
         return value
 
     def _encode_text(self, text: str) -> Any:
-        raw = text.encode("utf-8")
+        try:
+            raw = text.encode("utf-8")
+        except UnicodeEncodeError:
+            # JSON escapes retain the text exactly, including unpaired surrogates.
+            return self._maybe_spill_json(text)
         if len(raw) <= self._config.blob_threshold:
             return text
         return self._blob_reference(
@@ -200,7 +204,7 @@ class PayloadEncoder:
             ensure_ascii=False,
             allow_nan=False,
             separators=(",", ":"),
-        ).encode("utf-8")
+        ).encode("utf-8", errors="backslashreplace")
         if len(raw) <= self._config.blob_threshold:
             return value
         preview = raw[:PREVIEW_CHARS].decode("utf-8", errors="replace")
@@ -279,11 +283,11 @@ def _redaction_bytes(value: Any) -> bytes:
     if isinstance(value, bytes):
         return value
     if isinstance(value, str):
-        return value.encode("utf-8")
+        return value.encode("utf-8", errors="surrogatepass")
     try:
         return json.dumps(value, sort_keys=True, default=_safe_repr).encode("utf-8")
     except Exception:
-        return _safe_repr(value).encode("utf-8")
+        return _safe_repr(value).encode("utf-8", errors="surrogatepass")
 
 
 def _safe_repr(value: Any) -> str:

--- a/src/metis/runlog/langchain.py
+++ b/src/metis/runlog/langchain.py
@@ -233,6 +233,6 @@ def _response_payload(response: Any) -> dict[str, Any]:
 def _positive_int(value: Any) -> int:
     try:
         parsed = int(value or 0)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0
     return parsed if parsed > 0 else 0

--- a/src/metis/runlog/session.py
+++ b/src/metis/runlog/session.py
@@ -228,7 +228,9 @@ class RunLogSession:
         created_ndjson = False
         try:
             self.output_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-            self._file = self.ndjson_path.open("x", encoding="utf-8", buffering=1)
+            self._file = self.ndjson_path.open(
+                "x", encoding="utf-8", errors="backslashreplace", buffering=1
+            )
             created_ndjson = True
             self.ndjson_path.chmod(0o600)
             self._encoder = PayloadEncoder(self.blobs_dir, self.config)
@@ -468,6 +470,12 @@ class RunLogSession:
                         if record_type == "event"
                         else span_explanation(kind or "operation", name)
                     )
+                encoded_attributes = self._encoder.encode_mapping(
+                    materialized_attributes
+                )
+                encoded_error = (
+                    self._encoder.encode_mapping(error) if error is not None else None
+                )
                 record: dict[str, Any] = {
                     "v": SCHEMA_VERSION,
                     "record": record_type,
@@ -481,7 +489,7 @@ class RunLogSession:
                     "explanation": resolved_explanation,
                     "thread": threading.current_thread().name,
                     "thread_id": threading.get_ident(),
-                    "attributes": self._encoder.encode_mapping(materialized_attributes),
+                    "attributes": encoded_attributes,
                 }
                 if record_type != "event":
                     record["parent_span_id"] = parent_span_id
@@ -490,8 +498,8 @@ class RunLogSession:
                     record["status"] = status
                 if duration_ms is not None:
                     record["duration_ms"] = round(duration_ms, 3)
-                if error is not None:
-                    record["error"] = self._encoder.encode_mapping(error)
+                if encoded_error is not None:
+                    record["error"] = encoded_error
                 line = json.dumps(
                     record,
                     ensure_ascii=False,
@@ -527,7 +535,7 @@ class RunLogSession:
             self.meta_path,
             payload,
             indent=2,
-            ensure_ascii=False,
+            ensure_ascii=True,
             allow_nan=False,
             mode=0o600,
         )
@@ -690,9 +698,14 @@ def _merge_attributes(
 
 
 def _exception_payload(exc: BaseException) -> dict[str, Any]:
+    try:
+        message = str(exc)
+    except BaseException:
+        # Formatting must not replace the original failure, even with an interrupt.
+        message = "<exception str() failed>"
     return {
         "type": type(exc).__name__,
-        "message": str(exc),
+        "message": message,
         "traceback": "".join(
             traceback.format_exception(type(exc), exc, exc.__traceback__)
         ),

--- a/src/metis/sarif/triage.py
+++ b/src/metis/sarif/triage.py
@@ -63,7 +63,10 @@ def apply_triage_annotations(report_data: Any, sarif_payload: Any) -> Any:
     properties_by_id: dict[str, dict[str, Any]] = {}
     ambiguous_ids: set[str] = set()
     for run in runs:
-        for result in run.get("results", ()) if isinstance(run, dict) else ():
+        results = run.get("results") if isinstance(run, dict) else None
+        if not isinstance(results, list):
+            continue
+        for result in results:
             properties = result.get("properties") if isinstance(result, dict) else None
             if not isinstance(properties, dict):
                 continue
@@ -238,13 +241,13 @@ def apply_triage_result(
     metadata: dict[str, Any] | None = None,
 ) -> bool:
     runs = payload.get("runs")
-    if not isinstance(runs, list) or run_index >= len(runs):
+    if not isinstance(runs, list) or not 0 <= run_index < len(runs):
         return False
     run = runs[run_index]
     if not isinstance(run, dict):
         return False
     results = run.get("results")
-    if not isinstance(results, list) or result_index >= len(results):
+    if not isinstance(results, list) or not 0 <= result_index < len(results):
         return False
     result = results[result_index]
     if not isinstance(result, dict):

--- a/src/metis/sarif/writer.py
+++ b/src/metis/sarif/writer.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from uuid import uuid4
+from copy import deepcopy
 
 from metis.sarif.triage import METIS_FINDING_ID_KEY
 from metis.version import __version__ as TOOL_VERSION
@@ -99,7 +100,7 @@ def generate_sarif(
                         "version": TOOL_VERSION,
                         "fullName": f"{tool_name} v{TOOL_VERSION}",
                         "informationUri": "https://github.com/arm/metis",
-                        "rules": RULES,
+                        "rules": deepcopy(RULES),
                     }
                 },
                 "automationDetails": {"id": automation_id},

--- a/src/metis/usage/collector.py
+++ b/src/metis/usage/collector.py
@@ -72,17 +72,19 @@ class UsageCollector:
         output_tokens: int,
         total_tokens: int | None = None,
     ) -> None:
+        input_tokens = max(0, int(input_tokens or 0))
+        output_tokens = max(0, int(output_tokens or 0))
         event = {
             "operation": operation or "llm",
             "model": model or "unknown",
-            "input_tokens": max(0, int(input_tokens or 0)),
-            "output_tokens": max(0, int(output_tokens or 0)),
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
             "total_tokens": max(
                 0,
                 (
                     int(total_tokens)
                     if total_tokens is not None
-                    else int(input_tokens or 0) + int(output_tokens or 0)
+                    else input_tokens + output_tokens
                 ),
             ),
         }

--- a/src/metis/usage/llamaindex.py
+++ b/src/metis/usage/llamaindex.py
@@ -14,7 +14,7 @@ from metis.utils import count_tokens
 def _as_int(value: Any) -> int:
     try:
         parsed = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0
     return parsed if parsed > 0 else 0
 

--- a/src/metis/usage/runtime.py
+++ b/src/metis/usage/runtime.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
 from typing import Any, Iterator
+from uuid import uuid4
 
 from llama_index.core.callbacks import CallbackManager
 from langchain_core.callbacks import BaseCallbackHandler
@@ -134,17 +136,19 @@ class UsageRuntime:
         }
         with self._lock:
             self._completed_commands.append(record)
-        return record
+        return deepcopy(record)
 
     def completed_commands(self) -> list[dict[str, Any]]:
         with self._lock:
-            return list(self._completed_commands)
+            return deepcopy(self._completed_commands)
 
     def default_output_path(self) -> str:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        return str(Path("results") / f"metis_usage_{timestamp}.json")
+        return str(Path("results") / f"metis_usage_{timestamp}_{uuid4().hex}.json")
 
     def build_persisted_payload(self) -> dict[str, Any]:
+        # Read commands first so concurrently completed work cannot exceed totals.
+        commands = self.completed_commands()
         return {
             "schema_version": 1,
             "project_name": Path(self.codebase_path).resolve().name,
@@ -152,7 +156,7 @@ class UsageRuntime:
             "started_at": self.started_at,
             "ended_at": _utc_now(),
             "totals": self.snapshot_total(),
-            "commands": self.completed_commands(),
+            "commands": commands,
         }
 
     def save_run_summary(self, output_path: str | None = None) -> str:

--- a/tests/fixtures/execution_extension/README.md
+++ b/tests/fixtures/execution_extension/README.md
@@ -1,0 +1,19 @@
+# Offline execution extension
+
+`tests/test_execution_e2e.py` builds this pure-Python wheel once per test session
+with the installed setuptools backend. Subprocesses import the wheel directly;
+Python discovers its genuine distribution and entry-point metadata. No package
+index, external service, provider credentials, or security workload is used.
+Build and execution subprocesses inherit only basic process settings; provider
+credentials and other unrelated environment values are excluded.
+
+The fixture exercises custom stages, scalar and tuple ports, a replacement review
+publisher, partial failure, and a capability owned by the public engine.
+The pool stage also measures shared node/job capacity, graph admission, context
+propagation and cancellation with condition-protected counters and bounded waits. Its chat
+provider raises if a test accidentally requests a model. Optional JSON-line
+events are written to `METIS_E2E_EVENTS` for ordering and cleanup assertions.
+
+The shared pytest fixture and configuration helpers in `test_execution_e2e` are
+also used by `test_cli_e2e.py` to run the actual `python -m metis` entry point and
+verify JSON, SARIF, HTML, CSV, error status, and checkpoint persistence.

--- a/tests/fixtures/execution_extension/metis_e2e_extension/__init__.py
+++ b/tests/fixtures/execution_extension/metis_e2e_extension/__init__.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inert installed extension: public contracts, no provider or target workloads."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+import json
+import os
+from pathlib import Path
+from threading import Condition
+from threading import Event
+from threading import Lock
+from threading import get_ident
+from time import monotonic
+from time import sleep
+from typing import Annotated
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import PrivateAttr
+
+from metis.capabilities import CapabilityManifest
+from metis.capabilities import CapabilityRegistration
+from metis.execution_nodes import CapabilityRequirement
+from metis.execution_nodes import EmptyNodeConfiguration
+from metis.execution_nodes import ExecutionDiagnostic
+from metis.execution_nodes import ExecutionStatus
+from metis.execution_nodes import NodeRegistration
+from metis.execution_nodes import NodeResult
+from metis.execution_nodes import ReviewCommand
+from metis.execution_nodes import SarifPayload
+from metis.execution_nodes import StandardReviewResult
+from metis.execution_stages import StageContract
+from metis.execution_stages import StageRegistration
+from metis.providers.base import ChatProvider
+from metis.providers.config import ProviderConfigSpec
+from metis.version import __version__
+
+_event_lock = Lock()
+execution_tag = ContextVar("e2e_execution_tag", default=None)
+
+
+def event(name, **fields):
+    if destination := os.environ.get("METIS_E2E_EVENTS"):
+        with _event_lock:
+            with Path(destination).open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"event": name, **fields}) + "\n")
+
+
+class OfflineProvider(ChatProvider):
+    CONFIG_SPEC = ProviderConfigSpec("Metis E2E", copy_keys=("model",))
+
+    def get_chat_model(self, *args, **kwargs):
+        raise AssertionError("The inert extension must never request a model")
+
+
+class Settings(BaseModel):
+    _lock: object = PrivateAttr(default_factory=Lock)
+    value: int = 3
+    factor: int = 1
+    status: Literal["ok", "inconclusive"] = "ok"
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def seed_stage():
+    event("stage_contract", stage="e2e_seed")
+    return StageRegistration("e2e_seed", StageContract({}))
+
+
+collect_stage = StageRegistration(
+    "e2e_collect",
+    StageContract(
+        {"seed": Annotated[int, Field(gt=0)]},
+        {"total": Annotated[int, Field(gt=0)]},
+    ),
+)
+faults_stage = StageRegistration("e2e_faults", StageContract({}))
+wait_stage = StageRegistration("e2e_wait", StageContract({}))
+
+
+def seed(invocation):
+    with invocation.configuration._lock:
+        event("seed")
+        return NodeResult({"seed": invocation.configuration.value})
+
+
+def multiply(invocation):
+    value = invocation.inputs["seed"] * invocation.configuration.factor
+    event("multiply", value=value)
+    return NodeResult({"value": value})
+
+
+def join(invocation):
+    values = invocation.inputs["values"]
+    event("join", values=values)
+    return NodeResult({"total": sum(values)})
+
+
+def findings(invocation):
+    request = invocation.inputs["request"]
+    event("review", mode=request.mode, target=request.target)
+    return {
+        "formats": ("json", "sarif"),
+        "findings": StandardReviewResult.model_validate(
+            {
+                "reviews": [
+                    {
+                        "file": "fixture.txt",
+                        "reviews": [
+                            {"id": "e2e-1", "issue": "Inert extension fixture"}
+                        ],
+                    }
+                ]
+            }
+        ),
+    }
+
+
+def review(invocation):
+    payload = findings(invocation)
+    payload["filename"] = invocation.filename
+    payload["sarif"] = SarifPayload.model_validate(
+        {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "Metis E2E"}},
+                    "results": [{"message": {"text": "Inert extension fixture"}}],
+                }
+            ],
+        }
+    )
+    status = ExecutionStatus(invocation.configuration.status)
+    if invocation.context.callbacks.resume is not None:
+        event("resume", records=invocation.context.callbacks.resume("e2e_result"))
+    if invocation.context.callbacks.checkpoint is not None:
+        invocation.context.callbacks.checkpoint(
+            {
+                "metis_version": __version__,
+                "producer": "e2e_result",
+                "key": "fixture",
+                "record": {"completed": True},
+            },
+            1,
+            1,
+        )
+    diagnostics = (
+        (ExecutionDiagnostic("e2e.warning", "Inert extension warning", "warning"),)
+        if status is ExecutionStatus.INCONCLUSIVE
+        else ()
+    )
+    return NodeResult(payload, status, diagnostics)
+
+
+def fail(invocation):
+    event("failure")
+    return NodeResult(
+        {},
+        ExecutionStatus.ERROR,
+        (ExecutionDiagnostic("e2e.failure", "Deliberate fixture failure"),),
+    )
+
+
+seed_node = NodeRegistration("seed", "e2e_seed", Settings, {}, {"seed": int}, seed)
+left_node = NodeRegistration(
+    "left", "e2e_collect", Settings, {"seed": int}, {"value": int}, multiply
+)
+right_node = NodeRegistration(
+    "right", "e2e_collect", Settings, {"seed": int}, {"value": int}, multiply
+)
+join_node = NodeRegistration(
+    "join",
+    "e2e_collect",
+    EmptyNodeConfiguration,
+    {"values": tuple[int, ...]},
+    {"total": int},
+    join,
+)
+review_node = NodeRegistration(
+    "e2e_result",
+    "review",
+    Settings,
+    {"request": ReviewCommand},
+    {
+        "formats": tuple[Literal["json", "sarif"], ...],
+        "findings": StandardReviewResult,
+        "sarif": SarifPayload,
+        "filename": str | None,
+    },
+    review,
+)
+findings_node = NodeRegistration(
+    "e2e_findings",
+    "review",
+    EmptyNodeConfiguration,
+    {"request": ReviewCommand},
+    {"formats": tuple[Literal["json", "sarif"], ...], "findings": StandardReviewResult},
+    lambda invocation: NodeResult(findings(invocation)),
+)
+sarif_failure_node = NodeRegistration(
+    "e2e_sarif_failure",
+    "review",
+    EmptyNodeConfiguration,
+    {},
+    {"sarif": SarifPayload},
+    fail,
+)
+good_node = NodeRegistration(
+    "good",
+    "e2e_faults",
+    EmptyNodeConfiguration,
+    {},
+    {"value": int},
+    lambda invocation: event("good") or NodeResult({"value": 7}),
+)
+bad_node = NodeRegistration(
+    "bad", "e2e_faults", EmptyNodeConfiguration, {}, {"value": int}, fail
+)
+
+
+class Resource:
+    def __init__(self):
+        self.closed = False
+        self.condition = Condition()
+        self.finish_work = Event()
+        self.finish_work.set()
+        self.active = {"node": 0, "job": 0}
+        self.peak = {"node": 0, "job": 0}
+        self.started = {"node": 0, "job": 0}
+        self.threads = {"node": set(), "job": set()}
+        self.tags = {"node": set(), "job": set()}
+        self.on_work = None
+        event("resource_created")
+
+    def use(self):
+        with self.condition:
+            assert not self.closed, "handler used an already closed capability"
+
+    @contextmanager
+    def hold(self, kind):
+        with self.condition:
+            self.use()
+            self.active[kind] += 1
+            self.peak[kind] = max(self.peak[kind], self.active[kind])
+            self.started[kind] += 1
+            self.threads[kind].add(get_ident())
+            self.tags[kind].add(execution_tag.get())
+            self.condition.notify_all()
+        try:
+            yield
+        finally:
+            with self.condition:
+                self.use()
+                self.active[kind] -= 1
+                self.condition.notify_all()
+
+    def close(self):
+        with self.condition:
+            assert not self.closed, "capability closed more than once"
+            assert not any(self.active.values()), (
+                "capability closed before work drained"
+            )
+            self.closed = True
+            event("resource_closed")
+
+
+resource_capability = CapabilityRegistration(
+    CapabilityManifest("e2e_resource"),
+    EmptyNodeConfiguration,
+    lambda context, configuration: Resource(),
+    close=lambda resource: resource.close(),
+)
+
+
+def wait_for_cancellation(invocation):
+    resource = invocation.context.capabilities["e2e_resource"]
+
+    def worker(number):
+        event("job_started", number=number)
+        deadline = monotonic() + 10
+        try:
+            while not invocation.context.runtime.is_cancelled():
+                resource.use()
+                if monotonic() > deadline:
+                    raise AssertionError("cooperative worker was never cancelled")
+                sleep(0.01)
+        finally:
+            resource.use()
+            event("job_finished", number=number)
+        return number
+
+    return NodeResult(
+        {
+            "values": tuple(
+                invocation.context.jobs.run(
+                    tuple(range(8)), worker, label="e2e", result_key=str
+                )
+            )
+        }
+    )
+
+
+wait_node = NodeRegistration(
+    "wait",
+    "e2e_wait",
+    EmptyNodeConfiguration,
+    {},
+    {"values": tuple[int, ...]},
+    wait_for_cancellation,
+    {"e2e_resource": CapabilityRequirement.REQUIRED},
+)
+
+
+class NativePayload(BaseModel):
+    data: bytes
+
+
+native_node = NodeRegistration(
+    "native",
+    "e2e_faults",
+    EmptyNodeConfiguration,
+    {},
+    {"value": NativePayload},
+    lambda invocation: NodeResult({"value": NativePayload(data=b"\xff")}),
+)
+
+
+pool_stage = StageRegistration("e2e_pool", StageContract({}))
+
+
+def pool_work(invocation):
+    resource = invocation.context.capabilities["e2e_resource"]
+
+    def worker(number):
+        with resource.hold("job"):
+            if resource.on_work is not None:
+                resource.on_work()
+            deadline = monotonic() + 5
+            while not resource.finish_work.wait(0.01):
+                resource.use()
+                if invocation.context.runtime.is_cancelled():
+                    break
+                assert monotonic() < deadline, "work was neither released nor cancelled"
+            return number
+
+    with resource.hold("node"):
+        return NodeResult(
+            {
+                "values": tuple(
+                    invocation.context.jobs.run(
+                        (0, 1, 2), worker, label=None, result_key=str
+                    )
+                )
+            }
+        )
+
+
+pool_left_node = NodeRegistration(
+    "left",
+    "e2e_pool",
+    EmptyNodeConfiguration,
+    {},
+    {"values": tuple[int, ...]},
+    pool_work,
+    {"e2e_resource": CapabilityRequirement.REQUIRED},
+)
+pool_right_node = NodeRegistration(
+    "right",
+    "e2e_pool",
+    EmptyNodeConfiguration,
+    {},
+    {"values": tuple[int, ...]},
+    pool_work,
+    {"e2e_resource": CapabilityRequirement.REQUIRED},
+)

--- a/tests/fixtures/execution_extension/pyproject.toml
+++ b/tests/fixtures/execution_extension/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools" ]
+
+[project]
+name = "metis-execution-e2e"
+version = "0.0.1"
+requires-python = ">=3.12"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+entry-points."metis.capabilities".e2e_resource = "metis_e2e_extension:resource_capability"
+entry-points."metis.execution_nodes"."e2e_collect.join" = "metis_e2e_extension:join_node"
+entry-points."metis.execution_nodes"."e2e_collect.left" = "metis_e2e_extension:left_node"
+entry-points."metis.execution_nodes"."e2e_collect.right" = "metis_e2e_extension:right_node"
+entry-points."metis.execution_nodes"."e2e_faults.bad" = "metis_e2e_extension:bad_node"
+entry-points."metis.execution_nodes"."e2e_faults.good" = "metis_e2e_extension:good_node"
+entry-points."metis.execution_nodes"."e2e_faults.native" = "metis_e2e_extension:native_node"
+entry-points."metis.execution_nodes"."e2e_pool.left" = "metis_e2e_extension:pool_left_node"
+entry-points."metis.execution_nodes"."e2e_pool.right" = "metis_e2e_extension:pool_right_node"
+entry-points."metis.execution_nodes"."e2e_seed.seed" = "metis_e2e_extension:seed_node"
+entry-points."metis.execution_nodes"."e2e_wait.wait" = "metis_e2e_extension:wait_node"
+entry-points."metis.execution_nodes"."review.e2e_findings" = "metis_e2e_extension:findings_node"
+entry-points."metis.execution_nodes"."review.e2e_result" = "metis_e2e_extension:review_node"
+entry-points."metis.execution_nodes"."review.e2e_sarif_failure" = "metis_e2e_extension:sarif_failure_node"
+entry-points."metis.execution_stages".e2e_collect = "metis_e2e_extension:collect_stage"
+entry-points."metis.execution_stages".e2e_faults = "metis_e2e_extension:faults_stage"
+entry-points."metis.execution_stages".e2e_pool = "metis_e2e_extension:pool_stage"
+entry-points."metis.execution_stages".e2e_seed = "metis_e2e_extension:seed_stage"
+entry-points."metis.execution_stages".e2e_wait = "metis_e2e_extension:wait_stage"
+entry-points."metis.providers"."metis_e2e.chat" = "metis_e2e_extension:OfflineProvider"

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -10,7 +10,10 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import ValidationError
+from pydantic import model_validator
 
+from metis.configuration import load_runtime_config
+from metis.configuration import load_yaml
 from metis.capabilities import CapabilityContext
 from metis.capabilities import CapabilityManifest
 from metis.capabilities import CapabilityRegistration
@@ -116,6 +119,90 @@ def test_invalid_selected_configuration_fails_before_factory(tmp_path: Path) -> 
     factory.assert_not_called()
 
 
+@pytest.mark.parametrize("callback", ("registration", "validation"))
+def test_capability_reentry_before_factory_is_rejected_and_retryable(
+    tmp_path: Path, callback: str
+) -> None:
+    instance = object()
+    factory = Mock(return_value=instance)
+    closed: list[object] = []
+    reentered = False
+
+    class Configuration(EmptyNodeConfiguration):
+        @model_validator(mode="before")
+        @classmethod
+        def validate_configuration(cls, values):
+            nonlocal reentered
+            if callback == "validation" and not reentered:
+                reentered = True
+                capabilities.require("shared")
+            return values
+
+    registration = CapabilityRegistration(
+        CapabilityManifest("shared"), Configuration, factory, closed.append
+    )
+
+    def load_registration():
+        nonlocal reentered
+        if callback == "registration" and not reentered:
+            reentered = True
+            capabilities.require("shared")
+        return registration
+
+    capabilities = build_engine_capabilities(
+        {"shared"},
+        {},
+        CapabilityCatalog((), (_EntryPoint("shared", load_registration),)),
+        _context(tmp_path),
+    )
+    try:
+        with pytest.raises(RuntimeError, match="shared.*already being constructed"):
+            capabilities.require("shared")
+        factory.assert_not_called()
+        assert closed == []
+        assert capabilities.require("shared") is instance
+        assert capabilities["shared"] is instance
+        factory.assert_called_once()
+    finally:
+        capabilities.close()
+    assert closed == [instance]
+
+
+def test_failed_capability_validation_does_not_block_retry(tmp_path: Path) -> None:
+    attempts = 0
+    instance = object()
+    factory = Mock(return_value=instance)
+    closed: list[object] = []
+
+    class Configuration(EmptyNodeConfiguration):
+        @model_validator(mode="before")
+        @classmethod
+        def validate_configuration(cls, values):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise ValueError("temporarily invalid configuration")
+            return values
+
+    registration = CapabilityRegistration(
+        CapabilityManifest("shared"), Configuration, factory, closed.append
+    )
+    capabilities = build_engine_capabilities(
+        {"shared"}, {}, CapabilityCatalog((registration,), ()), _context(tmp_path)
+    )
+    try:
+        with pytest.raises(ValidationError, match="temporarily invalid"):
+            capabilities["shared"]
+        factory.assert_not_called()
+        assert capabilities["shared"] is instance
+        assert capabilities.require("shared") is instance
+        assert attempts == 2
+        factory.assert_called_once()
+    finally:
+        capabilities.close()
+    assert closed == [instance]
+
+
 def test_external_capability_cannot_shadow_builtin() -> None:
     registration = _registration("shared", Mock())
     catalog = CapabilityCatalog(
@@ -155,3 +242,69 @@ def test_unsupported_node_grant_does_not_load_capability(tmp_path: Path) -> None
 
     assert entry_point.load_count == 0
     factory.assert_not_called()
+
+
+def test_raw_capability_manifest_and_runtime_settings_keep_registered_identity(
+    tmp_path: Path,
+):
+    manifest_path = tmp_path / "capability.yaml"
+    manifest_path.write_text(
+        """
+name: CustomCapability
+operations:
+  - id: CustomCapability.Run
+    name: Run
+    surfaces: [model_tool]
+""",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        """
+llm_provider: {name: ollama, model: test-model}
+metis_engine:
+  capabilities:
+    CustomCapability: {budget: 3}
+""",
+        encoding="utf-8",
+    )
+    manifest = CapabilityManifest.from_mapping(load_yaml(manifest_path))
+    registration = CapabilityRegistration(
+        manifest, _Configuration, lambda _context, config: config.budget
+    )
+    catalog = CapabilityCatalog((registration,), ())
+    runtime = load_runtime_config(config_path)
+
+    capabilities = build_engine_capabilities(
+        {"CustomCapability"},
+        runtime["capability_settings"].configurations,
+        catalog,
+        _context(tmp_path),
+    )
+    try:
+        assert capabilities["CustomCapability"] == 3
+        assert (
+            catalog.resolve("CustomCapability").manifest.operations[0].id
+            == "CustomCapability.Run"
+        )
+    finally:
+        capabilities.close()
+
+
+@pytest.mark.parametrize(
+    "invalid_field",
+    (
+        "operations: model",
+        "contracts: []",
+        "operation: []",
+        "operations: [{id: demo.run, name: Run, surfaces: model}]",
+    ),
+)
+def test_capability_manifest_rejects_malformed_raw_fields(
+    tmp_path: Path, invalid_field
+):
+    path = tmp_path / "manifest.yaml"
+    path.write_text("name: demo\n" + invalid_field + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        CapabilityManifest.from_mapping(load_yaml(path))

--- a/tests/test_checkpoint_recovery.py
+++ b/tests/test_checkpoint_recovery.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
+from threading import Event
+from threading import current_thread
+import sqlite3
+
+import pytest
+
+from metis.cli import review_checkpoints
+from metis.engine.stages.review.models import ReviewCheckpointRecord
+from metis.version import __version__ as METIS_VERSION
+
+
+@pytest.mark.parametrize(
+    "contents", [b"inert invalid sqlite", b"SQLite format 3\x00" + bytes(256)]
+)
+def test_corrupt_checkpoints_are_preserved_after_reads_and_writes(
+    tmp_path, caplog, contents
+):
+    path = tmp_path / "checkpoint.sqlite3"
+    path.write_bytes(contents)
+    record = ReviewCheckpointRecord(
+        metis_version=METIS_VERSION,
+        producer="fixture",
+        key="one",
+        record={"revision": 1},
+    )
+
+    assert review_checkpoints._sqlite_records(path) is None
+    review_checkpoints._write_sqlite_record(path, record)
+
+    assert path.read_bytes() == contents
+    assert "Unable to save review checkpoint" in caplog.text
+
+
+def test_incompatible_checkpoint_schema_is_preserved(tmp_path, caplog):
+    path = tmp_path / "checkpoint.sqlite3"
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute("CREATE TABLE review_checkpoint_records (custom TEXT)")
+        connection.execute("INSERT INTO review_checkpoint_records VALUES ('retained')")
+    before = path.read_bytes()
+    record = ReviewCheckpointRecord(
+        metis_version=METIS_VERSION, producer="fixture", key="one", record={}
+    )
+
+    assert review_checkpoints._sqlite_records(path) is None
+    review_checkpoints._write_sqlite_record(path, record)
+
+    assert path.read_bytes() == before
+    assert "Unable to save review checkpoint" in caplog.text
+
+
+@pytest.mark.parametrize("reading", [False, True])
+def test_stale_corruption_error_preserves_another_writers_replacement(
+    tmp_path, monkeypatch, reading
+):
+    path = tmp_path / "checkpoint.sqlite3"
+    path.write_bytes(b"inert invalid sqlite")
+    observed, replacement_done = Event(), Event()
+    original_connect = review_checkpoints._connect_checkpoint
+    record = ReviewCheckpointRecord(
+        metis_version=METIS_VERSION,
+        producer="fixture",
+        key="completed",
+        record={"revision": 1},
+    )
+
+    class Connection:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def __getattr__(self, name):
+            return getattr(self.connection, name)
+
+        def execute(self, *args, **kwargs):
+            try:
+                return self.connection.execute(*args, **kwargs)
+            except sqlite3.DatabaseError:
+                # Pause an actual SQLite error until another writer publishes a
+                # healthy replacement. The error still describes the old file.
+                observed.set()
+                assert replacement_done.wait(5)
+                raise
+
+    def connect(target):
+        connection = original_connect(target)
+        if current_thread().name.startswith("stale-checkpoint"):
+            return Connection(connection)
+        return connection
+
+    monkeypatch.setattr(review_checkpoints, "_connect_checkpoint", connect)
+
+    def stale_operation():
+        if reading:
+            review_checkpoints._sqlite_records(path)
+        else:
+            review_checkpoints._write_sqlite_record(
+                path, record.model_copy(update={"key": "stale"})
+            )
+
+    def replace_checkpoint():
+        try:
+            assert observed.wait(5)
+            replacement = tmp_path / "replacement.sqlite3"
+            review_checkpoints._write_sqlite_record(replacement, record)
+            replacement.replace(path)
+        finally:
+            replacement_done.set()
+
+    with ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="stale-checkpoint"
+    ) as stale:
+        with ThreadPoolExecutor(max_workers=1) as replacement:
+            pending = stale.submit(stale_operation)
+            replacement.submit(replace_checkpoint).result(timeout=10)
+            pending.result(timeout=10)
+
+    assert review_checkpoints._sqlite_records(path) == {"completed": {"revision": 1}}
+
+
+def test_undecodable_nested_checkpoint_does_not_hide_other_records(tmp_path):
+    path = tmp_path / "checkpoint.sqlite3"
+    record = ReviewCheckpointRecord(
+        metis_version=METIS_VERSION,
+        producer="fixture",
+        key="a_valid",
+        record={"revision": 1},
+    )
+    review_checkpoints._write_sqlite_record(path, record)
+    review_checkpoints._write_sqlite_record(
+        path, record.model_copy(update={"key": "z_valid"})
+    )
+    malformed = '{"nested":' + "[" * 10000 + "0" + "]" * 10000 + "}"
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute(
+            "INSERT INTO review_checkpoint_records VALUES (?, ?, ?)",
+            (METIS_VERSION, "m_invalid", malformed),
+        )
+
+    assert review_checkpoints._sqlite_records(path) == {
+        "a_valid": {"revision": 1},
+        "z_valid": {"revision": 1},
+    }

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -266,13 +266,82 @@ def test_graph_progress_hands_review_rows_to_triage() -> None:
     assert progress.rules == ["Init", "Review", "Triage"]
     assert progress.removed == [1, 2, 3, 4]
     assert progress.renderables == 2
-    assert "[green]✓ review.result complete[/green]" in progress.messages
-    assert "[green]✓ triage.result complete[/green]" in progress.messages
+    assert "[yellow]! review.result inconclusive[/yellow]" in progress.messages
+    assert "[yellow]! triage.result inconclusive[/yellow]" in progress.messages
     assert any(
         "[green]Valid: 1[/green] [red]Invalid: 1[/red]"
         in str(update.get("description"))
         for update in progress.updates
     )
+
+
+@pytest.mark.parametrize("node", ("result", "collect"))
+def test_graph_progress_uses_status_for_generic_node_names(node) -> None:
+    progress = _Progress()
+    reporter = ExecutionGraphProgressReporter(progress)
+    reporter({"event": "execution_stage_start", "stage": "archive"})
+    reporter(
+        {
+            "event": "execution_node_end",
+            "stage": "archive",
+            "node": node,
+            "status": "inconclusive",
+        }
+    )
+    assert f"[yellow]! archive.{node} inconclusive[/yellow]" in progress.messages
+
+
+@pytest.mark.parametrize(
+    ("status", "description"),
+    (
+        ("error", "[red]Triage failed[/red]"),
+        ("ok", "[green]No findings[/green]"),
+    ),
+)
+def test_graph_progress_preserves_triage_terminal_row(status, description) -> None:
+    progress = _Progress()
+    reporter = ExecutionGraphProgressReporter(progress)
+    reporter({"event": "execution_stage_start", "stage": "triage"})
+    reporter(
+        {
+            "event": "execution_node_end",
+            "stage": "triage",
+            "node": "triage",
+            "status": status,
+        }
+    )
+    assert progress.updates[-1]["description"] == description
+
+    reporter({"event": "execution_stage_end", "stage": "triage", "status": status})
+    assert progress.updates[-1]["description"] == description
+    for _ in range(2):
+        reporter.finish()
+        assert progress.updates[-1]["description"] == description
+
+
+@pytest.mark.parametrize("status", ("ok", "error"))
+def test_graph_progress_retires_triage_before_custom_stage(status) -> None:
+    progress = _Progress()
+    reporter = ExecutionGraphProgressReporter(progress)
+    reporter({"event": "execution_stage_start", "stage": "triage"})
+    reporter(
+        {
+            "event": "execution_node_end",
+            "stage": "triage",
+            "node": "triage",
+            "status": status,
+        }
+    )
+    terminal_description = progress.updates[-1]["description"]
+    reporter({"event": "execution_stage_start", "stage": "archive"})
+
+    assert progress.updates[-1]["description"] == terminal_description
+    assert progress.removed == [1]
+    assert progress.renderables == 1
+    update_count = len(progress.updates)
+    reporter.finish()
+    assert len(progress.updates) == update_count
+    assert progress.renderables == 1
 
 
 @pytest.mark.parametrize(
@@ -434,12 +503,12 @@ def test_review_checkpoints_can_be_disabled(tmp_path):
     assert not (tmp_path / ".metis").exists()
 
 
-def test_review_checkpoints_replace_incompatible_database(tmp_path):
+def test_review_checkpoints_write_legacy_schema(tmp_path):
     checkpoint_path = (
         tmp_path / ".metis" / "checkpoints" / "review.simple_llm_review.sqlite3"
     )
     checkpoint_path.parent.mkdir(parents=True)
-    with sqlite3.connect(checkpoint_path) as connection:
+    with closing(sqlite3.connect(checkpoint_path)) as connection, connection:
         connection.execute(
             """
             CREATE TABLE review_checkpoint_records (
@@ -666,3 +735,26 @@ def test_run_review_code_preserves_review_output_when_triage_fails(monkeypatch):
     commands.run_review_code(_Engine(), args, runtime)
 
     assert saved == [{"version": "2.1.0", "runs": [{"results": []}]}]
+
+
+@pytest.mark.parametrize(
+    "producers",
+    [("Example", "example"), ("Café", "Cafe\u0301"), ("x" * 300, "x" * 301)],
+)
+def test_checkpoint_filenames_preserve_exact_producer_identity(tmp_path, producers):
+    callbacks = review_checkpoint_callbacks(codebase_path=tmp_path, enabled=True)
+    for index, producer in enumerate(producers):
+        record = ReviewCheckpointRecord(
+            metis_version=METIS_VERSION,
+            producer=producer,
+            key="shared",
+            record={"value": index},
+        )
+        callbacks["review_checkpoint_callback"](record.model_dump(mode="json"), 1, 1)
+    for index, producer in enumerate(producers):
+        assert callbacks["review_resume_callback"](producer) == {
+            "shared": {"value": index}
+        }
+    paths = list((tmp_path / ".metis" / "checkpoints").glob("*.sqlite3"))
+    assert len(paths) == 2
+    assert len({path.name.casefold() for path in paths}) == 2

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the actual CLI against an offline extension and inspect published artifacts."""
+
+import csv
+import json
+import stat
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+from test_execution_e2e import extension_environment
+from test_execution_e2e import extension_graph
+from test_execution_e2e import (
+    installed_execution_extension as installed_execution_extension,
+)
+from test_execution_e2e import write_execution_config
+
+
+def run_cli(
+    installation, directory, *arguments, input_text=None, config_file="metis.yaml"
+):
+    return subprocess.run(
+        [sys.executable, "-m", "metis", "--config", config_file, *arguments],
+        cwd=directory,
+        env=extension_environment(
+            installation, METIS_E2E_EVENTS=directory / "events.jsonl"
+        ),
+        capture_output=True,
+        text=True,
+        input=input_text,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "verbose", "explicit"),
+    [
+        ("ok", False, True),
+        ("ok", True, False),
+        ("inconclusive", False, False),
+        ("inconclusive", True, True),
+    ],
+)
+def test_cli_executes_installed_extension_and_publishes_reports(
+    installed_execution_extension, tmp_path, status, verbose, explicit
+):
+    graph = extension_graph()
+    graph["node_configuration"]["review"] = {"e2e_result": {"status": status}}
+    config_file = "custom-config.yml" if explicit else "metis.yaml"
+    write_execution_config(tmp_path / config_file, graph)
+    arguments = ["--log-workflow-debug", "--log-workflow-debug-path", "trace.ndjson"]
+    if verbose:
+        arguments.append("--verbose")
+    if explicit:
+        for suffix in ("json", "sarif", "html", "csv"):
+            target = tmp_path / f"report.{suffix}"
+            target.write_text("previous report", encoding="utf-8")
+            target.chmod(0o640)
+            arguments.extend(["--output-file", target.name])
+    completed = run_cli(
+        installed_execution_extension, tmp_path, *arguments, config_file=config_file
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert (
+        "inconclusive results" if status == "inconclusive" else "graph complete"
+    ) in completed.stdout
+    assert ("Inert extension warning" in completed.stdout) == (status == "inconclusive")
+    json_path = (
+        tmp_path / "report.json"
+        if explicit
+        else next((tmp_path / "results").glob("*.json"))
+    )
+    report = json.loads(json_path.read_text())
+    assert report["reviews"][0]["reviews"][0]["id"] == "e2e-1"
+    sarif = json.loads(json_path.with_suffix(".sarif").read_text())
+    assert (
+        sarif["runs"][0]["results"][0]["message"]["text"] == "Inert extension fixture"
+    )
+    assert stat.S_IMODE(json_path.stat().st_mode) == 0o600
+    if explicit:
+        assert "Inert extension fixture" in (tmp_path / "report.html").read_text()
+        with (tmp_path / "report.csv").open(newline="", encoding="utf-8") as handle:
+            assert list(csv.DictReader(handle))[0]["Issue"] == "Inert extension fixture"
+        for suffix in ("html", "csv"):
+            assert stat.S_IMODE((tmp_path / f"report.{suffix}").stat().st_mode) == 0o640
+    trace = [
+        json.loads(line)
+        for line in (tmp_path / "trace.ndjson").read_text().splitlines()
+    ]
+    assert trace[0]["kind"] == trace[-1]["kind"] == "run"
+    if status == "ok":
+        assert trace[-1]["status"] == "ok"
+    assert any(
+        item["record"] == "span.start"
+        and item.get("kind") == "command"
+        and item["name"] == "execution_graph"
+        for item in trace
+    )
+    assert any(item.get("status") == status for item in trace)
+    events = [
+        json.loads(line)["event"]
+        for line in (tmp_path / "events.jsonl").read_text().splitlines()
+    ]
+    assert events.index("seed") < events.index("join") < events.index("review")
+    assert not list(tmp_path.rglob("*.tmp"))
+
+
+def test_cli_uses_filename_from_external_result_node(
+    installed_execution_extension, tmp_path
+):
+    graph = extension_graph()
+    graph["stages"]["review"]["nodes"]["e2e_result"] = {
+        "filename": "custom-result",
+        "formats": ["json", "sarif"],
+    }
+    graph["stages"]["review"]["outputs"]["filename"] = "e2e_result.filename"
+    write_execution_config(tmp_path / "metis.yaml", graph)
+
+    completed = run_cli(installed_execution_extension, tmp_path)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    report = json.loads((tmp_path / "custom-result.json").read_text())
+    assert report["reviews"][0]["reviews"][0]["id"] == "e2e-1"
+    sarif = json.loads((tmp_path / "custom-result.sarif").read_text())
+    assert (
+        sarif["runs"][0]["results"][0]["message"]["text"] == "Inert extension fixture"
+    )
+
+
+@pytest.mark.parametrize("explicit", [False, True], ids=["configured", "explicit"])
+def test_cli_preserves_valid_findings_when_sarif_producer_fails(
+    installed_execution_extension, tmp_path, explicit
+):
+    write_execution_config(tmp_path / "metis.yaml", extension_graph(fail=True))
+    old_sarif = tmp_path / "report.sarif"
+    old_sarif.write_text("previous complete report", encoding="utf-8")
+    arguments = ["--output-files", "report.json", "report.sarif"] if explicit else []
+    completed = run_cli(installed_execution_extension, tmp_path, *arguments)
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "Deliberate fixture failure" in completed.stdout
+    assert "Unable to save partial outputs" not in completed.stdout
+    report_path = (
+        tmp_path / "report.json"
+        if explicit
+        else next((tmp_path / "results").glob("*.json"))
+    )
+    assert (
+        json.loads(report_path.read_text())["reviews"][0]["reviews"][0]["id"] == "e2e-1"
+    )
+    assert old_sarif.read_text() == "previous complete report"
+    assert list(tmp_path.rglob("*.sarif")) == [old_sarif]
+    assert not list(tmp_path.rglob("*.tmp"))
+
+
+def test_cli_checkpoint_round_trip_across_processes(
+    installed_execution_extension, tmp_path
+):
+    config_path = write_execution_config(tmp_path / "metis.yaml", extension_graph())
+    configuration = yaml.safe_load(config_path.read_text())
+    configuration["metis_engine"]["review_checkpoints"] = True
+    config_path.write_text(yaml.safe_dump(configuration), encoding="utf-8")
+    for _ in range(2):
+        completed = run_cli(
+            installed_execution_extension, tmp_path, "--output-file", "report.json"
+        )
+        assert completed.returncode == 0, completed.stdout + completed.stderr
+    resumes = [
+        item["records"]
+        for line in (tmp_path / "events.jsonl").read_text().splitlines()
+        if (item := json.loads(line))["event"] == "resume"
+    ]
+    assert resumes == [None, {"fixture": {"completed": True}}]
+    assert (tmp_path / ".metis" / "checkpoints" / "review.e2e_result.sqlite3").is_file()
+    assert not list(tmp_path.glob("*.sqlite3"))
+
+
+def test_interactive_cli_rejects_bad_arguments_and_recovers_without_outputs(
+    installed_execution_extension, tmp_path
+):
+    write_execution_config(tmp_path / "metis.yaml", extension_graph())
+    completed = run_cli(
+        installed_execution_extension,
+        tmp_path,
+        "--interactive",
+        input_text="\n".join(
+            [
+                "review_file one.txt two.txt",
+                "index ignored",
+                "ask",
+                "help ignored",
+                "exit ignored",
+                "review_file one.txt --output-file",
+                "version",
+                "exit",
+                "",
+            ]
+        ),
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "requires exactly one file path" in completed.stdout
+    assert "requires a question" in completed.stdout
+    assert completed.stdout.count("does not accept positional arguments") >= 3
+    assert "--output-file requires a filename" in completed.stdout
+    assert "Goodbye" in completed.stdout
+    assert not (tmp_path / "results").exists()
+    assert not list(tmp_path.glob("*.json"))
+
+
+@pytest.mark.parametrize("config_kind", ["missing", "directory"])
+def test_cli_reports_config_path_errors_without_traceback(
+    installed_execution_extension, tmp_path, config_kind
+):
+    if config_kind == "directory":
+        (tmp_path / "metis.yaml").mkdir()
+    completed = run_cli(installed_execution_extension, tmp_path)
+    assert completed.returncode == 1
+    assert "Error:" in completed.stdout
+    assert "Traceback" not in completed.stderr
+    assert not (tmp_path / "events.jsonl").exists()
+    assert not (tmp_path / "results").exists()
+
+
+@pytest.mark.parametrize(
+    "configuration", ["metis_engine: [", "metis_engine:\n  max_workers: 0\n"]
+)
+def test_cli_reports_invalid_yaml_before_engine_setup(
+    installed_execution_extension, tmp_path, configuration
+):
+    (tmp_path / "metis.yaml").write_text(configuration, encoding="utf-8")
+    completed = run_cli(installed_execution_extension, tmp_path)
+    assert completed.returncode == 1
+    assert "Error:" in completed.stdout
+    assert "Traceback" not in completed.stderr
+    assert not (tmp_path / "events.jsonl").exists()
+    assert not (tmp_path / "results").exists()

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -4,9 +4,9 @@
 from contextlib import nullcontext
 from pathlib import Path
 import json
-import subprocess
 import sys
 from types import SimpleNamespace
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -15,18 +15,6 @@ from metis.cli import command_registry
 from metis.engine.execution import ExecutionDiagnostic
 from metis.engine.execution import ExecutionResult
 from metis.engine.execution import ExecutionStatus
-from metis.version import __version__ as METIS_VERSION
-
-
-def test_cli_entry_imports_in_clean_interpreter():
-    completed = subprocess.run(
-        [sys.executable, "-c", "from metis.cli.entry import main"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    assert completed.returncode == 0, completed.stderr
 
 
 def test_execute_command_allows_interactive_triage_command_with_global_triage_flag(
@@ -145,6 +133,57 @@ def test_interactive_loop_parses_quoted_paths_and_recovers_from_bad_quotes(monke
     ]
 
 
+@pytest.mark.parametrize("verbose", [False, True])
+@pytest.mark.parametrize("failure", [False, True])
+def test_execute_graph_forwards_progress_and_finishes_reporter(
+    monkeypatch, verbose, failure
+):
+    progress = object()
+    reporter = Mock()
+    build_progress = Mock(return_value=nullcontext(progress))
+    build_reporter = Mock(return_value=reporter)
+    monkeypatch.setattr(entry, "build_standard_progress", build_progress)
+    monkeypatch.setattr(entry, "ExecutionGraphProgressReporter", build_reporter)
+    callbacks = {"diagnostic_callback": object()}
+    events = [
+        {"event": "stage_start", "stage": "review"},
+        {"event": "node_end", "stage": "review", "node": "result", "status": "ok"},
+    ]
+    result = object()
+
+    def execute_graph(**kwargs):
+        assert kwargs["callbacks"] is callbacks
+        assert kwargs["include_triaged"] is None
+        callback = callbacks.get("progress_callback")
+        assert callback is (reporter if verbose else None)
+        if callback is not None:
+            for event in events:
+                callback(event)
+        if failure:
+            raise RuntimeError("graph failed")
+        return result
+
+    engine = SimpleNamespace(execute_graph=execute_graph)
+    args = SimpleNamespace(verbose=verbose, include_triaged=False)
+    if failure:
+        with pytest.raises(RuntimeError, match="graph failed"):
+            entry._execute_graph_with_progress(engine, args, callbacks)
+    else:
+        assert entry._execute_graph_with_progress(engine, args, callbacks) is result
+
+    if verbose:
+        build_progress.assert_called_once_with(transient=True)
+        build_reporter.assert_called_once_with(progress)
+        assert reporter.mock_calls == [
+            *(call(event) for event in events),
+            call.finish(),
+        ]
+    else:
+        build_progress.assert_not_called()
+        build_reporter.assert_not_called()
+        assert not reporter.mock_calls
+
+
 def test_main_version_does_not_require_runtime_config(monkeypatch, capsys):
     def fail_load_runtime_config(*_args, **_kwargs):
         raise AssertionError("runtime config should not be loaded for --version")
@@ -168,176 +207,6 @@ def test_main_rejects_removed_command_mode_flags(monkeypatch, removed_args, caps
         entry.main()
 
     assert "unrecognized arguments" in capsys.readouterr().err
-
-
-@pytest.mark.parametrize(
-    "argv",
-    [
-        ["metis"],
-        ["metis", "-v"],
-        ["metis", "-v", "--config", "graph.yaml"],
-    ],
-)
-def test_main_executes_configured_graph_by_default(monkeypatch, argv):
-    calls = []
-    messages = []
-    progress_events = []
-    reporter_finishes = []
-
-    class _Reporter:
-        def __init__(self, _progress):
-            pass
-
-        def __call__(self, event):
-            progress_events.append(event)
-
-        def finish(self):
-            reporter_finishes.append(True)
-
-    def execute_graph(**kwargs):
-        assert callable(kwargs["callbacks"]["review_checkpoint_callback"])
-        assert callable(kwargs["callbacks"]["review_resume_callback"])
-        progress = kwargs["callbacks"].get("progress_callback")
-        if progress is not None:
-            progress({"event": "execution_stage_start", "stage": "review"})
-            progress(
-                {
-                    "event": "execution_node_start",
-                    "stage": "review",
-                    "node": "reachability",
-                }
-            )
-        kwargs["callbacks"]["diagnostic_callback"](
-            SimpleNamespace(severity="warning", message="fallback review")
-        )
-        calls.append("graph")
-        return ExecutionResult(
-            ExecutionStatus.INCONCLUSIVE,
-            {
-                "review": {
-                    "formats": ["sarif"],
-                    "findings": {"reviews": []},
-                    "sarif": {"version": "2.1.0", "runs": []},
-                },
-                "triage": {
-                    "formats": ["sarif"],
-                    "sarif": {"version": "2.1.0", "runs": []},
-                },
-            },
-            (ExecutionDiagnostic("review.fallback", "fallback review", "warning"),),
-        )
-
-    engine = SimpleNamespace(execute_graph=execute_graph)
-    monkeypatch.setattr(sys, "argv", argv)
-    monkeypatch.setattr(entry, "load_runtime_config", lambda **_kwargs: {})
-    monkeypatch.setattr(entry, "build_engine", lambda *_args: (engine, None))
-    monkeypatch.setattr(
-        entry,
-        "build_standard_progress",
-        lambda **_kwargs: nullcontext(object()),
-    )
-    monkeypatch.setattr(entry, "ExecutionGraphProgressReporter", _Reporter)
-    monkeypatch.setattr(
-        entry,
-        "determine_output_file",
-        lambda _cmd, args, _cmd_args: setattr(args, "output_file", ["graph.json"]),
-    )
-    monkeypatch.setattr(
-        entry,
-        "save_output",
-        lambda *_args, **_kwargs: calls.append("save"),
-    )
-    monkeypatch.setattr(
-        entry,
-        "print_console",
-        lambda message, *_args, **_kwargs: messages.append(message),
-    )
-    monkeypatch.setattr(
-        entry, "finalize_cli_session_and_close", lambda *_args: calls.append("close")
-    )
-
-    entry.main()
-
-    assert calls == ["graph", "save", "save", "close"]
-    assert "[yellow]fallback review[/yellow]" in messages
-    if "-v" in argv:
-        assert [event["event"] for event in progress_events] == [
-            "execution_stage_start",
-            "execution_node_start",
-        ]
-        assert reporter_finishes == [True]
-    else:
-        assert progress_events == []
-        assert reporter_finishes == []
-
-
-def test_main_interactive_flag_starts_prompt(monkeypatch):
-    calls = []
-    engine = SimpleNamespace()
-    monkeypatch.setattr(sys, "argv", ["metis", "--interactive"])
-    monkeypatch.setattr(entry, "load_runtime_config", lambda **_kwargs: {})
-    monkeypatch.setattr(entry, "build_engine", lambda *_args: (engine, None))
-    monkeypatch.setattr(
-        entry,
-        "run_interactive_loop",
-        lambda *_args: calls.append("interactive") or None,
-    )
-    monkeypatch.setattr(
-        entry,
-        "finalize_cli_session_and_close",
-        lambda *_args: calls.append("close"),
-    )
-
-    entry.main()
-
-    assert calls == ["interactive", "close"]
-
-
-def test_graph_checkpoints_use_codebase_metis_directory(monkeypatch, tmp_path):
-    generated_path = tmp_path / "generated.json"
-
-    def execute_graph(**kwargs):
-        kwargs["callbacks"]["review_checkpoint_callback"](
-            {
-                "metis_version": METIS_VERSION,
-                "producer": "simple_llm_review",
-                "key": "file:key",
-                "record": {"reviews": []},
-            },
-            1,
-            1,
-        )
-        return ExecutionResult(ExecutionStatus.OK, {}, ())
-
-    def determine_output(_cmd, args, _cmd_args):
-        args.output_file = [str(generated_path)]
-        args._metis_generated_output = True
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["metis", "--codebase-path", str(tmp_path)],
-    )
-    monkeypatch.setattr(
-        entry,
-        "load_runtime_config",
-        lambda **_kwargs: {},
-    )
-    monkeypatch.setattr(
-        entry,
-        "build_engine",
-        lambda *_args: (SimpleNamespace(execute_graph=execute_graph), None),
-    )
-    monkeypatch.setattr(entry, "determine_output_file", determine_output)
-    monkeypatch.setattr(entry, "print_console", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(entry, "finalize_cli_session_and_close", lambda *_args: None)
-
-    entry.main()
-
-    assert (
-        tmp_path / ".metis" / "checkpoints" / "review.simple_llm_review.sqlite3"
-    ).exists()
-    assert not (tmp_path / "generated.simple_llm_review.sqlite3").exists()
 
 
 def test_main_rejects_a_missing_codebase_before_creating_outputs(
@@ -522,38 +391,6 @@ def test_default_graph_failure_exits_cleanly(monkeypatch):
     assert calls[-1] == "closed"
 
 
-def test_main_passes_custom_config_path_to_runtime_loader(monkeypatch, tmp_path):
-    config_path = tmp_path / "custom.yaml"
-    captured = {}
-
-    def load_runtime_config(*, config_path, enable_psql):
-        captured["config_path"] = config_path
-        captured["enable_psql"] = enable_psql
-        return {}
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "metis",
-            "--config",
-            str(config_path),
-        ],
-    )
-    monkeypatch.setattr(entry, "load_runtime_config", load_runtime_config)
-    engine = SimpleNamespace(
-        execute_graph=lambda **_kwargs: ExecutionResult(ExecutionStatus.OK, {})
-    )
-    monkeypatch.setattr(entry, "build_engine", lambda *_args: (engine, None))
-    monkeypatch.setattr(entry, "determine_output_file", lambda *_args: None)
-    monkeypatch.setattr(entry, "_save_graph_outputs", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(entry, "finalize_cli_session_and_close", lambda *_args: None)
-
-    entry.main()
-
-    assert captured == {"config_path": str(config_path), "enable_psql": False}
-
-
 def test_build_engine_defers_embedding_model_construction(
     monkeypatch,
     tmp_path,
@@ -627,87 +464,168 @@ def test_build_engine_defers_embedding_model_construction(
     assert captured["engine_kwargs"]["usage_runtime"].codebase_path == str(tmp_path)
 
 
-def test_build_engine_allows_graphs_without_index_stage_to_omit_embeddings(
-    monkeypatch, tmp_path
-):
-    class ChatProvider:
-        def __init__(self, _runtime):
-            pass
-
-    class DummyEngine:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-    args = SimpleNamespace(
-        backend="chroma",
-        chroma_dir=str(tmp_path / "chromadb"),
-        codebase_path=str(tmp_path),
-        custom_prompt=None,
-    )
-    runtime = {
-        "llm_provider_name": "test-provider",
-        "llm_provider": {
-            "api_key": "test-api-key",
-            "model": "test-model",
+def test_partial_graph_exports_sarif_without_findings_and_skips_failed_triage(tmp_path):
+    sarif = {"version": "2.1.0", "runs": []}
+    result = ExecutionResult(
+        ExecutionStatus.ERROR,
+        {
+            "review": {"formats": ("json", "sarif"), "sarif": sarif},
+            "triage": {"formats": ("sarif",)},
         },
-        "embedding_provider_raw_config": None,
-        "max_workers": 2,
-        "max_token_length": 2048,
-        "llama_query_model": "test-model",
-        "similarity_top_k": 3,
-        "response_mode": "compact",
-    }
-
-    monkeypatch.setattr(entry, "get_chat_provider", lambda _name: ChatProvider)
-    monkeypatch.setattr(
-        entry,
-        "build_chroma_backend",
-        lambda *_args: SimpleNamespace(embed_model_code=None, embed_model_docs=None),
     )
-    monkeypatch.setattr(entry, "MetisEngine", DummyEngine)
+    requested_json = tmp_path / "report.json"
+    requested_json.write_text("previous report", encoding="utf-8")
+    requested_sarif = tmp_path / "report.sarif"
 
-    engine, _backend = entry.build_engine(args, runtime)
+    entry._save_graph_outputs([str(requested_json), str(requested_sarif)], result, True)
 
-    assert engine.kwargs["embedding_provider"] is None
+    assert json.loads(requested_sarif.read_text()) == sarif
+    assert requested_json.read_text() == "previous report"
+    assert set(tmp_path.iterdir()) == {requested_json, requested_sarif}
 
 
-def test_main_writes_workflow_runlog_bundle(monkeypatch, tmp_path):
-    trace_path = tmp_path / "workflow.ndjson"
+@pytest.mark.parametrize(
+    "command,arguments",
+    [
+        ("review_file", []),
+        ("review_file", ["one.py", "two.py"]),
+        ("review_dir", ["one", "two"]),
+        ("update", ["one.patch", "two.patch"]),
+        ("index", ["ignored"]),
+        ("help", ["ignored"]),
+        ("version", ["ignored"]),
+        ("exit", ["ignored"]),
+        ("ask", []),
+        ("ask", [" "]),
+    ],
+)
+def test_invalid_interactive_arguments_do_not_invoke_or_create_outputs(
+    monkeypatch, tmp_path, command, arguments
+):
+    monkeypatch.chdir(tmp_path)
+    invoke = Mock()
+    engine = Mock()
+    monkeypatch.setattr(command_registry.CommandSpec, "invoke", invoke)
+    result = entry.execute_command(
+        engine, command, arguments, SimpleNamespace(quiet=True, output_file=None)
+    )
+    assert result is not entry.EXIT_REQUESTED
+    invoke.assert_not_called()
+    engine.usage_command.assert_not_called()
+    assert not (tmp_path / "results").exists()
 
-    class Engine:
-        def execute_graph(self, **_kwargs):
-            return ExecutionResult(ExecutionStatus.OK, {}, ())
 
-    def build_engine(args, _runtime):
-        assert args._metis_runlog.ndjson_path == trace_path.resolve()
-        return Engine(), None
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["one.py", "--output-file"],
+        ["one.py", "--output-file", ""],
+        ["one.py", "--output-file", "--output-file", "report.json"],
+    ],
+)
+def test_interactive_output_option_requires_a_value(monkeypatch, tmp_path, arguments):
+    monkeypatch.chdir(tmp_path)
+    invoke = Mock()
+    monkeypatch.setattr(command_registry.CommandSpec, "invoke", invoke)
+    with pytest.raises(ValueError, match="--output-file requires a filename"):
+        entry.execute_command(
+            Mock(),
+            "review_file",
+            arguments,
+            SimpleNamespace(quiet=True, output_file=None),
+        )
+    invoke.assert_not_called()
+    assert not (tmp_path / "results").exists()
 
-    monkeypatch.setattr(
-        sys,
-        "argv",
+
+@pytest.mark.parametrize(
+    "embedding_config",
+    [
+        {"name": "openai", "api_key": "inert"},
+        {"name": "no-such-embedding-provider"},
+    ],
+)
+def test_build_engine_validates_embedding_before_provider_construction(
+    monkeypatch, embedding_config
+):
+    def unexpected_provider(_config):
+        pytest.fail("invalid embedding settings constructed a chat provider")
+
+    monkeypatch.setattr(entry, "get_chat_provider", lambda _name: unexpected_provider)
+    with pytest.raises(ValueError):
+        entry.build_engine(
+            None,
+            {
+                "llm_provider_name": "inert",
+                "llm_provider": {},
+                "embedding_provider_raw_config": embedding_config,
+            },
+        )
+
+
+@pytest.mark.parametrize("schema_exists", [False, True])
+def test_postgres_prompt_checks_index_only_for_index_commands(
+    monkeypatch, schema_exists
+):
+    backend = Mock()
+    backend.check_project_schema_exists.return_value = schema_exists
+    inputs = iter(
         [
-            "metis",
-            "--log-workflow-debug-path",
-            str(trace_path),
-        ],
+            "review_code",
+            "review_file f",
+            "review_dir d",
+            "review_patch p",
+            "ask question",
+            "exit",
+        ]
     )
-    monkeypatch.setattr(entry, "load_runtime_config", lambda **_kwargs: {})
-    monkeypatch.setattr(entry, "build_engine", build_engine)
-    monkeypatch.setattr(entry, "determine_output_file", lambda *_args: None)
-    monkeypatch.setattr(entry, "print_console", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(entry, "finalize_cli_session_and_close", lambda *_args: None)
+    calls = []
+    monkeypatch.setattr(entry, "PG_SUPPORTED", True)
+    monkeypatch.setattr(entry, "PGVectorStoreImpl", type(backend), raising=False)
+    monkeypatch.setattr(entry, "prompt", lambda *a, **kw: next(inputs))
 
-    entry.main()
+    def execute(engine, command, command_args, args):
+        calls.append(command)
+        return entry.EXIT_REQUESTED if command == "exit" else None
 
-    records = [
-        json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()
+    monkeypatch.setattr(entry, "execute_command", execute)
+    entry.run_interactive_loop(None, SimpleNamespace(quiet=True), backend)
+    assert calls == [
+        "review_code",
+        "review_file",
+        "review_dir",
+        "review_patch",
+        *(["ask"] if schema_exists else []),
+        "exit",
     ]
-    assert records[0]["kind"] == "run"
-    command = next(
-        record
-        for record in records
-        if record["record"] == "span.start" and record.get("kind") == "command"
-    )
-    assert command["name"] == "execution_graph"
-    assert records[-1]["kind"] == "run"
-    assert records[-1]["status"] == "ok"
+    backend.check_project_schema_exists.assert_called_once_with()
+
+
+def test_main_reports_codebase_io_errors_without_setup(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["metis", "--codebase-path", "inaccessible"])
+
+    def inaccessible(path):
+        raise PermissionError("codebase access denied")
+
+    monkeypatch.setattr(entry, "check_dir_exists", inaccessible)
+    with pytest.raises(SystemExit, match="1"):
+        entry.main()
+    assert "codebase access denied" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "failure", [BrokenPipeError("closed pipe"), KeyboardInterrupt()]
+)
+def test_farewell_failure_cannot_skip_engine_close(monkeypatch, failure):
+    engine = SimpleNamespace(close=Mock())
+
+    def fail_print(*args, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(entry, "print_console", fail_print)
+    with pytest.raises(type(failure)) as caught:
+        entry.finalize_cli_session_and_close(
+            engine, SimpleNamespace(quiet=False), "Goodbye"
+        )
+    assert caught.value is failure
+    engine.close.assert_called_once_with()

--- a/tests/test_cli_exporters.py
+++ b/tests/test_cli_exporters.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from copy import deepcopy
+import csv
+import json
+
+import pytest
+
+from metis.cli.exporters import export_csv
+from metis.cli.exporters import export_html
+from metis.sarif.triage import apply_triage_annotations
+from metis.sarif.triage import apply_triage_result
+from metis.sarif.writer import generate_sarif
+
+
+def test_sarif_roundtrip_exports_preserve_review_fields_and_triage_status(tmp_path):
+    statuses = ("valid", "invalid", "inconclusive", None)
+    review = {
+        "reviews": [
+            {
+                "file": "audit.txt",
+                "reviews": [
+                    {
+                        "id": f"marker-{index}",
+                        "issue": f"Format marker {index}",
+                        "line_number": index + 1,
+                        "code_snippet": "audit marker",
+                        "severity": "Medium",
+                        "cwe": "CWE-Unknown",
+                        "reasoning": "Format check",
+                        "mitigation": "Keep the marker",
+                        "confidence": 0.5,
+                    }
+                    for index in range(len(statuses))
+                ],
+            }
+        ]
+    }
+    sarif = generate_sarif(review)
+    for index, status in enumerate(statuses):
+        if status is not None:
+            assert apply_triage_result(
+                sarif,
+                run_index=0,
+                result_index=index,
+                status=status,
+                reason=f"Recorded {status}",
+            )
+    apply_triage_annotations(review, sarif)
+    original_sarif = deepcopy(sarif)
+
+    review_html = export_html(review, tmp_path / "review.html", "__DATA_JSON__", "test")
+    sarif_html = export_html(sarif, tmp_path / "sarif.html", "__DATA_JSON__", "test")
+    review_data = json.loads(review_html.read_text())
+    sarif_data = json.loads(sarif_html.read_text())
+    assert sarif_data == review_data
+    assert [item["triageStatus"] for item in sarif_data["issues"]] == [
+        "valid",
+        "invalid",
+        "inconclusive",
+        "",
+    ]
+    assert [item["triageReason"] for item in sarif_data["issues"]] == [
+        "Recorded valid",
+        "Recorded invalid",
+        "Recorded inconclusive",
+        "",
+    ]
+    assert all(item["triageTimestamp"] for item in sarif_data["issues"][:3])
+    assert sarif_data["severityCounts"] == {"Medium": 4}
+
+    review_csv = export_csv(review, tmp_path / "review.csv")
+    sarif_csv = export_csv(sarif, tmp_path / "sarif.csv")
+    assert sarif_csv.read_text() == review_csv.read_text()
+    with sarif_csv.open(newline="") as stream:
+        rows = list(csv.DictReader(stream))
+    assert [row["Issue"] for row in rows] == [f"Format marker {i}" for i in range(4)]
+    assert sarif == original_sarif
+
+
+def test_external_sarif_exports_without_metis_properties(tmp_path):
+    sarif = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "results": [
+                    {
+                        "message": {"text": "External format marker"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "external.txt"},
+                                    "region": {
+                                        "startLine": 7,
+                                        "snippet": {"text": "external marker"},
+                                    },
+                                }
+                            }
+                        ],
+                    }
+                ]
+            }
+        ],
+    }
+    html_path = export_html(sarif, tmp_path / "external.html", "__DATA_JSON__", "test")
+    issues = json.loads(html_path.read_text())["issues"]
+    assert len(issues) == 1
+    assert issues[0]["issue"] == "External format marker"
+    assert issues[0]["file"] == "external.txt"
+    assert issues[0]["line"] == "7"
+    assert issues[0]["snippet"] == "external marker"
+    assert issues[0]["triageStatus"] == ""
+    csv_path = export_csv(sarif, tmp_path / "external.csv")
+    with csv_path.open(newline="") as stream:
+        rows = list(csv.DictReader(stream))
+    assert len(rows) == 1
+    assert rows[0]["Issue"] == "External format marker"
+    assert rows[0]["File"] == "external.txt"
+    assert rows[0]["Line"] == "7"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {},
+        {"reviews": []},
+        {"version": "2.1.0", "runs": []},
+        {"version": "2.1.0", "runs": [{"results": []}]},
+    ),
+)
+def test_empty_payload_exports_remain_empty(tmp_path, payload):
+    html_path = export_html(payload, tmp_path / "empty.html", "__DATA_JSON__", "test")
+    assert json.loads(html_path.read_text())["issues"] == []
+    csv_path = export_csv(payload, tmp_path / "empty.csv")
+    with csv_path.open(newline="") as stream:
+        assert list(csv.DictReader(stream)) == []
+
+
+def test_html_template_keeps_placeholder_text_in_report_and_metadata(tmp_path):
+    text = "__TITLE__ __GENERATED_AT__ __DATA_JSON__ __METIS_VERSION__"
+    report = {"reviews": [{"reviews": [{"issue": text}]}]}
+    template = "__TITLE__\n__GENERATED_AT__\n__METIS_VERSION__\n__DATA_JSON__"
+    html_path = export_html(
+        report,
+        tmp_path / "__DATA_JSON__ & <note>.html",
+        template,
+        "release-__TITLE__",
+    )
+    title, generated_at, version, data = html_path.read_text().split("\n", 3)
+    assert title == "Metis Security Report - __DATA_JSON__ &amp; &lt;note&gt;"
+    assert generated_at.endswith(" UTC")
+    assert version == "release-__TITLE__"
+    assert json.loads(data)["issues"][0]["issue"] == text
+    csv_path = export_csv(report, tmp_path / "report.csv")
+    with csv_path.open(newline="") as stream:
+        assert next(csv.DictReader(stream))["Issue"] == text
+
+
+@pytest.mark.parametrize(
+    ("severity", "expected"),
+    [
+        ("high", "High"),
+        ("HIGH", "High"),
+        (" critical ", "Critical"),
+        ("medium", "Medium"),
+        ("LOW", "Low"),
+        ("unknown", "Unknown"),
+        ("CustomCase", "CustomCase"),
+    ],
+)
+def test_exports_normalize_known_severity_names(tmp_path, severity, expected):
+    report = {
+        "reviews": [
+            {
+                "file": "audit.txt",
+                "reviews": [{"issue": "Format marker", "severity": severity}],
+            }
+        ]
+    }
+    html_path = export_html(report, tmp_path / "report.html", "__DATA_JSON__", "test")
+    data = json.loads(html_path.read_text())
+    assert data["issues"][0]["severity"] == expected
+    assert data["severityCounts"] == {expected: 1}
+    assert data["fileStats"]["audit.txt"]["maxSeverity"] == (
+        "Unknown" if expected == "CustomCase" else expected
+    )
+    csv_path = export_csv(report, tmp_path / "report.csv")
+    with csv_path.open(newline="") as stream:
+        assert next(csv.DictReader(stream))["Severity"] == expected

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI logging configuration must fail before work and preserve usable handlers."""
+
+import logging
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+import warnings
+
+import pytest
+
+from metis.cli import entry
+from metis.cli.utils import configure_logger
+from metis.runlog import current_runlog
+
+
+@pytest.fixture
+def cli_logger(monkeypatch):
+    logger = logging.Logger("cli-logging-test")
+    monkeypatch.setattr(entry, "logger", logger)
+    monkeypatch.setattr(logging, "captureWarnings", lambda _capture: None)
+    for name in (
+        "",
+        "py.warnings",
+        "httpx",
+        "httpcore",
+        "openai",
+        "openai._base_client",
+        "azure",
+        "urllib3",
+    ):
+        affected = logging.getLogger(name)
+        monkeypatch.setattr(affected, "level", affected.level)
+        monkeypatch.setattr(affected, "propagate", affected.propagate)
+    with warnings.catch_warnings():
+        try:
+            yield logger
+        finally:
+            for handler in logger.handlers[:]:
+                logger.removeHandler(handler)
+                handler.close()
+
+
+@pytest.mark.parametrize(
+    "arguments, message",
+    [
+        (["--log-level", "DEBIG"], "invalid choice"),
+        (["--log-level", "20"], "invalid choice"),
+        (["--log-level", ""], "invalid choice"),
+        (["--log-level", " debug "], "invalid choice"),
+        (
+            ["--tools", "none"],
+            "configure execution nodes and capability grants in YAML",
+        ),
+        (["--interactive", "--tools", "navigation,index"], "--tools has been removed"),
+    ],
+)
+def test_invalid_cli_configuration_fails_before_resources(
+    arguments, message, monkeypatch, capsys
+):
+    monkeypatch.setattr("sys.argv", ["metis", *arguments])
+    monkeypatch.setattr(
+        entry, "configure_logger", lambda *_args: pytest.fail("logging was configured")
+    )
+    monkeypatch.setattr(
+        entry,
+        "load_runtime_config",
+        lambda **_kwargs: pytest.fail("runtime was loaded"),
+    )
+    with pytest.raises(SystemExit) as exc:
+        entry.main()
+    assert exc.value.code == 2
+    assert message in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "level, expected",
+    [("debug", logging.DEBUG), ("warn", logging.WARNING), ("NOTSET", logging.NOTSET)],
+)
+def test_cli_normalizes_valid_logging_levels(level, expected, monkeypatch, cli_logger):
+    monkeypatch.setattr("sys.argv", ["metis", "--log-level", level])
+
+    def stop_after_logging(**_kwargs):
+        assert cli_logger.level == expected
+        raise OSError("inert stop before engine construction")
+
+    monkeypatch.setattr(entry, "load_runtime_config", stop_after_logging)
+    with pytest.raises(SystemExit) as exc:
+        entry.main()
+    assert exc.value.code == 1
+
+
+def test_logger_replacement_is_transactional_and_closes_old_files(cli_logger, tmp_path):
+    old_path = tmp_path / "old.log"
+    configure_logger(cli_logger, SimpleNamespace(log_level="ERROR", log_file=old_path))
+    old_handlers = cli_logger.handlers[:]
+    old_stream = old_handlers[-1].stream
+
+    with pytest.raises(IsADirectoryError):
+        configure_logger(
+            cli_logger, SimpleNamespace(log_level="DEBUG", log_file=tmp_path)
+        )
+    assert cli_logger.handlers == old_handlers
+    assert cli_logger.level == logging.ERROR
+    cli_logger.error("kept old destination")
+    assert "kept old destination" in old_path.read_text()
+
+    new_path = tmp_path / "new.log"
+    configure_logger(cli_logger, SimpleNamespace(log_level="info", log_file=new_path))
+    assert old_stream.closed
+    assert old_handlers[-1].stream is None
+    cli_logger.info("one new record")
+    assert new_path.read_text().count("one new record") == 1
+    assert "one new record" not in old_path.read_text()
+
+
+def test_invalid_direct_logger_level_preserves_configuration(cli_logger, tmp_path):
+    configure_logger(cli_logger, SimpleNamespace(log_level="ERROR", log_file=None))
+    handlers = cli_logger.handlers[:]
+    new_path = tmp_path / "must-not-exist.log"
+    with pytest.raises(ValueError, match="level"):
+        configure_logger(
+            cli_logger, SimpleNamespace(log_level="DEBIG", log_file=new_path)
+        )
+    assert cli_logger.handlers == handlers
+    assert not new_path.exists()
+
+
+@pytest.mark.parametrize("destination", ["log-file-directory", "existing-trace"])
+def test_logging_destination_error_is_reported_before_runtime(
+    destination, cli_logger, tmp_path, monkeypatch, capsys
+):
+    trace = tmp_path / "prior.ndjson"
+    trace.write_text("previous run")
+    arguments = (
+        ["--log-file", str(tmp_path)]
+        if destination == "log-file-directory"
+        else ["--log-workflow-debug-path", str(trace)]
+    )
+    monkeypatch.setattr("sys.argv", ["metis", *arguments])
+    monkeypatch.setattr(
+        entry,
+        "load_runtime_config",
+        lambda **_kwargs: pytest.fail("runtime was loaded"),
+    )
+    with pytest.raises(SystemExit) as exc:
+        entry.main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert "Error:" in output.out
+    assert "Traceback" not in output.out + output.err
+    assert trace.read_text() == "previous run"
+    assert current_runlog() is None
+
+
+@pytest.mark.parametrize(
+    "option, value, exit_code",
+    [
+        ("--log-level", "DEBIG", 2),
+        ("--tools", "none", 2),
+        ("--log-file", ".", 1),
+        ("--log-workflow-debug-path", "prior.ndjson", 1),
+    ],
+)
+def test_cli_process_rejects_invalid_logging_or_legacy_flags(
+    option, value, exit_code, tmp_path
+):
+    trace = tmp_path / "prior.ndjson"
+    trace.write_text("previous run")
+    completed = subprocess.run(
+        [sys.executable, "-m", "metis", option, value],
+        cwd=tmp_path,
+        env={"PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src")},
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert completed.returncode == exit_code
+    output = completed.stdout + completed.stderr
+    assert "error:" in output.lower()
+    assert "Traceback" not in output
+    assert trace.read_text() == "previous run"
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["prior.ndjson"]

--- a/tests/test_cli_output_paths.py
+++ b/tests/test_cli_output_paths.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from metis.cli.utils import output_files_for_formats
+from metis.cli.utils import save_output
+
+
+def test_companion_outputs_preserve_dotted_basename(tmp_path: Path):
+    unrelated = tmp_path / "report.sarif"
+    unrelated.write_text("previous report", encoding="utf-8")
+    formats = ("json", "sarif", "html", "csv")
+
+    paths = output_files_for_formats(
+        [str(tmp_path / "report.v1.json")], formats, command="review"
+    )
+    save_output(paths, {"reviews": []}, quiet=True)
+
+    assert paths == [
+        str(tmp_path / f"report.v1.{format_name}") for format_name in formats
+    ]
+    assert all(Path(path).is_file() for path in paths)
+    assert unrelated.read_text(encoding="utf-8") == "previous report"
+
+
+def test_html_output_preserves_explicit_suffix_case(tmp_path: Path):
+    output = tmp_path / "report.HtMl"
+
+    save_output(output, {"reviews": []}, quiet=True)
+
+    assert {path.name for path in tmp_path.iterdir()} == {output.name}
+    assert "<!DOCTYPE html>" in output.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("names", [("Report", "report"), ("café", "cafe\u0301")])
+def test_filesystem_aliases_cannot_overwrite_another_stage(tmp_path, names):
+    from metis.cli.entry import _save_graph_outputs
+    from metis.engine.execution import ExecutionResult, ExecutionStatus
+
+    (tmp_path / names[0]).touch()
+    if not (tmp_path / names[1]).exists():
+        pytest.skip("filesystem preserves these distinct spellings")
+    outputs = {
+        name: {
+            "formats": ["sarif"],
+            "sarif": {"version": "2.1.0", "runs": []},
+            "filename": str(tmp_path / filename),
+        }
+        for name, filename in [("review", names[0]), ("triage", names[1])]
+    }
+    with pytest.raises(ValueError, match="distinct"):
+        _save_graph_outputs(None, ExecutionResult(ExecutionStatus.OK, outputs), True)
+    assert not list(tmp_path.glob("*.sarif"))
+
+
+@pytest.mark.parametrize("names", [("Report", "report"), ("café", "cafe\u0301")])
+def test_explicit_output_aliases_follow_filesystem_rules(tmp_path, names):
+    (tmp_path / names[0]).touch()
+    paths = [str(tmp_path / f"{name}.json") for name in names]
+    if (tmp_path / names[1]).exists():
+        with pytest.raises(ValueError, match="unique"):
+            output_files_for_formats(paths, ("json",), command="review")
+    else:
+        assert output_files_for_formats(paths, ("json",), command="review") == paths

--- a/tests/test_cli_unicode.py
+++ b/tests/test_cli_unicode.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import pytest
+
+from metis import runlog
+from test_cli_e2e import run_cli
+from test_execution_e2e import extension_graph
+from test_execution_e2e import (
+    installed_execution_extension as installed_execution_extension,
+)
+from test_execution_e2e import write_execution_config
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX filesystem surrogate decoding")
+def test_cli_records_surrogate_arguments_in_complete_trace(
+    installed_execution_extension, tmp_path
+):
+    write_execution_config(tmp_path / "metis.yaml", extension_graph())
+    project = os.fsdecode(b"project-\xff")
+    trace = tmp_path / "trace.ndjson"
+    output = tmp_path / "report.json"
+    completed = run_cli(
+        installed_execution_extension,
+        tmp_path,
+        "--quiet",
+        "--project-schema",
+        project,
+        "--log-workflow-debug",
+        "--log-workflow-debug-path",
+        trace.name,
+        "--output-file",
+        output.name,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert json.loads(output.read_text())["reviews"]
+    assert runlog.validate_runlog(trace).status == "ok"
+    metadata = json.loads(trace.with_suffix(".ndjson.meta.json").read_text())
+    assert project in metadata["metadata"]["argv"]
+    records = [json.loads(line) for line in trace.read_text().splitlines()]
+    assert any(
+        record["name"] == "artifact.written"
+        and record["attributes"]["path"] == str(output)
+        for record in records
+    )

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,480 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from concurrent.futures import CancelledError
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
+from contextvars import copy_context
+from threading import Barrier
+from threading import Event
+from threading import Lock
+from threading import Thread
+from threading import get_ident
+
+import pytest
+
+from metis.engine.concurrency import JobScheduler
+from metis.engine.concurrency import serialized_progress_callback
+from metis.execution_nodes import NodeRuntime
+
+
+WAIT = 2
+
+
+@pytest.fixture
+def scheduler():
+    scheduler = JobScheduler(2)
+    try:
+        yield scheduler
+    finally:
+        scheduler.close()
+
+
+@pytest.fixture
+def start_run(scheduler, monkeypatch):
+    registered = Event()
+    original = scheduler._register
+
+    def register(run):
+        try:
+            return original(run)
+        finally:
+            registered.set()
+
+    # Observe admission only, so tests release workers after competing runs are queued.
+    monkeypatch.setattr(scheduler, "_register", register)
+    with ThreadPoolExecutor(max_workers=3) as callers:
+
+        def start(jobs, values, worker, **kwargs):
+            registered.clear()
+            future = callers.submit(
+                jobs.run, values, worker, label=None, result_key=str, **kwargs
+            )
+            assert registered.wait(WAIT), "job caller never registered its run"
+            return future
+
+        yield start
+
+
+def test_jobs_preserve_context_and_none_values_off_the_caller(scheduler):
+    value = ContextVar("test_job_value", default="unset")
+    caller = get_ident()
+    token = value.set("caller")
+
+    def worker(job):
+        assert get_ident() != caller
+        assert value.get() == "caller"
+        value.set("worker")
+        return job
+
+    try:
+        assert scheduler.limit(1).run(
+            [None, 2], worker, label=None, result_key=str
+        ) == [None, 2]
+        assert value.get() == "caller"
+    finally:
+        value.reset(token)
+
+
+def test_results_and_callbacks_follow_completion_order(scheduler):
+    first_started = Event()
+    release_first = Event()
+    completed = []
+
+    def worker(value):
+        if value == 1:
+            first_started.set()
+            assert release_first.wait(WAIT)
+        else:
+            assert first_started.wait(WAIT)
+        return value
+
+    def collect(value, count, total):
+        completed.append((value, count, total))
+        if value == 2:
+            release_first.set()
+
+    try:
+        assert scheduler.limit(2).run(
+            [1, 2], worker, label=None, result_key=str, on_complete=collect
+        ) == [2, 1]
+    finally:
+        release_first.set()
+    assert completed == [(2, 1, 2), (1, 2, 2)]
+
+
+@pytest.mark.parametrize("operation", ["run", "close"])
+def test_finished_worker_context_does_not_remain_a_worker(scheduler, operation):
+    jobs = scheduler.limit(1)
+    copied = jobs.run([1], lambda _: copy_context(), label=None, result_key=str)[0]
+    if operation == "close":
+        copied.run(scheduler.close)
+    else:
+        assert copied.run(
+            jobs.run, [2], lambda value: value, label=None, result_key=str
+        ) == [2]
+
+
+@pytest.mark.parametrize("operation", ["run", "close"])
+def test_worker_cannot_reenter_or_close_its_own_scheduler(operation):
+    scheduler = JobScheduler(1)
+    jobs = scheduler.limit(1).with_cancellation(Event())
+
+    def worker(value):
+        with pytest.raises(RuntimeError):
+            if operation == "close":
+                scheduler.close()
+            else:
+                jobs.run([value], lambda job: job, label=None, result_key=str)
+        return value
+
+    with ThreadPoolExecutor(max_workers=1) as caller:
+        result = caller.submit(jobs.run, [1], worker, label=None, result_key=str)
+        try:
+            assert result.result(WAIT) == [1]
+            assert jobs.run([2], lambda value: value, label=None, result_key=str) == [2]
+        finally:
+            jobs.cancel()
+            scheduler.close()
+
+
+@pytest.mark.parametrize("view_limit", [None, 1, 2])
+def test_concurrent_limit_views_share_capacity_and_leave_other_nodes_room(
+    scheduler, start_run, view_limit
+):
+    jobs = scheduler.limit(1)
+    release = Event()
+    first_started = Event()
+    lock = Lock()
+    active = peak = 0
+
+    def worker(value):
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+        first_started.set()
+        try:
+            assert release.wait(WAIT)
+            return value
+        finally:
+            with lock:
+                active -= 1
+
+    first = start_run(jobs, [1], worker)
+    assert first_started.wait(WAIT)
+    view = jobs if view_limit is None else jobs.limit(view_limit)
+    second = start_run(view, [2], worker)
+    try:
+        # A quota violation occupies both workers and prevents this probe from finishing.
+        probe = start_run(scheduler.limit(1), [3], lambda value: value)
+        assert probe.result(WAIT) == [3]
+    finally:
+        release.set()
+    assert first.result(WAIT) == [1]
+    assert second.result(WAIT) == [2]
+    assert peak == 1
+
+
+def test_slow_collector_blocks_its_own_queue_but_not_another_run(scheduler, start_run):
+    jobs = scheduler.limit(1)
+    release_worker = Event()
+    collecting = Event()
+    release_collector = Event()
+    later_started = Event()
+
+    def worker(value):
+        if value == 1:
+            assert release_worker.wait(WAIT)
+        else:
+            later_started.set()
+        return value
+
+    def collect(value, _count, _total):
+        if value == 1:
+            collecting.set()
+            assert release_collector.wait(WAIT)
+
+    # Fill the second global slot so the other run is already queued when work completes.
+    occupied = Event()
+    release_occupied = Event()
+
+    def occupy(value):
+        occupied.set()
+        assert release_occupied.wait(WAIT)
+        return value
+
+    holder = start_run(scheduler.limit(1), [0], occupy)
+    assert occupied.wait(WAIT)
+    first = start_run(jobs, [1, 2], worker, on_complete=collect)
+    other = start_run(scheduler.limit(1), [3], lambda value: value)
+    try:
+        release_worker.set()
+        assert collecting.wait(WAIT)
+        assert other.result(WAIT) == [3]
+        assert not later_started.is_set()
+    finally:
+        release_collector.set()
+        release_occupied.set()
+        release_worker.set()
+    assert first.result(WAIT) == [1, 2]
+    assert holder.result(WAIT) == [0]
+
+
+@pytest.mark.parametrize("action", ["cancel", "parent", "close"])
+def test_cancellation_signals_active_jobs_and_discards_queued_work(
+    scheduler, monkeypatch, action
+):
+    parent = Event()
+    cancellation = Event()
+    jobs = scheduler.limit(2).with_cancellation(parent).with_cancellation(cancellation)
+    started = Barrier(3)
+    observed = []
+    release = Event()
+    draining = Event()
+    wait_for = scheduler._condition.wait_for
+
+    def observe_drain(predicate, timeout=None):
+        if cancellation.is_set() and timeout is None and not predicate():
+            draining.set()
+        return wait_for(predicate, timeout)
+
+    monkeypatch.setattr(scheduler._condition, "wait_for", observe_drain)
+
+    def worker(value):
+        started.wait(WAIT)
+        observed.append((value, cancellation.wait(WAIT)))
+        if action != "close":
+            assert release.wait(WAIT)
+        return value
+
+    with ThreadPoolExecutor(max_workers=1) as caller:
+        result = caller.submit(jobs.run, [0, 1, 2], worker, label=None, result_key=str)
+        try:
+            started.wait(WAIT)
+            if action == "close":
+                scheduler.close()
+            elif action == "parent":
+                parent.set()
+            else:
+                jobs.cancel()
+            if action != "close":
+                assert draining.wait(WAIT), "cancelled run must block while draining"
+                assert not result.done()
+                release.set()
+            with pytest.raises(CancelledError):
+                result.result(WAIT)
+        finally:
+            release.set()
+            cancellation.set()
+            jobs.cancel()
+    assert sorted(observed) == [(0, True), (1, True)]
+    assert parent.is_set() is (action == "parent")
+
+
+def test_job_error_signals_its_explicit_scope_without_cancelling_parent(scheduler):
+    parent = Event()
+    cancellation = Event()
+    jobs = scheduler.limit(2).with_cancellation(parent).with_cancellation(cancellation)
+    peer_started = Event()
+    observed = []
+
+    def worker(value):
+        if value == 0:
+            assert peer_started.wait(WAIT)
+            raise RuntimeError("worker failed")
+        peer_started.set()
+        observed.append(cancellation.wait(WAIT))
+        return value
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        jobs.run([0, 1], worker, label=None, result_key=str)
+    assert observed == [True]
+    assert not parent.is_set()
+    with pytest.raises(CancelledError):
+        jobs.run([], worker, label=None, result_key=str)
+    assert scheduler.limit(1).run(
+        [2], lambda value: value, label=None, result_key=str
+    ) == [2]
+
+
+@pytest.mark.parametrize("failure", ["worker", "callback", "submission"])
+def test_failed_plain_run_is_cleaned_up_and_handle_can_be_reused(
+    scheduler, monkeypatch, failure
+):
+    jobs = scheduler.limit(1)
+    observed = []
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("expected failure")
+
+    def worker(value):
+        observed.append(value)
+        if failure == "worker" and value == 1:
+            fail()
+        return value
+
+    with monkeypatch.context() as patch:
+        if failure == "submission":
+            patch.setattr(scheduler._executor, "submit", fail)
+        with pytest.raises(RuntimeError, match="expected failure"):
+            jobs.run(
+                [1, 2],
+                worker,
+                label=None,
+                result_key=str,
+                on_complete=fail if failure == "callback" else None,
+            )
+    assert jobs.run([3], worker, label=None, result_key=str) == [3]
+    scheduler.close()
+    assert observed == ([3] if failure == "submission" else [1, 3])
+
+
+def test_completion_callback_can_submit_and_cancel_its_final_result(scheduler):
+    jobs = scheduler.limit(1)
+    nested = []
+
+    def complete(value, _count, _total):
+        nested.extend(
+            jobs.run([value + 1], lambda job: job, label=None, result_key=str)
+        )
+        jobs.cancel()
+
+    with pytest.raises(CancelledError):
+        jobs.run(
+            [1], lambda value: value, label=None, result_key=str, on_complete=complete
+        )
+    assert nested == [2]
+
+
+def test_closed_scheduler_rejects_empty_and_nonempty_work(scheduler):
+    jobs = scheduler.limit(1)
+    scheduler.close()
+    scheduler.close()
+    for values in ([], [1]):
+        with pytest.raises(RuntimeError, match="shutdown"):
+            jobs.run(values, lambda value: value, label=None, result_key=str)
+
+
+def test_serialized_progress_callback_allows_same_thread_reentry():
+    observed = []
+
+    def callback(event):
+        observed.append(event)
+        if event == 0:
+            wrapped(1)
+
+    wrapped = serialized_progress_callback(callback)
+    assert serialized_progress_callback(wrapped) is wrapped
+    thread = Thread(target=wrapped, args=(0,), daemon=True)
+    thread.start()
+    thread.join(WAIT)
+    assert not thread.is_alive(), "same-thread progress reentry deadlocked"
+    assert observed == [0, 1]
+
+
+@pytest.mark.parametrize("maximum", [0, -1, True, 1.5, "2"])
+@pytest.mark.parametrize("entry", ["scheduler", "handle", "run"])
+def test_worker_limits_require_positive_integers(scheduler, maximum, entry):
+    with pytest.raises(ValueError):
+        if entry == "scheduler":
+            JobScheduler(maximum)
+        elif entry == "handle":
+            scheduler.limit(maximum)
+        else:
+            scheduler.run(
+                [],
+                lambda value: value,
+                max_concurrency=maximum,
+                cancellation=None,
+                label=None,
+                result_key=str,
+                on_complete=None,
+            )
+
+
+@pytest.mark.parametrize("cancel_parent", [False, True])
+def test_runtime_child_scopes_share_job_cancellation_without_cancelling_siblings(
+    scheduler, cancel_parent
+):
+    root = Event()
+    runtime = NodeRuntime(
+        model="unused",
+        max_workers=2,
+        max_token_length=1,
+        chat_model_kwargs={},
+        jobs=scheduler.limit(2).with_cancellation(root),
+        is_cancelled=root.is_set,
+    )
+    child = runtime._with_cancellation()
+    sibling = runtime._with_cancellation()
+    grandchild = child._with_cancellation()
+    if cancel_parent:
+        root.set()
+    else:
+        child.jobs.cancel()
+    assert child.is_cancelled()
+    assert grandchild.is_cancelled()
+    assert runtime.is_cancelled() is cancel_parent
+    assert sibling.is_cancelled() is cancel_parent
+    for cancelled in (child, grandchild):
+        with pytest.raises(CancelledError):
+            cancelled.jobs.run([1], lambda value: value, label=None, result_key=str)
+    if not cancel_parent:
+        assert sibling.jobs.run(
+            [2], lambda value: value, label=None, result_key=str
+        ) == [2]
+        assert runtime.jobs.run(
+            [3], lambda value: value, label=None, result_key=str
+        ) == [3]
+
+
+def test_runtime_cancellation_scope_requires_a_job_handle():
+    runtime = NodeRuntime(
+        model="unused", max_workers=1, max_token_length=1, chat_model_kwargs={}
+    )
+    with pytest.raises(RuntimeError, match="scheduler is unavailable"):
+        runtime._with_cancellation()
+
+
+def test_repeated_interruptions_drain_workers_before_preserving_original_error(
+    scheduler, monkeypatch
+):
+    started = Event()
+    release = Event()
+    draining = Event()
+    wait_for = scheduler._condition.wait_for
+    waits = 0
+
+    def interrupted_wait(predicate, timeout=None):
+        nonlocal waits
+        waits += 1
+        if waits == 1:
+            assert wait_for(started.is_set, WAIT)
+            raise KeyboardInterrupt("initial interruption")
+        if waits == 2:
+            raise KeyboardInterrupt("cleanup interruption")
+        draining.set()
+        return wait_for(predicate, timeout)
+
+    def worker(value):
+        started.set()
+        assert release.wait(WAIT * 2)
+        return value
+
+    monkeypatch.setattr(scheduler._condition, "wait_for", interrupted_wait)
+    with ThreadPoolExecutor(max_workers=1) as caller:
+        result = caller.submit(
+            scheduler.limit(1).run, [1], worker, label=None, result_key=str
+        )
+        try:
+            assert draining.wait(WAIT), "cleanup abandoned its active worker"
+            assert not result.done()
+            release.set()
+            with pytest.raises(KeyboardInterrupt, match="initial interruption"):
+                result.result(WAIT)
+        finally:
+            release.set()
+    assert scheduler.limit(1).run(
+        [2], lambda value: value, label=None, result_key=str
+    ) == [2]

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from copy import deepcopy
+from importlib.resources import as_file
+from importlib.resources import files
 
 import pytest
 import yaml
@@ -15,41 +16,10 @@ from metis.runtime_settings import CapabilityRuntimeSettings
 from metis.runtime_settings import ModelToolSettings
 from metis.runtime_settings import TriageOptions
 
-_TOOL_CONFIG = {
-    "model_tools": {"max_rounds": 6, "max_contract_chars": 6000},
-    "capabilities": {
-        "index": {
-            "search": {
-                "max_top_k": 4,
-                "code_top_k": 1,
-                "docs_top_k": 4,
-                "docs_char_ratio": 1.0,
-                "default_max_chars": 5000,
-                "max_chars": 7000,
-            }
-        },
-        "navigation": {"timeout_seconds": 8, "max_chars": 16000},
-    },
-}
 
-
-def _write_config(tmp_path, content: str, *, complete_tool_config: bool = True):
+def _write_config(tmp_path, content: str):
     config_path = tmp_path / "metis.yaml"
-    config = yaml.safe_load(content)
-    if complete_tool_config:
-        engine = config.setdefault("metis_engine", {})
-        model_tools = engine.setdefault("model_tools", {})
-        for key, value in _TOOL_CONFIG["model_tools"].items():
-            model_tools.setdefault(key, value)
-        capabilities = engine.setdefault("capabilities", {})
-        index = capabilities.setdefault("index", {})
-        search = index.setdefault("search", {})
-        for key, value in _TOOL_CONFIG["capabilities"]["index"]["search"].items():
-            search.setdefault(key, value)
-        navigation = capabilities.setdefault("navigation", {})
-        for key, value in _TOOL_CONFIG["capabilities"]["navigation"].items():
-            navigation.setdefault(key, value)
-    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    config_path.write_text(content, encoding="utf-8")
     return config_path
 
 
@@ -131,26 +101,6 @@ llm_provider:
     assert runtime["triage_options"] == TriageOptions(include_triaged=True)
 
 
-@pytest.mark.parametrize("max_workers", (0, -1, True, "2"))
-def test_runtime_rejects_invalid_max_workers(tmp_path, monkeypatch, max_workers):
-    config_path = _write_config(
-        tmp_path,
-        yaml.safe_dump(
-            {
-                "metis_engine": {"max_workers": max_workers},
-                "llm_provider": {"name": "openai", "model": "test-model"},
-            }
-        ),
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    with pytest.raises(
-        ValueError,
-        match="metis_engine.max_workers must be a positive integer",
-    ):
-        load_runtime_config(config_path)
-
-
 @pytest.mark.parametrize("enabled", (True, False))
 def test_runtime_loads_review_checkpoint_setting(tmp_path, monkeypatch, enabled):
     config_path = _write_config(
@@ -167,67 +117,6 @@ def test_runtime_loads_review_checkpoint_setting(tmp_path, monkeypatch, enabled)
     runtime = load_runtime_config(config_path)
 
     assert runtime["review_checkpoints_enabled"] is enabled
-
-
-@pytest.mark.parametrize(
-    "review_checkpoints",
-    ([], "false"),
-)
-def test_runtime_rejects_invalid_review_checkpoint_setting(
-    tmp_path,
-    monkeypatch,
-    review_checkpoints,
-):
-    config_path = _write_config(
-        tmp_path,
-        yaml.safe_dump(
-            {
-                "metis_engine": {"review_checkpoints": review_checkpoints},
-                "llm_provider": {"name": "openai", "model": "test-model"},
-            }
-        ),
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    with pytest.raises(ValueError, match="metis_engine.review_checkpoints"):
-        load_runtime_config(config_path)
-
-
-def test_runtime_passes_language_replacements_from_selected_yaml(tmp_path, monkeypatch):
-    config_path = _write_config(
-        tmp_path,
-        """
-language_plugins:
-  verilog:
-    implementation: vendor:VerilogPlugin
-llm_provider:
-  name: openai
-  model: test-model
-""",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["plugin_config"]["language_plugins"] == {
-        "verilog": {"implementation": "vendor:VerilogPlugin"}
-    }
-
-
-def test_runtime_rejects_non_mapping_language_replacements(tmp_path, monkeypatch):
-    config_path = _write_config(
-        tmp_path,
-        """
-language_plugins: []
-llm_provider:
-  name: openai
-  model: test-model
-""",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    with pytest.raises(ValueError, match="language_plugins must be a mapping"):
-        load_runtime_config(config_path)
 
 
 def test_load_runtime_config_accepts_chat_provider_without_embeddings(
@@ -264,9 +153,9 @@ query:
     }
     assert runtime["llm_max_retries"] == 5
     assert runtime["chat_model_kwargs"] == {"reasoning_effort": "high"}
-    assert runtime["capability_settings"] == CapabilityRuntimeSettings(
-        model_tools=ModelToolSettings(max_rounds=9, max_contract_chars=4200),
-        configurations=deepcopy(_TOOL_CONFIG["capabilities"]),
+    assert runtime["capability_settings"].model_tools == ModelToolSettings(
+        max_rounds=9,
+        max_contract_chars=4200,
     )
     assert runtime["memory"] == {
         "backend": "sqlite",
@@ -368,38 +257,6 @@ llm_provider:
     assert runtime["execution_config"] == {"stages": {}}
 
 
-@pytest.mark.parametrize(
-    ("path", "value", "message"),
-    [
-        (("model_tools", "max_contract_chars"), 0, "max_contract_chars"),
-        (("model_tools",), "disabled", "model_tools must be a mapping"),
-        (("model_tools",), False, "model_tools must be a mapping"),
-    ],
-)
-def test_load_runtime_config_rejects_invalid_tool_limits(
-    tmp_path, monkeypatch, path, value, message
-):
-    engine_config = deepcopy(_TOOL_CONFIG)
-    target = engine_config
-    for key in path[:-1]:
-        target = target[key]
-    target[path[-1]] = value
-    config_path = _write_config(
-        tmp_path,
-        yaml.safe_dump(
-            {
-                "metis_engine": engine_config,
-                "llm_provider": {"name": "openai", "model": "gpt-test"},
-            }
-        ),
-        complete_tool_config=False,
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    with pytest.raises(ValueError, match=message):
-        load_runtime_config(config_path)
-
-
 def test_load_runtime_config_accepts_threat_model_sources(tmp_path, monkeypatch):
     config_path = _write_config(
         tmp_path,
@@ -438,33 +295,24 @@ def test_pgvector_halfvec_rejects_invalid_flags(value):
         pgvector_use_halfvec_setting(value, 3072)
 
 
-def test_load_runtime_config_accepts_pgvector_halfvec_flag(tmp_path, monkeypatch):
-    config_path = _write_config(
-        tmp_path,
-        """
-metis_engine:
-  pgvector_use_halfvec: true
-llm_provider:
-  name: openai
-  model: gpt-test
-  base_url: https://example.test/openai/v1
-""",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["pgvector_use_halfvec"] is True
-
-
-def test_load_runtime_config_auto_enables_pgvector_halfvec_for_large_embeddings(
-    tmp_path, monkeypatch
+@pytest.mark.parametrize(
+    "settings,expected",
+    [
+        ("pgvector_use_halfvec: true", True),
+        ("embed_dim: 3072", True),
+        ("embed_dim: 1536", False),
+        ("embed_dim: 3072\n  pgvector_use_halfvec: false", False),
+    ],
+    ids=["explicit-on", "auto-large", "auto-small", "explicit-off"],
+)
+def test_load_runtime_config_resolves_pgvector_halfvec(
+    tmp_path, monkeypatch, settings, expected
 ):
     config_path = _write_config(
         tmp_path,
-        """
+        f"""
 metis_engine:
-  embed_dim: 3072
+  {settings}
 llm_provider:
   name: openai
   model: gpt-test
@@ -472,51 +320,7 @@ llm_provider:
 """,
     )
     monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["pgvector_use_halfvec"] is True
-
-
-def test_load_runtime_config_auto_keeps_pgvector_full_precision_for_small_embeddings(
-    tmp_path, monkeypatch
-):
-    config_path = _write_config(
-        tmp_path,
-        """
-metis_engine:
-  embed_dim: 1536
-llm_provider:
-  name: openai
-  model: gpt-test
-  base_url: https://example.test/openai/v1
-""",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["pgvector_use_halfvec"] is False
-
-
-def test_load_runtime_config_allows_forcing_pgvector_halfvec_off(tmp_path, monkeypatch):
-    config_path = _write_config(
-        tmp_path,
-        """
-metis_engine:
-  embed_dim: 3072
-  pgvector_use_halfvec: false
-llm_provider:
-  name: openai
-  model: gpt-test
-  base_url: https://example.test/openai/v1
-""",
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "chat-key")
-
-    runtime = load_runtime_config(config_path)
-
-    assert runtime["pgvector_use_halfvec"] is False
+    assert load_runtime_config(config_path)["pgvector_use_halfvec"] is expected
 
 
 def test_build_embedding_provider_config_resolves_openai_embedding_provider(
@@ -790,3 +594,360 @@ embedding_provider:
     assert "api_key" not in runtime["llm_provider"]
     assert "api_key" not in embedding_provider_config
     assert embedding_provider_config["code_embedding_model"] == "nomic-embed-text:v1.5"
+
+
+@pytest.mark.parametrize(
+    ("content", "key"),
+    [
+        ("metis_engine: {}\nmetis_engine: {}\n", "metis_engine"),
+        ("metis_engine: {execution: {stages: {custom: {}, custom: {}}}}", "custom"),
+        (
+            "metis_engine: {execution: {stages: {custom: {nodes: {task: {}, task: {}}}}}}",
+            "task",
+        ),
+        ("metis_engine: {<<: {max_workers: 1, max_workers: 2}}", "max_workers"),
+        ('{=: first, "=": second}', "="),
+        ('{<<: {=: first, "=": second}}', "="),
+    ],
+)
+def test_raw_yaml_rejects_duplicate_keys_including_merged_maps(tmp_path, content, key):
+    config_path = _write_config(tmp_path, content)
+
+    with pytest.raises(
+        yaml.constructor.ConstructorError, match=f"duplicate key '{key}'"
+    ) as failure:
+        load_metis_config(config_path)
+
+    assert str(config_path) in str(failure.value)
+    assert "line" in str(failure.value)
+
+
+@pytest.mark.parametrize("key", ("=", '"="'))
+def test_raw_yaml_allows_value_keys_in_merge_overrides(tmp_path, key):
+    config_path = _write_config(
+        tmp_path,
+        f"defaults: &defaults {{=: inherited}}\nmerged: {{<<: *defaults, {key}: explicit}}",
+    )
+
+    loaded = load_metis_config(config_path)
+
+    assert loaded == {"defaults": {"=": "inherited"}, "merged": {"=": "explicit"}}
+
+
+def test_raw_yaml_allows_nested_merge_overrides_and_literal_merge_key(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        """
+first:
+  nested: &overrides
+    <<: &defaults {max_workers: 1}
+    max_workers: 2
+later:
+  <<: *overrides
+literal:
+  <<: *defaults
+  "<<": preserved
+""",
+    )
+
+    loaded = load_metis_config(config_path)
+
+    assert loaded["first"]["nested"] == loaded["later"] == {"max_workers": 2}
+    assert loaded["literal"] == {"max_workers": 1, "<<": "preserved"}
+
+
+@pytest.mark.parametrize("content", ("", "[]", "false", "42"))
+def test_runtime_rejects_non_mapping_document(tmp_path, content):
+    with pytest.raises(ValueError, match="configuration must be a mapping"):
+        load_runtime_config(_write_config(tmp_path, content))
+
+
+@pytest.mark.parametrize(
+    ("configured", "message"),
+    [
+        ("metis_engine: null", "metis_engine must be a mapping"),
+        ("metis_engine: {max_worker: 2}", "Unknown metis_engine settings: max_worker"),
+        ("metis_engine: {max_workers: 0}", "max_workers must be a positive integer"),
+        ("metis_engine: {max_workers: -1}", "max_workers must be a positive integer"),
+        ("metis_engine: {max_workers: true}", "max_workers must be a positive integer"),
+        ('metis_engine: {max_workers: "2"}', "max_workers must be a positive integer"),
+        (
+            "metis_engine: {max_token_length: .inf}",
+            "max_token_length must be a positive integer",
+        ),
+        (
+            "metis_engine: {doc_chunk_size: 20, doc_chunk_overlap: 20}",
+            "doc_chunk_overlap must be less",
+        ),
+        (
+            "metis_engine: {triage_checkpoint_every: -1}",
+            "triage_checkpoint_every must be a non-negative integer",
+        ),
+        (
+            "metis_engine: {review_checkpoints: []}",
+            "review_checkpoints must be a boolean",
+        ),
+        (
+            'metis_engine: {review_checkpoints: "false"}',
+            "review_checkpoints must be a boolean",
+        ),
+        (
+            "metis_engine: {model_tools: {max_contract_chars: 0}}",
+            "max_contract_chars must be a positive integer",
+        ),
+        ("metis_engine: {model_tools: disabled}", "model_tools must be a mapping"),
+        ("metis_engine: {model_tools: false}", "model_tools must be a mapping"),
+        ("metis_engine: {codegraph: false}", "codegraph must be a mapping"),
+        ("metis_engine: {capabilities: []}", "capabilities must be a mapping"),
+        ("language_plugins: []", "language_plugins must be a mapping"),
+        ("query: {max_token: 20}", "Unknown query settings: max_token"),
+        *[
+            (f"query: {{{key}: {value}}}", f"query.{key} must be a positive integer")
+            for key in ("max_tokens", "similarity_top_k")
+            for value in ("true", "false", "0", "-1", "1.5", '"2"', "[]", "{}")
+        ],
+        (
+            "query: {similarity_top_k: null}",
+            "similarity_top_k must be a positive integer",
+        ),
+        *[
+            (
+                f"metis_engine: {{{key}: {value}}}",
+                f"metis_engine.{key} must be a list of strings",
+            )
+            for key in ("review_code_include_paths", "review_code_exclude_paths")
+            for value in ("false", "null", '"src/"', "{}", "[src/, 2]", "[null]")
+        ],
+        *[
+            (
+                f"metis_engine: {{metisignore_file: {value}}}",
+                "metisignore_file must be a string or null",
+            )
+            for value in ("true", "1", "[]", "{}")
+        ],
+    ],
+)
+def test_runtime_rejects_invalid_raw_configuration(tmp_path, configured, message):
+    config_path = _write_config(
+        tmp_path, configured + "\nllm_provider: {name: ollama, model: test-model}\n"
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_runtime_config(config_path)
+
+
+@pytest.mark.parametrize(
+    ("max_tokens", "metisignore_file"),
+    [(None, None), (1, ""), (5000, "config/.metisignore")],
+)
+def test_runtime_preserves_valid_query_and_path_values(
+    tmp_path, max_tokens, metisignore_file
+):
+    runtime = load_runtime_config(
+        _write_config(
+            tmp_path,
+            yaml.safe_dump(
+                {
+                    "llm_provider": {"name": "ollama", "model": "test-model"},
+                    "query": {"max_tokens": max_tokens, "similarity_top_k": 3},
+                    "metis_engine": {
+                        "metisignore_file": metisignore_file,
+                        "review_code_include_paths": ["src/", "!src/generated/"],
+                        "review_code_exclude_paths": ["tests/"],
+                        "capabilities": {"CustomCapability": {"opaque": [None, False]}},
+                    },
+                }
+            ),
+        )
+    )
+
+    assert runtime["llama_query_max_tokens"] == max_tokens
+    assert runtime["similarity_top_k"] == 3
+    assert runtime["metisignore_file"] == metisignore_file
+    assert runtime["review_code_include_paths"] == ["src/", "!src/generated/"]
+    assert runtime["review_code_exclude_paths"] == ["tests/"]
+    assert runtime["capability_settings"].configurations["CustomCapability"] == {
+        "opaque": [None, False]
+    }
+
+
+def test_runtime_inherits_packaged_defaults_and_respects_explicit_replacements(
+    tmp_path,
+):
+    with as_file(files("metis") / "metis.yaml") as packaged_path:
+        defaults = load_metis_config(packaged_path)["metis_engine"]
+    provider = "llm_provider: {name: ollama, model: test-model}\n"
+    minimal = load_runtime_config(_write_config(tmp_path, provider))
+
+    assert minimal["llama_query_max_tokens"] is None
+    assert minimal["similarity_top_k"] == 5
+    assert minimal["metisignore_file"] is None
+    assert minimal["review_code_include_paths"] == []
+    assert minimal["review_code_exclude_paths"] == []
+
+    for key in ("max_workers", "max_token_length", "embed_dim"):
+        assert minimal[key] == defaults[key]
+    assert minimal["threat_model_config"] == defaults["threat_model"]
+    assert minimal["capability_settings"].configurations == defaults["capabilities"]
+
+    changed = load_runtime_config(
+        _write_config(
+            tmp_path,
+            provider
+            + """
+metis_engine:
+  capabilities:
+    navigation: {timeout_seconds: 2}
+    CustomCapability: {own_setting: 7}
+  execution: {stages: {}}
+  threat_model: {source_patterns: []}
+  codegraph: {source_functions: []}
+  triage_checkpoint_every: 0
+  llm_max_retries: 0
+""",
+        )
+    )
+    capabilities = changed["capability_settings"].configurations
+    assert capabilities["navigation"] == {
+        **defaults["capabilities"]["navigation"],
+        "timeout_seconds": 2,
+    }
+    assert capabilities["index"] == defaults["capabilities"]["index"]
+    assert capabilities["CustomCapability"] == {"own_setting": 7}
+    assert changed["execution_config"] == {"stages": {}}
+    assert changed["threat_model_config"]["source_patterns"] == []
+    assert changed["codegraph_config"] == {"source_functions": []}
+    assert changed["triage_checkpoint_every"] == changed["llm_max_retries"] == 0
+
+    empty = load_runtime_config(
+        _write_config(
+            tmp_path, provider + "metis_engine: {capabilities: {}, execution: {}}\n"
+        )
+    )
+    assert empty["capability_settings"].configurations == {}
+    assert empty["execution_config"] == {}
+
+
+@pytest.mark.parametrize("name", ["max_active_nodes", "max_concurrent_executions"])
+@pytest.mark.parametrize("value", [0, -1, True, 1.5, "2", []])
+def test_runtime_rejects_invalid_concurrency_budgets(tmp_path, name, value):
+    config = {"metis_engine": {name: value}}
+    with pytest.raises(ValueError, match=f"{name} must be a positive integer"):
+        load_runtime_config(_write_config(tmp_path, yaml.safe_dump(config)))
+
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        {},
+        {"max_active_nodes": None, "max_concurrent_executions": None},
+        {"max_active_nodes": 1, "max_concurrent_executions": 4},
+    ],
+)
+def test_runtime_resolves_independent_concurrency_budgets(tmp_path, limits):
+    runtime = load_runtime_config(
+        _write_config(
+            tmp_path,
+            yaml.safe_dump(
+                {
+                    "llm_provider": {"name": "ollama", "model": "unused"},
+                    "metis_engine": {"max_workers": 3, **limits},
+                }
+            ),
+        )
+    )
+    assert runtime["max_workers"] == 3
+    assert runtime["max_active_nodes"] == (limits.get("max_active_nodes") or 3)
+    assert runtime["max_concurrent_executions"] == (
+        limits.get("max_concurrent_executions") or 3
+    )
+
+
+@pytest.mark.parametrize(
+    ("configured", "message"),
+    [
+        *[
+            (f"query: {{temperature: {value}}}", "query.temperature")
+            for value in (
+                "true",
+                '"warm"',
+                "[]",
+                ".nan",
+                ".inf",
+                "-.inf",
+                "-0.1",
+                str(10**400),
+            )
+        ],
+        *[
+            (f"metis_engine: {{hnsw_kwargs: {{{key}: {value}}}}}", key)
+            for key in ("hnsw_m", "hnsw_ef_construction", "hnsw_ef_search")
+            for value in ("true", "null", "0", "1.5", '"16"')
+        ],
+        ("metis_engine: {review_checkpoints: falsehood}", "review_checkpoints"),
+        ("memory: invalid-shape", "MemoryCapabilityConfiguration"),
+        (
+            "metis_engine: {codegraph: {source_functions: [{name: ' '}]}}",
+            "source_functions",
+        ),
+        (
+            "metis_engine: {reachability: {max_path_length: 0}}",
+            "max_path_length",
+        ),
+    ],
+)
+def test_invalid_shared_settings_fail_before_provider_lookup(
+    tmp_path, monkeypatch, configured, message
+):
+    def unexpected_provider(**_kwargs):
+        pytest.fail("invalid shared settings reached provider lookup")
+
+    monkeypatch.setattr("metis.configuration._get_provider_cls", unexpected_provider)
+    with pytest.raises(ValueError, match=message):
+        load_runtime_config(_write_config(tmp_path, configured))
+
+
+@pytest.mark.parametrize("temperature", [None, 0, 0.5, 100, 1e100])
+def test_valid_temperature_and_partial_hnsw_settings(tmp_path, temperature):
+    runtime = load_runtime_config(
+        _write_config(
+            tmp_path,
+            yaml.safe_dump(
+                {
+                    "llm_provider": {"name": "ollama", "model": "inert"},
+                    "query": {"temperature": temperature},
+                    "metis_engine": {"hnsw_kwargs": {"hnsw_m": 16}},
+                }
+            ),
+        )
+    )
+    assert runtime["hnsw_kwargs"] == {"hnsw_m": 16}
+    if temperature is None:
+        assert "temperature" not in runtime["chat_model_kwargs"]
+    else:
+        assert runtime["chat_model_kwargs"]["temperature"] == temperature
+
+
+def test_blank_environment_credentials_allow_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("METIS_TEST_EMPTY_KEY", " \t")
+    monkeypatch.setenv("OPENAI_API_KEY", "inert-fallback")
+    config = (
+        "llm_provider: {name: openai, model: inert, api_key_env: METIS_TEST_EMPTY_KEY}"
+    )
+    runtime = load_runtime_config(_write_config(tmp_path, config))
+    assert runtime["llm_provider"]["api_key"] == "inert-fallback"
+    monkeypatch.setenv("OPENAI_API_KEY", " ")
+    with pytest.raises(RuntimeError, match="required.*not set"):
+        load_runtime_config(_write_config(tmp_path, config))
+
+
+@pytest.mark.parametrize("value", ["2026-02-30", "!!int nope", "!!float nope"])
+def test_invalid_yaml_scalars_preserve_source_location_and_recover(tmp_path, value):
+    path = _write_config(tmp_path, f"metis_engine:\n  max_workers: {value}\n")
+    with pytest.raises(yaml.constructor.ConstructorError) as caught:
+        load_metis_config(path)
+    assert caught.value.problem_mark.name == str(path)
+    assert (caught.value.problem_mark.line, caught.value.problem_mark.column) == (1, 15)
+    assert isinstance(caught.value.__cause__, ValueError)
+    path.write_text("metis_engine: {max_workers: 2}\n", encoding="utf-8")
+    assert load_metis_config(path)["metis_engine"]["max_workers"] == 2

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -3,19 +3,24 @@
 
 import logging
 import tempfile
-import threading
 from dataclasses import replace
+from contextlib import closing
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from pydantic import BaseModel
+from pydantic import ConfigDict
 
 from metis.configuration import load_execution_config
 from metis.engine import MetisEngine
+from metis.engine import ExecutionGraphError
 from metis.engine.capabilities.engine import EngineCapabilities
 from metis.engine.codegraph import CodeGraph
 from metis.engine.codegraph import CodeGraphReference
 from metis.engine.execution.contracts import ExecutionStatus
+from metis.engine.execution.contracts import ExecutionResult
+from metis.engine.execution.contracts import ExecutionDiagnostic
 from metis.engine.nodes.builtins import build_builtin_execution
 from metis.engine.nodes.reachability.review import ReachabilityReviewService
 from metis.engine.nodes.simple_llm_review.service import SimpleLlmReviewService
@@ -41,23 +46,6 @@ def _execution_with_index() -> dict[str, object]:
     execution = load_execution_config()
     execution["stages"]["initialize"]["nodes"]["index"] = {"capabilities": ["index"]}
     return execution
-
-
-@pytest.mark.parametrize("max_workers", (0, -1, True, "2"))
-def test_engine_rejects_invalid_max_workers(capability_settings, max_workers):
-    with pytest.raises(
-        ValueError,
-        match="MetisEngine.max_workers must be a positive integer",
-    ):
-        MetisEngine(
-            vector_backend=Mock(),
-            llm_provider=Mock(),
-            max_workers=max_workers,
-            max_token_length=2048,
-            llama_query_model="gpt-test",
-            similarity_top_k=3,
-            capability_settings=capability_settings,
-        )
 
 
 def test_index_capability_rejects_missing_retrievers(capability_settings):
@@ -122,41 +110,6 @@ def test_init_and_get_default_available_metisignore(capability_settings):
         )
         assert engine.repository.load_metisignore() is not None
     assert engine is not None
-
-
-def test_index_capability_initializes_retrievers_once_across_threads(
-    capability_settings,
-):
-    backend = Mock()
-    backend.init = Mock()
-    backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
-    engine = MetisEngine(
-        vector_backend=backend,
-        llm_provider=Mock(),
-        embedding_provider=_embedding_provider(),
-        max_workers=4,
-        max_token_length=2048,
-        llama_query_model="gpt-test",
-        similarity_top_k=3,
-        capability_settings=capability_settings,
-        execution_config=_execution_with_index(),
-    )
-
-    results = []
-    index = engine.capabilities["index"]
-
-    def _worker():
-        results.append(index.get_retrievers())
-
-    threads = [threading.Thread(target=_worker) for _ in range(8)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
-
-    assert results == [("code-retriever", "docs-retriever")] * 8
-    backend.init.assert_called_once()
-    backend.get_retrievers.assert_called_once()
 
 
 def test_index_capability_builds_embed_models_lazily_with_usage_callback_manager(
@@ -657,114 +610,71 @@ def test_engine_reuses_injected_runtime_and_backend_embed_models(
     llm_provider.get_chat_model.assert_not_called()
 
 
-def test_index_prepare_nodes_resets_backend_index_when_supported(
-    monkeypatch, capability_settings
-):
-    backend = Mock()
-    backend.init = Mock()
-    backend.reset_index = Mock()
-    backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
+@pytest.mark.parametrize("value", (bytes([255]), object()), ids=("binary", "resource"))
+def test_execution_error_preserves_native_values_and_original_diagnostics(value):
+    class Payload(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        value: object
 
-    embedding_provider = _embedding_provider()
-
-    engine = MetisEngine(
-        vector_backend=backend,
-        llm_provider=Mock(),
-        embedding_provider=embedding_provider,
-        max_workers=2,
-        max_token_length=2048,
-        llama_query_model="gpt-test",
-        similarity_top_k=3,
-        capability_settings=capability_settings,
+    native = Payload(value=value)
+    diagnostic = ExecutionDiagnostic("original.failure", "original failure")
+    result = ExecutionResult(
+        ExecutionStatus.ERROR,
+        {"stage": {"native": native, "normal": Payload(value="serializable")}},
+        (diagnostic,),
     )
 
-    class _Reader:
-        def __init__(self, **_kwargs):
-            pass
+    error = ExecutionGraphError(result)
 
-        def load_data(self):
-            return []
-
-    monkeypatch.setattr(
-        "metis.engine.capabilities.indexing.SimpleDirectoryReader", _Reader
-    )
-    engine.indexing.index_prepare_nodes()
-
-    embedding_provider.get_embed_model_code.assert_called_once()
-    embedding_provider.get_embed_model_docs.assert_called_once()
-    backend.init.assert_called_once()
-    backend.reset_index.assert_called_once()
+    assert "original failure" in str(error)
+    assert error.result.status is ExecutionStatus.ERROR
+    assert error.result.diagnostics == (diagnostic,)
+    assert error.result.outputs["stage"]["native"] is native
+    assert error.result.outputs["stage"]["normal"] == {"value": "serializable"}
+    assert error.result.outputs["stage"] is not result.outputs["stage"]
 
 
-def test_index_finalize_embeddings_delegates_node_writes_to_backend(
-    capability_settings,
-):
-    backend = Mock()
-    backend.init = Mock()
-    backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
-    backend.index_nodes = Mock()
-    code_embed_model = Mock()
-    docs_embed_model = Mock()
-
-    engine = MetisEngine(
-        vector_backend=backend,
-        llm_provider=Mock(),
-        embedding_provider=_embedding_provider(code_embed_model, docs_embed_model),
-        max_workers=2,
-        max_token_length=2048,
-        llama_query_model="gpt-test",
-        similarity_top_k=3,
-        capability_settings=capability_settings,
-    )
-    engine._state.pending_nodes = (["code-node"], ["docs-node"])
-
-    engine.indexing.index_finalize_embeddings()
-
-    backend.index_nodes.assert_called_once_with(
-        ["code-node"],
-        ["docs-node"],
-        embed_model_code=code_embed_model,
-        embed_model_docs=docs_embed_model,
-        callback_manager=engine._config.usage_runtime.hooks.callback_manager,
-    )
-    assert engine._state.pending_nodes is None
-
-
-def test_close_clears_retriever_cache_and_closes_backend(capability_settings):
-    backend = Mock()
-    backend.init = Mock()
-    backend.get_retrievers = Mock(return_value=("code-retriever", "docs-retriever"))
-    backend.close = Mock()
-
-    engine = MetisEngine(
-        vector_backend=backend,
-        llm_provider=Mock(),
-        embedding_provider=_embedding_provider(),
-        max_workers=2,
-        max_token_length=2048,
-        llama_query_model="gpt-test",
-        similarity_top_k=3,
-        capability_settings=capability_settings,
-        execution_config=_execution_with_index(),
-    )
-
-    index = engine.capabilities["index"]
-    assert index.get_retrievers() == ("code-retriever", "docs-retriever")
-    assert backend.get_retrievers.call_count == 1
-
-    engine.close()
-
-    assert engine._state.retriever_code is None
-    assert engine._state.retriever_docs is None
-    backend.close.assert_called_once()
-
-    with pytest.raises(RuntimeError, match="cannot schedule new futures"):
-        engine.execution._jobs.run(
-            [None],
-            lambda _value: None,
-            label=None,
-            result_key=str,
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        *[
+            (name, value)
+            for name in ("review_code_include_paths", "review_code_exclude_paths")
+            for value in ("src/", {"src/": False}, [1], [Path("src")], None)
+        ],
+        *[("metisignore_file", value) for value in (False, 1, [], {})],
+    ],
+)
+def test_engine_rejects_invalid_path_settings(capability_settings, name, value):
+    with pytest.raises(ValueError, match=f"MetisEngine.{name}"):
+        MetisEngine(
+            max_workers=1,
+            max_token_length=2048,
+            llama_query_model="inert",
+            similarity_top_k=3,
+            capability_settings=capability_settings,
+            **{name: value},
         )
 
-    assert index.get_retrievers() == ("code-retriever", "docs-retriever")
-    assert backend.get_retrievers.call_count == 2
+
+def test_engine_accepts_path_ignore_file_and_preserves_patterns(
+    tmp_path, capability_settings
+):
+    ignore_file = tmp_path / "設定 ignore"
+    ignore_file.write_text("ignored/\n", encoding="utf-8")
+    patterns = [" src/", "設定/", ""]
+    with closing(
+        MetisEngine(
+            codebase_path=tmp_path,
+            max_workers=1,
+            max_token_length=2048,
+            llama_query_model="inert",
+            similarity_top_k=3,
+            capability_settings=capability_settings,
+            metisignore_file=ignore_file,
+            review_code_include_paths=patterns,
+        )
+    ) as engine:
+        assert engine.repository.load_metisignore() is not None
+        assert engine._config.review_code_include_paths == patterns
+        assert engine._config.review_code_include_paths is not patterns

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -1,0 +1,828 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+from concurrent.futures import CancelledError
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Event
+from unittest.mock import Mock
+
+import pytest
+
+from metis.engine import MetisEngine
+from metis.engine import core
+from metis.engine.capabilities.contracts import CapabilityRegistration
+from metis.engine.capabilities.manifest import CapabilityManifest
+from metis.engine.execution.contracts import EmptyNodeConfiguration
+
+
+def _run_in_subprocess(request):
+    node = f"{Path(__file__).resolve()}::{request.node.name}"
+    if os.environ.get("METIS_LIFECYCLE_TEST") == node:
+        return False
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-o", "faulthandler_timeout=10", node],
+        env={**os.environ, "METIS_LIFECYCLE_TEST": node},
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return True
+
+
+class _ObservedLock:
+    def __init__(self, lock):
+        self._lock = lock
+        self.contended = Event()
+
+    def __enter__(self):
+        if not self._lock.acquire(blocking=False):
+            self.contended.set()
+            self._lock.acquire()
+        return self
+
+    def __exit__(self, *_args):
+        self._lock.release()
+
+
+class _LocalBackend:
+    """An inert storage boundary; readers, splitters and engine execution stay real."""
+
+    def __init__(self):
+        self.embed_model_code = object()
+        self.embed_model_docs = object()
+        self.documents = ["previous index"]
+        self.writes = []
+        self.write_kwargs = []
+        self.reset_count = 0
+        self.close_count = 0
+        self.closed = Event()
+        self.write_started = Event()
+        self.finish_write = Event()
+        self.finish_write.set()
+        self.fail_next_write = False
+        self.on_write = None
+        self.close_error = None
+
+    def init(self):
+        if self.closed.is_set():
+            raise RuntimeError("backend was closed during indexing")
+
+    def reset_index(self):
+        self.init()
+        self.reset_count += 1
+        self.documents = []
+
+    def index_nodes(self, code, docs, **kwargs):
+        self.write_started.set()
+        assert self.finish_write.wait(5)
+        self.init()
+        if self.on_write is not None:
+            self.on_write()
+        if self.fail_next_write:
+            self.fail_next_write = False
+            raise ValueError("storage temporarily unavailable")
+        self.documents = [node.text for node in [*code, *docs]]
+        self.writes.append(tuple(self.documents))
+        self.write_kwargs.append(kwargs)
+
+    def get_retrievers(self, *args, **kwargs):
+        self.init()
+        return "code retriever", "docs retriever"
+
+    def get_index_handles(self, **kwargs):
+        self.init()
+        return None, None
+
+    def close(self):
+        self.close_count += 1
+        self.closed.set()
+        if self.close_error is not None:
+            raise self.close_error
+
+
+def _engine(tmp_path, capability_settings, backend, **kwargs):
+    return MetisEngine(
+        codebase_path=str(tmp_path),
+        vector_backend=backend,
+        max_workers=kwargs.pop("max_workers", 2),
+        max_token_length=2048,
+        llama_query_model="unused",
+        similarity_top_k=3,
+        capability_settings=capability_settings,
+        execution_config=kwargs.pop(
+            "execution_config",
+            {
+                "stages": {
+                    "initialize": {
+                        "nodes": {"index": {"capabilities": ["index"]}},
+                        "outputs": {"index": "index.index"},
+                    }
+                }
+            },
+        ),
+        **kwargs,
+    )
+
+
+def test_real_index_preparations_preserve_each_snapshot_until_finalization(
+    tmp_path, capability_settings
+):
+    document = tmp_path / "README.md"
+    document.write_text("snapshot A")
+    backend = _LocalBackend()
+    engine = _engine(tmp_path, capability_settings, backend)
+    first_prepared, second_prepared, first_finished = (Event() for _ in range(3))
+
+    def first():
+        engine.indexing.index_prepare_nodes()
+        first_prepared.set()
+        assert second_prepared.wait(5)
+        assert backend.documents == ["previous index"]
+        engine.indexing.index_finalize_embeddings()
+        first_finished.set()
+
+    def second():
+        assert first_prepared.wait(5)
+        document.write_text("snapshot B")
+        engine.indexing.index_prepare_nodes()
+        second_prepared.set()
+        assert first_finished.wait(5)
+        engine.indexing.index_finalize_embeddings()
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            a, b = pool.submit(first), pool.submit(second)
+            a.result(timeout=10)
+            b.result(timeout=10)
+        assert backend.writes == [("snapshot A",), ("snapshot B",)]
+        assert backend.reset_count == 2
+        assert all(
+            kwargs["callback_manager"]
+            is engine._config.usage_runtime.hooks.callback_manager
+            and kwargs["embed_model_code"] is backend.embed_model_code
+            and kwargs["embed_model_docs"] is backend.embed_model_docs
+            for kwargs in backend.write_kwargs
+        )
+        assert engine.init_codebase() == {"index": {"status": "indexed"}}
+        assert backend.documents == ["snapshot B"]
+    finally:
+        engine.close()
+
+
+def test_failed_real_index_can_be_retried_on_the_same_worker(
+    tmp_path, capability_settings
+):
+    document = tmp_path / "README.md"
+    document.write_text("first attempt")
+    backend = _LocalBackend()
+    backend.fail_next_write = True
+    engine = _engine(tmp_path, capability_settings, backend)
+    try:
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            with pytest.raises(ValueError, match="temporarily unavailable"):
+                pool.submit(engine.indexing.index_codebase).result(timeout=5)
+            document.write_text("successful retry")
+            pool.submit(engine.indexing.index_codebase).result(timeout=5)
+        assert backend.documents == ["successful retry"]
+        assert backend.writes == [("successful retry",)]
+    finally:
+        engine.close()
+
+
+def test_engine_shutdown_waits_for_direct_indexing_and_rejects_later_writes(
+    tmp_path, capability_settings
+):
+    (tmp_path / "README.md").write_text("retained output")
+    backend = _LocalBackend()
+    backend.finish_write.clear()
+    engine = _engine(tmp_path, capability_settings, backend)
+    index = engine.capabilities["index"]
+    assert index.get_retrievers() == ("code retriever", "docs retriever")
+    indexing = engine.indexing
+    close_started = Event()
+
+    def close():
+        close_started.set()
+        engine.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        writing = pool.submit(indexing.index_codebase)
+        try:
+            assert backend.write_started.wait(5)
+            closing = pool.submit(close)
+            assert close_started.wait(5)
+            assert not backend.closed.wait(0.1)
+        finally:
+            backend.finish_write.set()
+        writing.result(timeout=5)
+        closing.result(timeout=5)
+    engine.close()
+    assert backend.documents == ["retained output"]
+    assert backend.close_count == 1
+    assert engine._state.retriever_code is None
+    assert engine._state.retriever_docs is None
+    with pytest.raises(RuntimeError, match="closed"):
+        indexing.index_codebase()
+    assert backend.reset_count == 1
+
+
+def test_index_shutdown_from_its_own_backend_fails_without_deadlock_or_leak(
+    tmp_path, capability_settings, request
+):
+    if _run_in_subprocess(request):
+        return
+    (tmp_path / "README.md").write_text("index contents")
+    backend = _LocalBackend()
+    engine = _engine(tmp_path, capability_settings, backend)
+    backend.on_write = engine.close
+    with pytest.raises(RuntimeError, match="active index"):
+        engine.indexing.index_codebase()
+    assert backend.close_count == 1
+    engine.close()
+    assert backend.close_count == 1
+
+
+def _add_capability(monkeypatch, registration):
+    builtins = core.builtin_capability_registrations
+    monkeypatch.setattr(
+        core,
+        "builtin_capability_registrations",
+        lambda *args: (*builtins(*args), registration),
+    )
+
+
+@pytest.mark.parametrize("resource_kind", ("index", "factory"))
+def test_concurrent_engine_shutdown_allows_resource_callback_to_close_owner(
+    tmp_path, capability_settings, monkeypatch, request, resource_kind
+):
+    if _run_in_subprocess(request):
+        return
+    (tmp_path / "README.md").write_text("index contents")
+    backend = _LocalBackend()
+    entered, release = Event(), Event()
+    resource, closed = object(), []
+
+    def factory(_context, _configuration):
+        entered.set()
+        assert release.wait(5)
+        engine.close()
+        return resource
+
+    if resource_kind == "factory":
+        _add_capability(
+            monkeypatch,
+            CapabilityRegistration(
+                CapabilityManifest("closing"),
+                EmptyNodeConfiguration,
+                factory,
+                closed.append,
+            ),
+        )
+    engine = _engine(tmp_path, capability_settings, backend)
+    if resource_kind == "index":
+        backend.finish_write = release
+        backend.on_write = engine.close
+        entered = backend.write_started
+        owner, lock_name = engine.indexing, "_mutation_lock"
+        operation = engine.indexing.index_codebase
+    else:
+        owner, lock_name = engine.capabilities, "_lock"
+
+        def operation():
+            return engine.capabilities.require("closing")
+
+    observed = _ObservedLock(getattr(owner, lock_name))
+    monkeypatch.setattr(owner, lock_name, observed)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            running = pool.submit(operation)
+            try:
+                assert entered.wait(5)
+                closing = pool.submit(engine.close)
+                assert observed.contended.wait(5)
+            finally:
+                release.set()
+            result = running.result(timeout=5)
+            closing.result(timeout=5)
+        if resource_kind == "factory":
+            assert result is resource
+            assert closed == [resource]
+        else:
+            assert backend.documents == ["index contents"]
+    finally:
+        engine.close()
+    assert backend.close_count == 1
+    with pytest.raises(RuntimeError, match="closed"):
+        engine.capabilities.require("index")
+
+
+@pytest.mark.parametrize("cleanup_fails", (False, True))
+def test_engine_never_publishes_a_capability_returned_after_owner_shutdown(
+    tmp_path, capability_settings, monkeypatch, cleanup_fails
+):
+    backend = _LocalBackend()
+    closed = []
+    resource = object()
+    engine = None
+
+    def factory(_context, _configuration):
+        assert engine is not None
+        engine.close()
+        return resource
+
+    def close(resource):
+        closed.append(resource)
+        if cleanup_fails:
+            raise ValueError("resource cleanup failed")
+
+    _add_capability(
+        monkeypatch,
+        CapabilityRegistration(
+            CapabilityManifest("late"), EmptyNodeConfiguration, factory, close
+        ),
+    )
+    engine = _engine(tmp_path, capability_settings, backend)
+    with pytest.raises(RuntimeError, match="closed") as caught:
+        engine.capabilities.require("late")
+    if cleanup_fails:
+        assert any("resource cleanup failed" in note for note in caught.value.__notes__)
+    assert closed == [resource]
+    assert backend.close_count == 1
+    with pytest.raises(RuntimeError, match="closed"):
+        engine.capabilities.require("late")
+    engine.close()
+    assert closed == [resource]
+
+
+def test_real_engine_cleanup_preserves_construction_error_and_closes_owned_index(
+    tmp_path, capability_settings
+):
+    backend = _LocalBackend()
+    backend.close_error = RuntimeError("storage close failed")
+    with pytest.raises(ValueError, match="no_such_port") as caught:
+        _engine(
+            tmp_path,
+            capability_settings,
+            backend,
+            execution_config={
+                "stages": {
+                    "initialize": {
+                        "nodes": {"index": {"capabilities": ["index"]}},
+                        "outputs": {"index": "index.no_such_port"},
+                    }
+                }
+            },
+        )
+    assert backend.close_count == 1
+    assert any("storage close failed" in note for note in caught.value.__notes__)
+
+
+def test_real_engine_constructs_a_lazy_capability_once_under_contention(
+    tmp_path, capability_settings, monkeypatch, request
+):
+    if _run_in_subprocess(request):
+        return
+    entered, release = Event(), Event()
+    instances, closed = [], []
+
+    def factory(_context, _configuration):
+        instance = object()
+        instances.append(instance)
+        entered.set()
+        assert release.wait(5)
+        return instance
+
+    _add_capability(
+        monkeypatch,
+        CapabilityRegistration(
+            CapabilityManifest("shared"), EmptyNodeConfiguration, factory, closed.append
+        ),
+    )
+    engine = _engine(tmp_path, capability_settings, _LocalBackend())
+
+    observed = _ObservedLock(engine.capabilities._lock)
+    monkeypatch.setattr(engine.capabilities, "_lock", observed)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(engine.capabilities.require, "shared")
+            try:
+                assert entered.wait(5)
+                other = pool.submit(engine.capabilities.require, "shared")
+                assert observed.contended.wait(5)
+            finally:
+                release.set()
+            assert first.result(timeout=5) is other.result(timeout=5)
+        assert len(instances) == 1
+    finally:
+        engine.close()
+    engine.close()
+    assert closed == instances
+    with pytest.raises(RuntimeError, match="closed"):
+        engine.capabilities.require("shared")
+
+
+def test_null_capability_factory_does_not_poison_a_real_engine(
+    tmp_path, capability_settings, monkeypatch
+):
+    (tmp_path / "README.md").write_text("still usable")
+    _add_capability(
+        monkeypatch,
+        CapabilityRegistration(
+            CapabilityManifest("invalid"), EmptyNodeConfiguration, lambda *_args: None
+        ),
+    )
+    backend = _LocalBackend()
+    engine = _engine(tmp_path, capability_settings, backend)
+    try:
+        with pytest.raises(TypeError, match="invalid.*None"):
+            engine.capabilities.require("invalid")
+        assert engine.init_codebase() == {"index": {"status": "indexed"}}
+        assert backend.documents == ["still usable"]
+    finally:
+        engine.close()
+
+
+def test_reentrant_capability_construction_rejects_same_name_and_allows_retry(
+    tmp_path, capability_settings, monkeypatch
+):
+    resource, dependency, closed = object(), object(), []
+    attempts = 0
+
+    def factory(_context, _configuration):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return engine.capabilities.require("recursive")
+        assert engine.capabilities.require("dependency") is dependency
+        return resource
+
+    for name, build in (
+        ("recursive", factory),
+        ("dependency", lambda *_args: dependency),
+    ):
+        _add_capability(
+            monkeypatch,
+            CapabilityRegistration(
+                CapabilityManifest(name), EmptyNodeConfiguration, build, closed.append
+            ),
+        )
+    engine = _engine(tmp_path, capability_settings, _LocalBackend())
+    try:
+        with pytest.raises(RuntimeError, match="recursive.*already being constructed"):
+            engine.capabilities.require("recursive")
+        assert attempts == 1
+        assert closed == []
+        assert engine.capabilities.require("recursive") is resource
+        assert engine.capabilities.require("recursive") is resource
+        assert attempts == 2
+    finally:
+        engine.close()
+    engine.close()
+    assert closed == [resource, dependency]
+
+
+@pytest.mark.parametrize(
+    "name", ["max_workers", "max_active_nodes", "max_concurrent_executions"]
+)
+@pytest.mark.parametrize("value", [0, -1, True, 1.5, "2"])
+def test_direct_engine_rejects_invalid_concurrency_budgets_before_resources(
+    tmp_path, capability_settings, name, value
+):
+    backend = _LocalBackend()
+    with pytest.raises(
+        ValueError, match=f"MetisEngine.{name} must be a positive integer"
+    ):
+        _engine(tmp_path, capability_settings, backend, **{name: value})
+    assert backend.close_count == 0
+    assert backend.writes == []
+
+
+def test_simultaneous_engine_closers_all_wait_for_active_execution(
+    tmp_path, capability_settings, request
+):
+    if _run_in_subprocess(request):
+        return
+    entered, release, second_started, second_returned = (Event() for _ in range(4))
+    backend = _LocalBackend()
+    engine = _engine(tmp_path, capability_settings, backend)
+    cancellation = None
+
+    def progress(event):
+        nonlocal cancellation
+        if event.get("event") == "execution_stage_start":
+            (cancellation,) = engine.execution._active_executions
+            entered.set()
+            assert release.wait(5)
+
+    def close_again():
+        second_started.set()
+        engine.close()
+        second_returned.set()
+
+    try:
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            executing = pool.submit(
+                engine.execute_graph, callbacks={"progress_callback": progress}
+            )
+            try:
+                assert entered.wait(5)
+                first = pool.submit(engine.close)
+                assert cancellation is not None and cancellation.wait(5)
+                second = pool.submit(close_again)
+                assert second_started.wait(5)
+                assert not second_returned.wait(0.1)
+                assert not first.done()
+                assert not backend.closed.is_set()
+            finally:
+                release.set()
+            with pytest.raises(CancelledError):
+                executing.result(timeout=5)
+            first.result(timeout=5)
+            second.result(timeout=5)
+    finally:
+        release.set()
+        engine.close()
+    assert backend.close_count == 1
+    assert backend.writes == []
+
+
+@pytest.mark.parametrize("already_closed", (False, True))
+def test_each_engine_closer_preserves_its_shutdown_error(
+    tmp_path, capability_settings, monkeypatch, already_closed
+):
+    backend = _LocalBackend()
+    engine = _engine(tmp_path, capability_settings, backend)
+    if already_closed:
+        engine.close()
+    interruption = KeyboardInterrupt("interrupted shutdown")
+    scheduler = engine.execution._scheduler
+    original_close = scheduler.close
+    attempts = 0
+
+    def interrupted_close():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise interruption
+        original_close()
+
+    backend.close_error = ValueError("later resource cleanup error")
+    monkeypatch.setattr(scheduler, "close", interrupted_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        engine.close()
+    assert caught.value is interruption
+    assert attempts == 2
+    engine.close()
+    assert backend.close_count == 1
+
+
+def test_embedding_initialization_is_shared_with_retriever_construction(
+    tmp_path, capability_settings, monkeypatch, request
+):
+    if _run_in_subprocess(request):
+        return
+    entered, release = Event(), Event()
+    models = object(), object()
+    provider = Mock()
+
+    def build_code(**_kwargs):
+        entered.set()
+        assert release.wait(5)
+        return models[0]
+
+    provider.get_embed_model_code.side_effect = build_code
+    provider.get_embed_model_docs.return_value = models[1]
+    backend = _LocalBackend()
+    backend.embed_model_code = backend.embed_model_docs = None
+    engine = _engine(
+        tmp_path, capability_settings, backend, embedding_provider=provider
+    )
+    index = engine.capabilities["index"]
+    observed = _ObservedLock(engine._state.retriever_lock)
+    monkeypatch.setattr(engine._state, "retriever_lock", observed)
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(index.get_embedding_models)
+            try:
+                assert entered.wait(5)
+                second = pool.submit(index.get_retrievers)
+                assert observed.contended.wait(5)
+            finally:
+                release.set()
+            assert first.result(timeout=5) == models
+            assert second.result(timeout=5) == ("code retriever", "docs retriever")
+        assert index.get_embedding_models() == models
+        assert (backend.embed_model_code, backend.embed_model_docs) == models
+        provider.get_embed_model_code.assert_called_once()
+        provider.get_embed_model_docs.assert_called_once()
+    finally:
+        release.set()
+        engine.close()
+
+
+@pytest.mark.parametrize("failure", ("code_reentry", "docs_reentry", "docs_error"))
+def test_embedding_initialization_failure_leaves_no_partial_pair_and_can_retry(
+    tmp_path, capability_settings, failure
+):
+    models = object(), object()
+    provider = Mock()
+    provider.get_embed_model_code.return_value = models[0]
+    provider.get_embed_model_docs.return_value = models[1]
+    backend = _LocalBackend()
+    backend.embed_model_code = backend.embed_model_docs = None
+    engine = _engine(
+        tmp_path, capability_settings, backend, embedding_provider=provider
+    )
+    index = engine.capabilities["index"]
+    failing_method = (
+        provider.get_embed_model_code
+        if failure == "code_reentry"
+        else provider.get_embed_model_docs
+    )
+    failing_method.side_effect = (
+        ValueError("model construction failed")
+        if failure == "docs_error"
+        else lambda **_kwargs: index.get_embedding_models()
+    )
+    try:
+        with pytest.raises(
+            (RuntimeError, ValueError), match="constructed|construction"
+        ):
+            index.get_retrievers()
+        assert index._embed_model_code is None
+        assert index._embed_model_docs is None
+        assert backend.embed_model_code is None
+        assert backend.embed_model_docs is None
+        assert engine._state.retriever_code is None
+        failing_method.side_effect = None
+        assert index.get_retrievers() == ("code retriever", "docs retriever")
+        assert index.get_embedding_models() == models
+        assert (backend.embed_model_code, backend.embed_model_docs) == models
+    finally:
+        engine.close()
+
+
+@pytest.mark.parametrize("reset_fails", (False, True))
+def test_reset_invalidates_both_caches_before_and_after_backend_callbacks(
+    tmp_path, capability_settings, monkeypatch, reset_fails
+):
+    backend = _LocalBackend()
+    monkeypatch.setattr(
+        backend,
+        "get_retrievers",
+        lambda *_args, **_kwargs: (
+            (backend.reset_count, object()),
+            (backend.reset_count, object()),
+        ),
+    )
+    engine = _engine(tmp_path, capability_settings, backend)
+    index = engine.capabilities["index"]
+    reset = backend.reset_index
+
+    def reset_index():
+        reset()
+        # A reentrant backend callback must not receive the cached old generation.
+        assert index.get_retrievers()[0][0] == backend.reset_count
+        assert index._retrievers_for_top_k(1)[0][0] == backend.reset_count
+        if reset_fails:
+            raise ValueError("reset failed after replacement")
+
+    monkeypatch.setattr(backend, "reset_index", reset_index)
+    try:
+        assert index.get_retrievers()[0][0] == 0
+        assert index._retrievers_for_top_k(1)[0][0] == 0
+        engine._state.pending_nodes = ([], [])
+        if reset_fails:
+            with pytest.raises(ValueError, match="reset failed"):
+                index.indexing.index_finalize_embeddings()
+        else:
+            index.indexing.index_finalize_embeddings()
+        assert engine._state.retriever_code is None
+        assert engine._state.retriever_docs is None
+        assert index._retrievers_by_top_k == {}
+        assert index.get_retrievers()[0][0] == 1
+        assert index._retrievers_for_top_k(1)[0][0] == 1
+    finally:
+        engine.close()
+
+
+def test_cached_retrieval_waits_for_collection_replacement(
+    tmp_path, capability_settings, monkeypatch, request
+):
+    if _run_in_subprocess(request):
+        return
+    entered, release = Event(), Event()
+    backend = _LocalBackend()
+    monkeypatch.setattr(
+        backend,
+        "get_retrievers",
+        lambda *_args, **_kwargs: (
+            (backend.reset_count, object()),
+            (backend.reset_count, object()),
+        ),
+    )
+    engine = _engine(tmp_path, capability_settings, backend)
+    index = engine.capabilities["index"]
+    observed = _ObservedLock(engine._state.retriever_lock)
+    monkeypatch.setattr(engine._state, "retriever_lock", observed)
+    reset = backend.reset_index
+
+    def reset_index():
+        entered.set()
+        assert release.wait(5)
+        reset()
+
+    def finalize():
+        engine._state.pending_nodes = ([], [])
+        index.indexing.index_finalize_embeddings()
+
+    monkeypatch.setattr(backend, "reset_index", reset_index)
+    try:
+        index.get_retrievers()
+        index._retrievers_for_top_k(1)
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            writing = pool.submit(finalize)
+            try:
+                assert entered.wait(5)
+                reading = pool.submit(index.get_retrievers)
+                assert observed.contended.wait(5)
+            finally:
+                release.set()
+            writing.result(timeout=5)
+            assert reading.result(timeout=5)[0][0] == 1
+        assert index._retrievers_for_top_k(1)[0][0] == 1
+    finally:
+        release.set()
+        engine.close()
+
+
+@pytest.mark.parametrize("top_k", (1, 3))
+def test_reentrant_reset_cannot_publish_retrievers_from_the_old_generation(
+    tmp_path, capability_settings, monkeypatch, top_k
+):
+    backend = _LocalBackend()
+    engine = _engine(tmp_path, capability_settings, backend)
+    index = engine.capabilities["index"]
+    first_call = True
+
+    def get_retrievers(*_args, **_kwargs):
+        nonlocal first_call
+        pair = (backend.reset_count, object()), (backend.reset_count, object())
+        if first_call:
+            first_call = False
+            engine._state.pending_nodes = ([], [])
+            index.indexing.index_finalize_embeddings()
+        return pair
+
+    monkeypatch.setattr(backend, "get_retrievers", get_retrievers)
+    try:
+        with pytest.raises(RuntimeError, match="Index changed during retriever"):
+            index._retrievers_for_top_k(top_k)
+        assert engine._state.retriever_code is None
+        assert index._retrievers_by_top_k == {}
+        assert index._retrievers_for_top_k(top_k)[0][0] == 1
+    finally:
+        engine.close()
+
+
+def test_retriever_initialization_serializes_concurrent_cache_misses(
+    tmp_path, capability_settings, request
+):
+    if _run_in_subprocess(request):
+        return
+    entered, release = Event(), Event()
+    backend = _LocalBackend()
+
+    def create(*args, **kwargs):
+        entered.set()
+        assert release.wait(5)
+        return "code", "docs"
+
+    backend.get_retrievers = Mock(side_effect=create)
+    engine = _engine(tmp_path, capability_settings, backend)
+    index = engine.capabilities["index"]
+    observed = _ObservedLock(engine._state.retriever_lock)
+    engine._state.retriever_lock = observed
+    try:
+        with ThreadPoolExecutor(max_workers=2) as workers:
+            first = workers.submit(index.get_retrievers)
+            try:
+                assert entered.wait(5)
+                second = workers.submit(index.get_retrievers)
+                assert observed.contended.wait(5)
+            finally:
+                release.set()
+            assert (
+                first.result(timeout=5) == second.result(timeout=5) == ("code", "docs")
+            )
+        backend.get_retrievers.assert_called_once()
+    finally:
+        release.set()
+        engine.close()

--- a/tests/test_execution_e2e.py
+++ b/tests/test_execution_e2e.py
@@ -1,0 +1,986 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Offline integration checks using a separately built, discovered extension wheel."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from textwrap import dedent
+from zipfile import ZipFile
+
+import pytest
+import yaml
+
+
+@pytest.fixture(scope="session")
+def installed_execution_extension(tmp_path_factory):
+    """Build once; Python imports this purelib wheel and its real entry-point metadata."""
+    directory = tmp_path_factory.mktemp("execution-extension")
+    project = directory / "project"
+    shutil.copytree(Path(__file__).parent / "fixtures" / "execution_extension", project)
+    wheels = directory / "wheels"
+    wheels.mkdir()
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from setuptools.build_meta import build_wheel; build_wheel(sys.argv[1])",
+            str(wheels),
+        ],
+        cwd=project,
+        env=extension_environment(project),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    (wheel,) = wheels.glob("*.whl")
+    with ZipFile(wheel) as archive:
+        metadata = archive.read("metis_execution_e2e-0.0.1.dist-info/WHEEL").decode()
+        assert "Root-Is-Purelib: true" in metadata
+    return wheel
+
+
+def extension_environment(installation, **extra_env):
+    environment = {
+        name: os.environ[name]
+        for name in (
+            "PATH",
+            "SYSTEMROOT",
+            "WINDIR",
+            "TEMP",
+            "TMP",
+            "TMPDIR",
+            "LANG",
+            "LC_ALL",
+        )
+        if name in os.environ
+    }
+    source = Path(__file__).resolve().parents[1] / "src"
+    environment["PYTHONPATH"] = os.pathsep.join((str(installation), str(source)))
+    environment["PYTHONUNBUFFERED"] = "1"
+    environment.update({name: str(value) for name, value in extra_env.items()})
+    return environment
+
+
+def test_extension_subprocesses_do_not_inherit_credentials(monkeypatch, tmp_path):
+    names = (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "CUSTOM_PRIVATE_VALUE",
+    )
+    for name in names:
+        monkeypatch.setenv(name, "not-a-real-credential")
+    environment = extension_environment(
+        tmp_path / "extension.whl", METIS_E2E_EVENTS=tmp_path / "events.jsonl"
+    )
+    assert not set(names).intersection(environment)
+    assert environment["METIS_E2E_EVENTS"] == str(tmp_path / "events.jsonl")
+
+
+def write_execution_config(path, execution, *, workers=2, **engine_settings):
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "llm_provider": {"name": "metis_e2e", "model": "offline"},
+                "query": {"model": "offline"},
+                "metis_engine": {
+                    "max_workers": workers,
+                    **engine_settings,
+                    "review_checkpoints": False,
+                    "capabilities": {"e2e_resource": {}},
+                    "execution": execution,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def extension_graph(*, fail=False):
+    review = {
+        "depends_on": ["e2e_collect"],
+        "outputs": {
+            name: f"e2e_result.{name}" for name in ("formats", "findings", "sarif")
+        },
+        "nodes": {"e2e_result": {}},
+    }
+    if fail:
+        review["outputs"] = {
+            "formats": "e2e_findings.formats",
+            "findings": "e2e_findings.findings",
+            "sarif": "e2e_sarif_failure.sarif",
+        }
+        review["nodes"] = {"e2e_findings": {}, "e2e_sarif_failure": {}}
+    node_configuration = {
+        "e2e_seed": {"seed": {"value": 3}},
+        "e2e_collect": {"left": {"factor": 1}, "right": {"factor": 2}},
+    }
+    return {
+        "inputs": {"review_request": {"mode": "code"}},
+        "stages": {
+            "review": review,
+            "e2e_collect": {
+                "inputs": {"seed": "e2e_seed.seed"},
+                "outputs": {"total": "join.total"},
+                "nodes": {
+                    "left": {},
+                    "right": {},
+                    "join": {"inputs": {"values": ["right.value", "left.value"]}},
+                },
+            },
+            "e2e_seed": {"outputs": {"seed": "seed.seed"}, "nodes": {"seed": {}}},
+        },
+        "node_configuration": node_configuration,
+    }
+
+
+_ENGINE_SETUP = """
+from importlib import metadata
+import json
+from pathlib import Path
+import sys
+from metis.configuration import load_runtime_config
+from metis.engine import MetisEngine, ExecutionGraphError
+from metis.providers.registry import get_chat_provider
+assert metadata.version("metis-execution-e2e") == "0.0.1"
+assert str(metadata.distribution("metis-execution-e2e").locate_file("")).endswith(".whl/")
+runtime = load_runtime_config(sys.argv[1])
+provider = get_chat_provider(runtime.pop("llm_provider_name"))(runtime.pop("llm_provider"))
+engine = MetisEngine(codebase_path=sys.argv[2], llm_provider=provider, **runtime)
+"""
+
+
+def _run_engine(installation, directory, config, script, *, timeout=20):
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            dedent(_ENGINE_SETUP) + dedent(script),
+            str(config),
+            str(directory),
+        ],
+        cwd=directory,
+        env=extension_environment(
+            installation, METIS_E2E_EVENTS=directory / "events.jsonl"
+        ),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return [
+        json.loads(line)
+        for line in (directory / "events.jsonl").read_text().splitlines()
+    ]
+
+
+@pytest.mark.parametrize(
+    "direct_review", [False, True], ids=["whole-graph", "direct-review"]
+)
+def test_installed_extension_yaml_runs_transitive_stages_and_typed_fanin(
+    installed_execution_extension,
+    tmp_path,
+    direct_review,
+):
+    execution = extension_graph()
+    if direct_review:
+        execution["stages"]["e2e_faults"] = {
+            "outputs": {"value": "good.value"},
+            "nodes": {"good": {}},
+        }
+    config = write_execution_config(tmp_path / "metis.yaml", execution)
+    invocation = (
+        'engine.execute_review("file", target="supplied.txt")'
+        if direct_review
+        else "engine.execute_graph().outputs"
+    )
+    events = _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        f"""
+try:
+    output = {invocation}
+    Path(sys.argv[2], "artifact.json").write_text(json.dumps(output), encoding="utf-8")
+finally:
+    engine.close()
+""",
+    )
+    output = json.loads((tmp_path / "artifact.json").read_text())
+    review = output if direct_review else output["review"]
+    assert (
+        review["sarif"]["runs"][0]["results"][0]["message"]["text"]
+        == "Inert extension fixture"
+    )
+    names = [item["event"] for item in events]
+    assert names.count("stage_contract") == 1
+    assert names.index("seed") < names.index("join") < names.index("review")
+    assert next(item["values"] for item in events if item["event"] == "join") == [6, 3]
+    assert "good" not in names
+    assert next(item["target"] for item in events if item["event"] == "review") == (
+        "supplied.txt" if direct_review else None
+    )
+    if not direct_review:
+        assert output["e2e_collect"] == {"total": 9}
+
+
+def test_installed_extension_keeps_partial_outputs_in_public_error(
+    installed_execution_extension,
+    tmp_path,
+):
+    config = write_execution_config(tmp_path / "metis.yaml", extension_graph(fail=True))
+    events = _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+try:
+    try:
+        engine.execute_graph()
+    except ExecutionGraphError as failure:
+        assert failure.result.status.value == "error"
+        assert any(item.code == "e2e.failure" for item in failure.result.diagnostics)
+        Path(sys.argv[2], "partial.json").write_text(json.dumps(failure.result.outputs), encoding="utf-8")
+    else:
+        raise AssertionError("The failing extension was reported as successful")
+finally:
+    engine.close()
+""",
+    )
+    output = json.loads((tmp_path / "partial.json").read_text())
+    assert output["e2e_collect"] == {"total": 9}
+    assert output["review"]["findings"]["reviews"][0]["reviews"][0]["id"] == "e2e-1"
+    assert "sarif" not in output["review"]
+    assert any(event["event"] == "failure" for event in events)
+
+
+@pytest.mark.parametrize("boundary", ("input", "output"))
+def test_installed_stage_constraints_reject_invalid_values_and_keep_valid_outputs(
+    installed_execution_extension, tmp_path, boundary
+):
+    execution = extension_graph()
+    execution["stages"]["e2e_collect"]["outputs"]["independent"] = "left.value"
+    if boundary == "input":
+        execution["node_configuration"]["e2e_seed"]["seed"]["value"] = -1
+    else:
+        execution["node_configuration"]["e2e_collect"]["right"]["factor"] = -2
+    config = write_execution_config(tmp_path / "metis.yaml", execution)
+    events = _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        f"""
+try:
+    try:
+        engine.execute_graph()
+    except ExecutionGraphError as failure:
+        assert failure.result.status.value == "error"
+        assert any(item.code == "execution.stage_{boundary}_invalid" for item in failure.result.diagnostics)
+        Path(sys.argv[2], "partial.json").write_text(json.dumps(failure.result.outputs), encoding="utf-8")
+    else:
+        raise AssertionError("The invalid stage value was accepted")
+finally:
+    engine.close()
+""",
+    )
+    output = json.loads((tmp_path / "partial.json").read_text())
+    names = [item["event"] for item in events]
+    assert "review" not in names
+    if boundary == "input":
+        assert output == {"e2e_seed": {"seed": -1}}
+        assert "multiply" not in names
+    else:
+        assert output == {
+            "e2e_seed": {"seed": 3},
+            "e2e_collect": {"independent": 3},
+        }
+        assert "join" in names
+
+
+def test_installed_extension_close_cancels_queued_work_before_capability_cleanup(
+    installed_execution_extension,
+    tmp_path,
+):
+    config = write_execution_config(
+        tmp_path / "metis.yaml",
+        {
+            "stages": {
+                "e2e_wait": {
+                    "outputs": {"values": "wait.values"},
+                    "nodes": {"wait": {"capabilities": ["e2e_resource"]}},
+                }
+            }
+        },
+        workers=1,
+    )
+    events = _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+from concurrent.futures import CancelledError
+from threading import Thread
+from time import monotonic, sleep
+outcomes = []
+def execute():
+    try:
+        outcomes.append(engine.execute_graph())
+    except BaseException as error:
+        outcomes.append(error)
+thread = Thread(target=execute)
+thread.start()
+events = Path(sys.argv[2], "events.jsonl")
+try:
+    deadline = monotonic() + 5
+    while not events.exists() or '"event": "job_started"' not in events.read_text():
+        assert not outcomes, outcomes
+        assert monotonic() < deadline, "Worker did not start"
+        sleep(0.01)
+    engine.close()
+    thread.join(timeout=5)
+    assert not thread.is_alive(), "Close left an execution thread alive"
+    assert len(outcomes) == 1 and isinstance(outcomes[0], CancelledError), outcomes
+    try:
+        engine.execute_graph()
+    except RuntimeError as error:
+        assert "closed" in str(error).lower()
+    else:
+        raise AssertionError("Execution after close was accepted")
+finally:
+    engine.close()
+    thread.join(timeout=5)
+""",
+        timeout=20,
+    )
+    names = [item["event"] for item in events]
+    assert names.count("job_started") == 1
+    assert names.count("job_finished") == 1
+    assert names.count("resource_closed") == 1
+    assert names.index("job_finished") < names.index("resource_closed")
+
+
+def test_completed_execution_context_can_close_public_engine(
+    installed_execution_extension,
+    tmp_path,
+):
+    config = write_execution_config(tmp_path / "metis.yaml", extension_graph())
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+from contextvars import copy_context
+saved = []
+def capture(event):
+    if event.get("event") == "execution_node_start":
+        saved.append(copy_context())
+try:
+    engine.execute_graph(callbacks={"progress_callback": capture})
+    assert saved, "No node callback was observed"
+    saved[-1].run(engine.close)
+finally:
+    engine.close()
+""",
+    )
+
+
+def test_nested_public_engine_rejects_closing_active_ancestor(
+    installed_execution_extension,
+    tmp_path,
+):
+    config = write_execution_config(tmp_path / "metis.yaml", extension_graph())
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+inner = MetisEngine(codebase_path=sys.argv[2], llm_provider=provider, **runtime)
+seen = []
+def close_ancestor(event):
+    if event.get("event") == "execution_stage_start" and not seen:
+        try:
+            engine.close()
+        except RuntimeError as error:
+            assert "active execution" in str(error)
+            seen.append("rejected")
+        else:
+            raise AssertionError("Nested callback closed its active ancestor")
+def execute_inner(event):
+    if event.get("event") == "execution_node_start" and event.get("node") == "seed":
+        assert inner.execute_graph(callbacks={"progress_callback": close_ancestor}).status.value == "ok"
+try:
+    assert engine.execute_graph(callbacks={"progress_callback": execute_inner}).status.value == "ok"
+    assert seen == ["rejected"]
+finally:
+    inner.close()
+    engine.close()
+""",
+    )
+
+
+def test_installed_extension_keeps_native_partial_values_in_public_error(
+    installed_execution_extension, tmp_path
+):
+    config = write_execution_config(
+        tmp_path / "metis.yaml",
+        {
+            "stages": {
+                "e2e_faults": {
+                    "outputs": {"native": "native.value", "failed": "bad.value"},
+                    "nodes": {"native": {}, "bad": {}},
+                }
+            }
+        },
+    )
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+from metis_e2e_extension import NativePayload
+try:
+    try:
+        engine.execute_graph()
+    except ExecutionGraphError as failure:
+        assert failure.result.status.value == "error"
+        assert any(item.code == "e2e.failure" for item in failure.result.diagnostics)
+        partial = failure.result.outputs["e2e_faults"]
+        assert isinstance(partial["native"], NativePayload)
+        assert partial["native"].data == bytes([255])
+        assert "failed" not in partial
+    else:
+        raise AssertionError("Native partial output hid the execution failure")
+finally:
+    engine.close()
+""",
+    )
+
+
+def test_public_engine_close_during_final_stage_callback_propagates_cancellation(
+    installed_execution_extension, tmp_path
+):
+    config = write_execution_config(tmp_path / "metis.yaml", extension_graph())
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+from concurrent.futures import CancelledError
+from threading import Thread
+closers = []
+errors = []
+def close():
+    try:
+        engine.close()
+    except BaseException as error:
+        errors.append(error)
+def progress(event):
+    if event.get("event") == "execution_stage_end" and event.get("stage") == "review":
+        # Observe the real cancellation event to force shutdown before the callback returns.
+        cancellation, = engine.execution._active_executions
+        closer = Thread(target=close)
+        closers.append(closer)
+        closer.start()
+        assert cancellation.wait(5), "Shutdown never cancelled the active execution"
+try:
+    try:
+        engine.execute_graph(callbacks={"progress_callback": progress})
+    except CancelledError:
+        pass
+    else:
+        raise AssertionError("Cancellation during the final stage callback was lost")
+finally:
+    for closer in closers:
+        closer.join(timeout=5)
+        assert not closer.is_alive(), "Shutdown left a thread alive"
+    engine.close()
+assert len(closers) == 1 and not errors, errors
+""",
+    )
+
+
+_POOL_GRAPH = {
+    "stages": {
+        "e2e_pool": {
+            "outputs": {"left": "left.values", "right": "right.values"},
+            "nodes": {
+                "left": {"capabilities": ["e2e_resource"]},
+                "right": {"capabilities": ["e2e_resource"]},
+            },
+        }
+    }
+}
+
+
+@pytest.mark.parametrize("workers,nodes,executions", [(1, 3, 2), (4, 1, 3), (2, 2, 1)])
+def test_engine_bounds_jobs_nodes_and_graphs_with_shared_extension_capability(
+    installed_execution_extension, tmp_path, workers, nodes, executions
+):
+    config = write_execution_config(
+        tmp_path / "metis.yaml",
+        _POOL_GRAPH,
+        workers=workers,
+        max_active_nodes=nodes,
+        max_concurrent_executions=executions,
+    )
+    events = _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from metis_e2e_extension import execution_tag
+resource = engine.capabilities["e2e_resource"]
+resource.finish_work.clear()
+graphs = {"active": 0, "peak": 0, "started": 0}
+start = Barrier(9, timeout=5)
+def progress(event):
+    with resource.condition:
+        if event["event"] == "execution_stage_start":
+            graphs["active"] += 1
+            graphs["started"] += 1
+            graphs["peak"] = max(graphs["peak"], graphs["active"])
+        elif event["event"] == "execution_stage_end":
+            graphs["active"] -= 1
+        resource.condition.notify_all()
+def execute(tag):
+    token = execution_tag.set(tag)
+    try:
+        start.wait()
+        return engine.execute_graph(callbacks={"progress_callback": progress})
+    finally:
+        execution_tag.reset(token)
+try:
+    with ThreadPoolExecutor(max_workers=8) as callers:
+        futures = [callers.submit(execute, tag) for tag in range(8)]
+        try:
+            start.wait()
+            expected_nodes = min(runtime["max_active_nodes"], runtime["max_concurrent_executions"] * 2)
+            expected_jobs = min(runtime["max_workers"], expected_nodes * 3)
+            with resource.condition:
+                assert resource.condition.wait_for(
+                    lambda: resource.peak["node"] >= expected_nodes
+                    and resource.peak["job"] >= expected_jobs
+                    and graphs["started"] >= runtime["max_concurrent_executions"], timeout=5
+                ), (resource.peak, graphs)
+        finally:
+            resource.finish_work.set()
+        for future in futures:
+            result = future.result(timeout=5)
+            assert result.status.value == "ok"
+            assert set(result.outputs) == {"e2e_pool"}
+            assert {name: sorted(values) for name, values in result.outputs["e2e_pool"].items()} == {"left": [0, 1, 2], "right": [0, 1, 2]}
+    assert graphs == {"active": 0, "peak": runtime["max_concurrent_executions"], "started": 8}, graphs
+    assert resource.peak == {"node": expected_nodes, "job": expected_jobs}, resource.peak
+    assert resource.started == {"node": 16, "job": 48}, resource.started
+    assert resource.active == {"node": 0, "job": 0}
+    assert resource.tags == {"node": set(range(8)), "job": set(range(8))}, resource.tags
+    assert len(resource.threads["node"]) <= runtime["max_active_nodes"]
+    assert len(resource.threads["job"]) <= runtime["max_workers"]
+    assert resource.threads["node"].isdisjoint(resource.threads["job"])
+finally:
+    resource.finish_work.set()
+    engine.close()
+assert resource.closed
+""",
+    )
+    names = [event["event"] for event in events]
+    assert names.count("resource_created") == names.count("resource_closed") == 1
+
+
+def test_engine_close_drains_active_work_and_rejects_waiting_graphs(
+    installed_execution_extension, tmp_path
+):
+    config = write_execution_config(
+        tmp_path / "metis.yaml",
+        _POOL_GRAPH,
+        workers=1,
+        max_active_nodes=1,
+        max_concurrent_executions=1,
+    )
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+from concurrent.futures import CancelledError, ThreadPoolExecutor
+from threading import Event, Thread, current_thread, enumerate as threads, get_ident
+resource = engine.capabilities["e2e_resource"]
+job_started = Event()
+release_job = Event()
+waiters_ready = Event()
+waiting = set()
+close_errors = []
+condition = engine.execution._condition
+original_wait = condition.wait
+
+def observed_wait(timeout=None):
+    # wait_for holds the real Condition lock here. Close cannot acquire it
+    # until this caller enters the original wait and releases the lock.
+    if current_thread().name.startswith("graph-caller"):
+        waiting.add(get_ident())
+        if len(waiting) == 3:
+            waiters_ready.set()
+    return original_wait(timeout)
+
+condition.wait = observed_wait
+
+def hold_job():
+    job_started.set()
+    assert release_job.wait(5), "Active job was never released"
+
+resource.on_work = hold_job
+
+def execute():
+    try:
+        return engine.execute_graph()
+    except (CancelledError, RuntimeError) as error:
+        return error
+
+def close():
+    try:
+        engine.close()
+    except BaseException as error:
+        close_errors.append(error)
+
+closer = Thread(target=close)
+try:
+    with ThreadPoolExecutor(max_workers=4, thread_name_prefix="graph-caller") as callers:
+        active = callers.submit(execute)
+        try:
+            assert job_started.wait(5), "Active graph never reached its job"
+            queued = [callers.submit(execute) for _ in range(3)]
+            assert waiters_ready.wait(5), "Three callers never waited for admission"
+            closer.start()
+            outcomes = [future.result(timeout=5) for future in queued]
+            assert all(isinstance(error, RuntimeError) and "closed" in str(error) for error in outcomes), outcomes
+            assert not active.done(), "Active graph returned before its job drained"
+            assert closer.is_alive(), "Close returned before the active job drained"
+            assert not resource.closed, "Capability closed while its job remained active"
+        finally:
+            release_job.set()
+        assert isinstance(active.result(timeout=5), CancelledError)
+    closer.join(timeout=5)
+    assert not closer.is_alive(), "Close did not finish after its job drained"
+    assert not close_errors, close_errors
+    assert resource.started == {"node": 1, "job": 1}, resource.started
+    assert resource.active == {"node": 0, "job": 0}
+    assert resource.closed
+    assert not [thread.name for thread in threads() if thread.name.startswith(("metis-node", "metis_"))]
+finally:
+    release_job.set()
+    if closer.ident is not None:
+        closer.join(timeout=5)
+        assert not closer.is_alive(), "Shutdown left its closer thread alive"
+    condition.wait = original_wait
+    engine.close()
+""",
+    )
+
+
+def test_engine_serializes_progress_under_observed_node_contention(
+    installed_execution_extension, tmp_path
+):
+    config = write_execution_config(
+        tmp_path / "metis.yaml",
+        _POOL_GRAPH,
+        workers=1,
+        max_active_nodes=2,
+        max_concurrent_executions=1,
+    )
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
+import metis.engine.stages.service as service
+entered = Event()
+attempted = Event()
+overlap = Event()
+release_callback = Event()
+in_callback = Lock()
+seen = []
+serialized = service.serialized_progress_callback
+
+class ObservedLock:
+    def __init__(self, lock):
+        self.lock = lock
+
+    def __enter__(self):
+        if not self.lock.acquire(blocking=False):
+            attempted.set()
+            self.lock.acquire()
+        return self
+
+    def __exit__(self, *_args):
+        self.lock.release()
+
+def observe_serialization(callback):
+    wrapped = serialized(callback)
+    if wrapped is not None:
+        # Observe the actual engine wrapper's lock without adding serialization.
+        for name, cell in zip(wrapped.__code__.co_freevars, wrapped.__closure__ or ()):
+            if name == "lock":
+                cell.cell_contents = ObservedLock(cell.cell_contents)
+    return wrapped
+
+service.serialized_progress_callback = observe_serialization
+
+def progress(event):
+    if event["event"] != "execution_node_start":
+        return
+    # A failed probe reports overlap immediately; this callback never waits
+    # for its own lock and therefore cannot supply missing engine serialization.
+    if not in_callback.acquire(blocking=False):
+        overlap.set()
+        attempted.set()
+        raise AssertionError("Engine delivered overlapping progress callbacks")
+    try:
+        seen.append(event["node"])
+        if len(seen) == 1:
+            entered.set()
+            assert release_callback.wait(5), "First callback was never released"
+    finally:
+        in_callback.release()
+
+try:
+    with ThreadPoolExecutor(max_workers=1) as callers:
+        result = callers.submit(engine.execute_graph, callbacks={"progress_callback": progress})
+        try:
+            assert entered.wait(5), "First node never delivered progress"
+            assert attempted.wait(5), "Second node never contended for progress delivery"
+            assert not overlap.is_set(), "Progress callbacks overlapped"
+            assert not result.done(), "Graph returned while its callback was active"
+        finally:
+            release_callback.set()
+        assert result.result(timeout=5).status.value == "ok"
+    assert sorted(seen) == ["left", "right"], seen
+finally:
+    release_callback.set()
+    service.serialized_progress_callback = serialized
+    engine.close()
+""",
+    )
+
+
+@pytest.mark.parametrize("location", ["stage", "node", "job"])
+def test_engine_rejects_nested_execution_before_waiting_for_capacity(
+    installed_execution_extension, tmp_path, location
+):
+    config = write_execution_config(
+        tmp_path / "metis.yaml",
+        _POOL_GRAPH,
+        workers=1,
+        max_active_nodes=1,
+        max_concurrent_executions=1,
+    )
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        f"""
+from threading import Lock
+resource = engine.capabilities["e2e_resource"]
+seen = []
+lock = Lock()
+def nested():
+    try:
+        engine.execute_graph()
+    except RuntimeError as error:
+        assert "active execution" in str(error), error
+        with lock:
+            seen.append(str(error))
+    else:
+        raise AssertionError("Nested execution was admitted")
+def progress(event):
+    if event["event"] == "execution_{location}_start":
+        nested()
+if {location!r} == "job":
+    resource.on_work = nested
+try:
+    for _ in range(2):
+        assert engine.execute_graph(callbacks={{"progress_callback": progress}}).status.value == "ok"
+    assert len(seen) == {{"stage": 2, "node": 4, "job": 12}}[{location!r}], seen
+finally:
+    engine.close()
+""",
+    )
+
+
+def test_cancelling_one_graph_keeps_peer_work_and_shared_pools_alive(
+    installed_execution_extension, tmp_path
+):
+    config = write_execution_config(
+        tmp_path / "metis.yaml",
+        _POOL_GRAPH,
+        workers=2,
+        max_active_nodes=4,
+        max_concurrent_executions=2,
+    )
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        """
+from concurrent.futures import CancelledError, ThreadPoolExecutor
+from metis_e2e_extension import execution_tag
+resource = engine.capabilities["e2e_resource"]
+resource.finish_work.clear()
+def abort(event):
+    if event["event"] == "execution_node_start":
+        raise CancelledError("caller cancelled this graph")
+def execute(tag, callbacks=None):
+    token = execution_tag.set(tag)
+    try:
+        return engine.execute_graph(callbacks=callbacks)
+    finally:
+        execution_tag.reset(token)
+try:
+    with ThreadPoolExecutor(max_workers=2) as callers:
+        peer = callers.submit(execute, 1)
+        try:
+            with resource.condition:
+                assert resource.condition.wait_for(lambda: resource.active["job"] == 2, timeout=5)
+            cancelled = callers.submit(execute, 0, {"progress_callback": abort})
+            try:
+                cancelled.result(timeout=5)
+            except CancelledError:
+                pass
+            else:
+                raise AssertionError("Cancellation was swallowed")
+            assert not peer.done()
+            assert not resource.closed
+        finally:
+            resource.finish_work.set()
+        assert peer.result(timeout=5).status.value == "ok"
+    assert execute(2).status.value == "ok"
+    assert resource.tags == {"node": {1, 2}, "job": {1, 2}}, resource.tags
+finally:
+    resource.finish_work.set()
+    engine.close()
+""",
+    )
+
+
+@pytest.mark.parametrize("scheduler_fails_first", [False, True])
+def test_engine_close_retries_interruptions_before_closing_capabilities(
+    installed_execution_extension, tmp_path, scheduler_fails_first
+):
+    config = write_execution_config(
+        tmp_path / "metis.yaml",
+        _POOL_GRAPH,
+        workers=1,
+        max_active_nodes=1,
+        max_concurrent_executions=1,
+    )
+    _run_engine(
+        installed_execution_extension,
+        tmp_path,
+        config,
+        f"scheduler_fails_first = {scheduler_fails_first!r}\n"
+        + """
+from concurrent.futures import CancelledError, ThreadPoolExecutor
+from threading import Event, get_ident, enumerate as threads
+resource = engine.capabilities["e2e_resource"]
+callback_entered, release_callback = Event(), Event()
+close_state_changed, close_finished = Event(), Event()
+condition = engine.execution._condition
+scheduler = engine.execution._scheduler
+nodes = engine.execution._node_executor
+original_wait = condition.wait
+original_scheduler_close = scheduler.close
+original_node_shutdown = nodes.shutdown
+closer_id = None
+attempts = {"scheduler": 0, "wait": 0, "nodes": 0}
+first_error = KeyboardInterrupt("first shutdown interruption")
+close_errors = []
+
+def interrupt_scheduler_close():
+    attempts["scheduler"] += 1
+    if scheduler_fails_first and attempts["scheduler"] == 1:
+        raise first_error
+    return original_scheduler_close()
+
+def interrupt_wait(timeout=None):
+    if get_ident() == closer_id:
+        attempts["wait"] += 1
+        if attempts["wait"] == 1 and not scheduler_fails_first:
+            raise first_error
+        if attempts["wait"] <= 2:
+            raise SystemExit("later graph-drain interruption")
+        close_state_changed.set()
+    return original_wait(timeout)
+
+def interrupt_node_shutdown(**kwargs):
+    attempts["nodes"] += 1
+    if attempts["nodes"] <= 2:
+        raise RuntimeError("later worker-drain interruption")
+    return original_node_shutdown(**kwargs)
+
+def close():
+    global closer_id
+    closer_id = get_ident()
+    try:
+        engine.close()
+    except BaseException as error:
+        close_errors.append(error)
+    finally:
+        close_finished.set()
+        close_state_changed.set()
+
+def progress(event):
+    if event["event"] == "execution_stage_end":
+        callback_entered.set()
+        assert release_callback.wait(5), "Callback was never released"
+        resource.use()
+
+try:
+    with ThreadPoolExecutor(max_workers=2) as callers:
+        active = callers.submit(engine.execute_graph, callbacks={"progress_callback": progress})
+        closing = None
+        try:
+            assert callback_entered.wait(5)
+            scheduler.close = interrupt_scheduler_close
+            condition.wait = interrupt_wait
+            nodes.shutdown = interrupt_node_shutdown
+            closing = callers.submit(close)
+            assert close_state_changed.wait(5), "Close neither retried nor returned"
+            resource.use()
+            assert not close_finished.is_set(), "Close returned before its graph drained"
+            assert not active.done()
+            assert len(engine.execution._active_executions) == 1
+            assert attempts["wait"] >= 3
+            assert attempts["nodes"] == 0
+        finally:
+            release_callback.set()
+            try:
+                active.result(timeout=5)
+            except CancelledError:
+                pass
+            if closing is not None:
+                closing.result(timeout=5)
+    assert close_errors == [first_error], close_errors
+    assert attempts["nodes"] == 3
+    assert not engine.execution._active_executions
+    assert resource.closed
+    assert not [thread.name for thread in threads() if thread.name.startswith(("metis-node", "metis_"))]
+finally:
+    release_callback.set()
+    scheduler.close = original_scheduler_close
+    condition.wait = original_wait
+    nodes.shutdown = original_node_shutdown
+    engine.close()
+""",
+        timeout=20,
+    )

--- a/tests/test_execution_graph.py
+++ b/tests/test_execution_graph.py
@@ -2,17 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import threading
+from collections import UserString
+from collections.abc import Mapping
+from collections.abc import Sequence
+from concurrent.futures import CancelledError
+from dataclasses import dataclass
 import time
 from dataclasses import replace
 from typing import Any
+from typing import Annotated
 from typing import Literal
+from typing import NewType
+from typing import Tuple
 from unittest.mock import Mock
 from unittest.mock import sentinel
 
 import pytest
 from pydantic import BaseModel
+from pydantic import AfterValidator
 from pydantic import ConfigDict
 from pydantic import ValidationError
+from pydantic import Field
+from pydantic import PrivateAttr
+from pydantic import field_validator
 
 from metis.configuration import load_execution_config
 from metis.engine.codegraph import CodeGraph
@@ -50,8 +62,6 @@ from metis.execution_nodes import NodeRegistration
 from metis.execution_nodes import NodeResult
 from metis.execution_nodes import NodeRuntime
 from metis.execution_nodes import ReviewCommand
-from metis.execution_stages import StageContract
-from metis.execution_stages import StageRegistration
 from metis.runtime_settings import TriageOptions
 
 
@@ -166,28 +176,31 @@ def test_simple_review_does_not_require_codegraph() -> None:
     _service(ExecutionConfiguration.model_validate(raw))
 
 
-def test_reachability_requires_initialized_codegraph() -> None:
-    with pytest.raises(ValueError, match="CodeGraph from Initialize"):
-        ExecutionConfiguration.model_validate(
-            {
-                "inputs": {"review_request": {"mode": "code"}},
-                "stages": {
-                    "review": {
-                        "nodes": {"reachability": {}, "result": {"formats": ["sarif"]}}
-                    }
-                },
-            }
-        )
+def test_reachability_requires_typed_codegraph_input() -> None:
+    configuration = ExecutionConfiguration.model_validate(
+        {
+            "inputs": {"review_request": {"mode": "code"}},
+            "stages": {
+                "review": {
+                    "nodes": {"reachability": {}, "result": {"formats": ["sarif"]}}
+                }
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="unbound inputs: codegraph"):
+        _service(configuration)
 
 
-def test_reachability_rejects_review_time_codegraph_binding() -> None:
+def test_reachability_rejects_unavailable_codegraph_producer() -> None:
     raw = _configuration().model_dump(mode="json")
     raw["stages"]["review"]["nodes"]["reachability"] = {
         "inputs": {"codegraph": "producer.codegraph"}
     }
+    configuration = ExecutionConfiguration.model_validate(raw)
 
-    with pytest.raises(ValueError, match="Review stage CodeGraph input"):
-        ExecutionConfiguration.model_validate(raw)
+    with pytest.raises(ValueError, match="unavailable nodes: producer"):
+        _service(configuration)
 
 
 def test_reachability_accepts_explicit_review_stage_codegraph_binding() -> None:
@@ -199,12 +212,28 @@ def test_reachability_accepts_explicit_review_stage_codegraph_binding() -> None:
     _service(ExecutionConfiguration.model_validate(raw))
 
 
-def test_profiled_codegraph_requires_profile_dependency() -> None:
+def test_profiled_codegraph_infers_required_profile_dependency() -> None:
     raw = _configuration().model_dump(mode="json")
-    raw["stages"]["initialize"]["nodes"]["compilation_profile"] = {}
+    raw["stages"]["initialize"]["nodes"]["custom_profile"] = {}
+    profile = NodeRegistration(
+        "custom_profile",
+        "initialize",
+        EmptyNodeConfiguration,
+        {},
+        {"profiled_source": ProfiledSourceReference},
+        lambda _invocation: NodeResult({}, ExecutionStatus.ERROR),
+    )
+    service, calls = _service(
+        ExecutionConfiguration.model_validate(raw),
+        extra_registrations=(profile,),
+    )
+    try:
+        result = service.execute_initialize()
 
-    with pytest.raises(ValueError, match="must depend on compilation_profile"):
-        ExecutionConfiguration.model_validate(raw)
+        assert result.status is ExecutionStatus.ERROR
+        assert "codegraph" not in calls
+    finally:
+        service.close()
 
 
 def test_finding_dedup_combines_producers_before_result() -> None:
@@ -710,6 +739,8 @@ def _service(
         llm_provider=Mock(count_tokens=lambda _text, model=None: 1),
         llama_query_model="test",
         max_workers=2,
+        max_active_nodes=2,
+        max_concurrent_executions=2,
         max_token_length=1000,
         chat_model_kwargs={},
     )
@@ -1435,6 +1466,8 @@ def test_explicit_input_resolves_an_implicit_binding_ambiguity():
     ("bindings", "source_annotation", "target_annotation", "value", "expected"),
     (
         ({}, Any, Any, sentinel.value, sentinel.value),
+        ({}, tuple[str, ...], tuple[str, ...], (), ()),
+        ({"values": "$inputs.values"}, tuple[str, ...], tuple[str, ...], (), ()),
         (
             {},
             tuple[str, ...],
@@ -1709,60 +1742,6 @@ class _SharedEntryPoint:
         )
 
 
-class _StageEntryPoints:
-    def __init__(self, entries: tuple[object, ...]) -> None:
-        self._entries = entries
-
-    def select(self, *, group: str) -> tuple[object, ...]:
-        return self._entries if group == "metis.execution_stages" else ()
-
-
-class _AuditStageEntryPoint:
-    name = "audit"
-
-    def load(self) -> StageRegistration:
-        return StageRegistration(
-            "audit",
-            StageContract({}, required_outputs={"value": str}),
-        )
-
-
-class _AuditNodeEntryPoint:
-    name = "audit.audit_node"
-
-    def load(self) -> NodeRegistration:
-        return NodeRegistration(
-            "audit_node",
-            "audit",
-            EmptyNodeConfiguration,
-            {},
-            {"value": str},
-            lambda _invocation: NodeResult({"value": "private"}),
-        )
-
-
-def test_external_stage_registration_runs_generic_stage(monkeypatch):
-    monkeypatch.setattr(
-        "metis.engine.stages.catalog.metadata.entry_points",
-        lambda: _StageEntryPoints((_AuditStageEntryPoint(),)),
-    )
-    configuration = ExecutionConfiguration.model_validate(
-        {
-            "stages": {
-                "audit": {
-                    "outputs": {"value": "audit_node.value"},
-                    "nodes": {"audit_node": {}},
-                }
-            }
-        }
-    )
-    service, _calls = _service(configuration, entry_points=(_AuditNodeEntryPoint(),))
-
-    result = service.execute_graph()
-
-    assert result.outputs == {"audit": {"value": "private"}}
-
-
 @pytest.mark.parametrize(
     ("node_name", "entry_points"),
     (
@@ -1859,3 +1838,772 @@ def test_private_registration_must_match_selected_stage():
     with pytest.raises(ValueError, match="not registered for stage 'review'"):
         _service(configuration, entry_points=(entry_point,))
     assert loads == []
+
+
+_PortUserId = NewType("_PortUserId", int)
+_PortOtherId = NewType("_PortOtherId", int)
+_PortStaffId = NewType("_PortStaffId", _PortUserId)
+
+
+type _OptionalIntegerPort = int | None
+type _OptionalCollectionPort = tuple[int, ...] | None
+
+
+class _ExternalPortResource:
+    pass
+
+
+@dataclass
+class _ExternalPortPayload:
+    value: _ExternalPortResource
+
+
+@pytest.mark.parametrize(
+    ("source_annotation", "target_annotation", "value"),
+    (
+        (Literal[1, None], int | None, None),
+        (_PortUserId, _PortUserId, _PortUserId(3)),
+        (_PortUserId, int, _PortUserId(3)),
+        (_PortStaffId, _PortUserId, _PortStaffId(_PortUserId(3))),
+        (list[_PortUserId], list[_PortUserId], [_PortUserId(3)]),
+        (list[_PortUserId], list[int], [_PortUserId(3)]),
+        (_OptionalIntegerPort, int | None, None),
+        (type(None), Literal[None], None),
+        (dict[str, int], Mapping[str, int], {"value": 3}),
+        (list[int], Sequence[int], [3]),
+        (tuple[int, ...], Sequence[int], (1, 2)),
+        (tuple[int, ...], tuple[int, ...], ()),
+        (tuple[int, str], Sequence[object], (1, "two")),
+        (tuple[int, str], tuple[object, ...], (1, "two")),
+        (tuple[()], tuple[()], ()),
+        (Tuple[()], tuple[()], ()),
+        (tuple[()], Tuple[()], ()),
+        (Tuple[()], Sequence[int], ()),
+        (tuple, tuple, (1, "two")),
+        (Tuple, tuple, (1, "two")),
+        (tuple, Tuple, (1, "two")),
+        (
+            Annotated[_ExternalPortPayload, "external"],
+            _ExternalPortPayload | None,
+            _ExternalPortPayload(_ExternalPortResource()),
+        ),
+        (
+            list[_ExternalPortPayload],
+            Sequence[_ExternalPortPayload],
+            [_ExternalPortPayload(_ExternalPortResource())],
+        ),
+    ),
+)
+def test_typed_node_ports_round_trip_without_coercion(
+    source_annotation, target_annotation, value
+):
+    registrations = (
+        NodeRegistration(
+            "source",
+            "initialize",
+            EmptyNodeConfiguration,
+            {},
+            {"value": source_annotation},
+            lambda _invocation: NodeResult({"value": value}),
+        ),
+        NodeRegistration(
+            "consumer",
+            "initialize",
+            EmptyNodeConfiguration,
+            {"value": target_annotation},
+            {"value": target_annotation},
+            lambda invocation: NodeResult(dict(invocation.inputs)),
+        ),
+    )
+    stage = StageConfiguration.model_validate(
+        {
+            "nodes": {"source": {}, "consumer": {"inputs": {"value": "source.value"}}},
+            "outputs": {"value": "consumer.value"},
+        }
+    )
+
+    result = run_stage(
+        "initialize", _compile(registrations, stage), _node_context(), {}
+    )
+
+    assert result.status is ExecutionStatus.OK
+    assert result.outputs["value"] == value
+
+
+@pytest.mark.parametrize("explicit", (False, True))
+@pytest.mark.parametrize(
+    "annotation,source_annotation,value",
+    (
+        (tuple[int, ...] | None, int, 3),
+        (Annotated[tuple[int, ...] | None, "values"], int, 3),
+        (tuple[int, ...] | Literal[None], int, 3),
+        (_OptionalCollectionPort, int, 3),
+        (tuple[None, ...], None, None),
+        (tuple[type(None), ...], type(None), None),
+        (tuple[None, ...] | None, type(None), None),
+    ),
+)
+def test_homogeneous_tuple_collects_producer_values(
+    annotation, source_annotation, value, explicit
+):
+    registrations = (
+        NodeRegistration(
+            "source",
+            "initialize",
+            EmptyNodeConfiguration,
+            {},
+            {"value": source_annotation},
+            lambda _invocation: NodeResult({"value": value}),
+        ),
+        NodeRegistration(
+            "consumer",
+            "initialize",
+            EmptyNodeConfiguration,
+            {"value": annotation},
+            {"value": annotation},
+            lambda invocation: NodeResult(dict(invocation.inputs)),
+        ),
+    )
+    stage = StageConfiguration.model_validate(
+        {
+            "nodes": {
+                "source": {},
+                "consumer": {"inputs": {"value": ["source.value"]}} if explicit else {},
+            },
+            "outputs": {"value": "consumer.value"},
+        }
+    )
+
+    result = run_stage(
+        "initialize", _compile(registrations, stage), _node_context(), {}
+    )
+
+    assert result.status is ExecutionStatus.OK
+    assert result.outputs["value"] == (value,)
+
+
+@pytest.mark.parametrize("annotation", (str, tuple[int, str], tuple[()]))
+def test_even_empty_multiple_source_binding_requires_homogeneous_tuple(annotation):
+    registration = NodeRegistration(
+        "consumer",
+        "initialize",
+        EmptyNodeConfiguration,
+        {"value": annotation},
+        {},
+        lambda _invocation: NodeResult({}),
+    )
+    stage = StageConfiguration.model_validate(
+        {"nodes": {"consumer": {"inputs": {"value": []}}}}
+    )
+
+    with pytest.raises(ValueError, match="does not accept multiple sources"):
+        _compile((registration,), stage)
+
+
+@pytest.mark.parametrize(
+    "annotation", (type(None), Literal[None], Annotated[int | None, "optional"])
+)
+@pytest.mark.parametrize("explicit", (False, True))
+def test_absent_optional_stage_input_is_none_for_explicit_and_implicit_binding(
+    annotation, explicit
+):
+    registration = NodeRegistration(
+        "consumer",
+        "initialize",
+        EmptyNodeConfiguration,
+        {"value": annotation},
+        {"value": annotation},
+        lambda invocation: NodeResult(dict(invocation.inputs)),
+    )
+    stage = StageConfiguration.model_validate(
+        {
+            "nodes": {
+                "consumer": {"inputs": {"value": "$inputs.value"}} if explicit else {}
+            }
+        }
+    )
+    plan = compile_stage(
+        NodeCatalog((registration,), ()), "initialize", stage, {}, {"value": annotation}
+    )
+
+    result = run_stage("initialize", plan, _node_context(), {})
+
+    assert result.status is ExecutionStatus.OK
+    assert result.outputs["consumer"] is None
+
+
+@pytest.mark.parametrize(
+    "annotation,value",
+    (
+        (int, "3"),
+        (int | None, "3"),
+        (Annotated[int | None, "strict"], "3"),
+        (_PortUserId, "3"),
+        (list[_PortUserId], ["3"]),
+    ),
+)
+def test_node_port_rejects_string_instead_of_coercing_integer(annotation, value):
+    handler = Mock(return_value=NodeResult({}))
+    registration = NodeRegistration(
+        "consumer",
+        "initialize",
+        EmptyNodeConfiguration,
+        {"value": annotation},
+        {},
+        handler,
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"consumer": {}}})
+    plan = compile_stage(
+        NodeCatalog((registration,), ()), "initialize", stage, {}, {"value": annotation}
+    )
+
+    result = run_stage("initialize", plan, _node_context(), {"value": value})
+
+    assert result.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "execution.node_failed"
+    handler.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "source_annotation,target_annotation,value",
+    (
+        (bool, int, True),
+        (Literal[True], int, True),
+        (Tuple, tuple[int, ...], ("wrong",)),
+        (tuple[int, ...], Tuple[()], (1,)),
+        (int, _PortUserId, 3),
+        (_PortUserId, _PortOtherId, _PortUserId(3)),
+        (list[int], list[_PortUserId], [3]),
+        (list[_PortUserId], list[_PortOtherId], [_PortUserId(3)]),
+    ),
+)
+def test_incompatible_port_annotations_reject_explicit_binding(
+    source_annotation, target_annotation, value
+):
+    registrations = (
+        NodeRegistration(
+            "source",
+            "initialize",
+            EmptyNodeConfiguration,
+            {},
+            {"value": source_annotation},
+            lambda _invocation: NodeResult({"value": value}),
+        ),
+        NodeRegistration(
+            "consumer",
+            "initialize",
+            EmptyNodeConfiguration,
+            {"value": target_annotation},
+            {},
+            lambda _invocation: NodeResult({}),
+        ),
+    )
+    stage = StageConfiguration.model_validate(
+        {"nodes": {"source": {}, "consumer": {"inputs": {"value": "source.value"}}}}
+    )
+
+    with pytest.raises(ValueError, match="not compatible"):
+        _compile(registrations, stage)
+
+
+@pytest.mark.parametrize(
+    "invalid_result",
+    (
+        {},
+        NodeResult({}, "ok"),
+        NodeResult(None),
+        NodeResult({}, diagnostics=None),
+        NodeResult({}, diagnostics=("bad",)),
+        NodeResult({}, diagnostics=(ExecutionDiagnostic("bad", "bad", "invalid"),)),
+        *(
+            NodeResult(
+                {}, status, (ExecutionDiagnostic("bad", "bad", UserString(severity)),)
+            )
+            for status in (ExecutionStatus.OK, ExecutionStatus.ERROR)
+            for severity in ("warning", "error")
+        ),
+    ),
+)
+def test_invalid_node_result_is_contained_and_independent_output_survives(
+    invalid_result,
+):
+    registrations = (
+        NodeRegistration(
+            "invalid",
+            "initialize",
+            EmptyNodeConfiguration,
+            {},
+            {},
+            lambda _invocation: invalid_result,
+        ),
+        _value_node("independent", "kept"),
+    )
+    stage = StageConfiguration.model_validate(
+        {"nodes": {"invalid": {}, "independent": {}}}
+    )
+
+    result = run_stage(
+        "initialize", _compile(registrations, stage), _node_context(), {}
+    )
+
+    assert result.status is ExecutionStatus.ERROR
+    assert result.outputs == {"independent": "kept"}
+    assert len(result.diagnostics) == 1
+    assert result.diagnostics[0].code == "execution.node_failed"
+
+
+def test_pre_cancelled_stage_does_not_execute_handler():
+    handler = Mock(return_value=NodeResult({}))
+    node = NodeRegistration(
+        "cancelled", "initialize", EmptyNodeConfiguration, {}, {}, handler
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"cancelled": {}}})
+    context = _node_context()
+    context = replace(
+        context, runtime=replace(context.runtime, is_cancelled=lambda: True)
+    )
+
+    with pytest.raises(CancelledError):
+        run_stage("initialize", _compile((node,), stage), context, {})
+
+    handler.assert_not_called()
+
+
+def test_node_cancelled_error_propagates_instead_of_becoming_failure_diagnostic():
+    handler = Mock(side_effect=CancelledError("cancelled"))
+    node = NodeRegistration(
+        "cancelled", "initialize", EmptyNodeConfiguration, {}, {}, handler
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"cancelled": {}}})
+
+    with pytest.raises(CancelledError, match="cancelled"):
+        run_stage("initialize", _compile((node,), stage), _node_context(), {})
+
+
+def test_node_configuration_mutation_does_not_leak_into_next_invocation():
+    class Configuration(BaseModel):
+        values: list[int] = []
+
+    seen = []
+
+    def execute(invocation):
+        seen.append(tuple(invocation.configuration.values))
+        invocation.configuration.values.append(1)
+        return NodeResult({})
+
+    node = NodeRegistration("configured", "initialize", Configuration, {}, {}, execute)
+    stage = StageConfiguration.model_validate({"nodes": {"configured": {}}})
+    plan = _compile((node,), stage)
+
+    for _ in range(2):
+        assert (
+            run_stage("initialize", plan, _node_context(), {}).status
+            is ExecutionStatus.OK
+        )
+
+    assert seen == [(), ()]
+
+
+@pytest.mark.parametrize(
+    "annotation,value",
+    (
+        (_ExternalPortPayload, _ExternalPortPayload(_ExternalPortResource())),
+        (_PortUserId, _PortUserId(3)),
+    ),
+)
+def test_annotated_output_keeps_custom_validation(annotation, value):
+    checked = []
+
+    def validate(payload):
+        checked.append(payload)
+        return payload
+
+    node = NodeRegistration(
+        "payload",
+        "initialize",
+        EmptyNodeConfiguration,
+        {},
+        {"value": Annotated[annotation, AfterValidator(validate)]},
+        lambda _invocation: NodeResult({"value": value}),
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"payload": {}}})
+
+    result = run_stage("initialize", _compile((node,), stage), _node_context(), {})
+
+    assert result.status is ExecutionStatus.OK
+    assert result.outputs["payload"] is value
+    assert checked == [value]
+
+
+@pytest.mark.parametrize("annotation", (123, list[123]))
+def test_compiler_rejects_malformed_stage_input_annotation_even_for_any_consumer(
+    annotation,
+):
+    node = NodeRegistration(
+        "consumer",
+        "initialize",
+        EmptyNodeConfiguration,
+        {"value": Any},
+        {},
+        lambda _invocation: NodeResult({}),
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"consumer": {}}})
+
+    with pytest.raises(TypeError, match="unsupported annotation"):
+        compile_stage(
+            NodeCatalog((node,), ()), "initialize", stage, {}, {"value": annotation}
+        )
+
+
+@pytest.mark.parametrize("configured", (False, True), ids=("defaults", "yaml-values"))
+def test_configuration_snapshot_rebuilds_private_state_without_revalidating_normalized_values(
+    configured,
+):
+    class NestedConfiguration(BaseModel):
+        values: list[int] = Field(alias="items")
+        _lock: object = PrivateAttr(default_factory=threading.Lock)
+
+        @field_validator("values")
+        @classmethod
+        def increment(cls, values):
+            return [value + 1 for value in values]
+
+    class Configuration(BaseModel):
+        nested: NestedConfiguration = Field(
+            default_factory=lambda: NestedConfiguration(items=[2])
+        )
+
+    seen, locks = [], []
+
+    def execute(invocation):
+        configuration = invocation.configuration.nested
+        locks.append(configuration._lock)
+        with configuration._lock:
+            seen.append(tuple(configuration.values))
+            configuration.values.append(99)
+        return NodeResult({})
+
+    registration = NodeRegistration(
+        "configured", "initialize", Configuration, {}, {}, execute
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"configured": {}}})
+    raw = {"nested": {"items": [2]}} if configured else {}
+    plan = compile_stage(
+        NodeCatalog((registration,), ()),
+        "initialize",
+        stage,
+        {"configured": raw},
+        {},
+    )
+    if configured:
+        raw["nested"]["items"].append(500)
+
+    for _ in range(2):
+        assert (
+            run_stage("initialize", plan, _node_context(), {}).status
+            is ExecutionStatus.OK
+        )
+
+    assert seen == [(3,), (3,)]
+    assert locks[0] is not locks[1]
+
+
+@pytest.mark.parametrize("port", ("input", "output"))
+@pytest.mark.parametrize("as_model", (False, True), ids=("mapping", "model"))
+def test_concrete_model_ports_require_instances(port, as_model):
+    class Payload(BaseModel):
+        value: int
+
+    value = Payload(value=1) if as_model else {"value": 1}
+    handler = Mock(
+        return_value=NodeResult({"value": value} if port == "output" else {})
+    )
+    registration = NodeRegistration(
+        "model",
+        "initialize",
+        EmptyNodeConfiguration,
+        {"value": Payload} if port == "input" else {},
+        {"value": Payload} if port == "output" else {},
+        handler,
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"model": {}}})
+    plan = compile_stage(
+        NodeCatalog((registration,), ()),
+        "initialize",
+        stage,
+        {},
+        {"value": Payload} if port == "input" else {},
+    )
+    result = run_stage(
+        "initialize", plan, _node_context(), {"value": value} if port == "input" else {}
+    )
+
+    assert result.status is (ExecutionStatus.OK if as_model else ExecutionStatus.ERROR)
+    if port == "input" and not as_model:
+        handler.assert_not_called()
+    else:
+        handler.assert_called_once()
+    if not as_model:
+        assert result.diagnostics[0].code == "execution.node_failed"
+        assert "Input should be an instance of Payload" in result.diagnostics[0].message
+
+
+@pytest.mark.parametrize(
+    "boundary", ["handler", "progress", "diagnostic", "job_failure"]
+)
+def test_node_cancellation_is_checked_before_publishing_success(boundary):
+    captured = []
+
+    def execute(invocation):
+        captured.append(invocation.context)
+        if boundary == "handler":
+            invocation.context.jobs.cancel()
+        if boundary == "job_failure":
+
+            def fail(_value):
+                raise ValueError("ordinary job failure")
+
+            invocation.context.jobs.run([1], fail, label=None, result_key=str)
+        return NodeResult(
+            {"value": "must not publish"},
+            diagnostics=(ExecutionDiagnostic("note", "note", "warning"),),
+        )
+
+    def progress(event):
+        if boundary == "progress" and event["event"] == "execution_node_end":
+            captured[0].jobs.cancel()
+
+    def diagnostic(_value):
+        if boundary == "diagnostic":
+            captured[0].jobs.cancel()
+
+    node = NodeRegistration(
+        "cancel", "initialize", EmptyNodeConfiguration, {}, {"value": str}, execute
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"cancel": {}}})
+    context = _node_context()
+    scheduler = JobScheduler(1)
+    context = replace(
+        context,
+        runtime=replace(context.runtime, jobs=scheduler.limit(1)),
+        callbacks=NodeCallbacks(progress=progress, diagnostic=diagnostic),
+    )
+    try:
+        if boundary == "job_failure":
+            result = run_stage("initialize", _compile((node,), stage), context, {})
+            assert result.status is ExecutionStatus.ERROR
+            assert "ordinary job failure" in result.diagnostics[0].message
+        else:
+            with pytest.raises(CancelledError, match="node was cancelled"):
+                run_stage("initialize", _compile((node,), stage), context, {})
+        assert captured[0].runtime.is_cancelled()
+    finally:
+        scheduler.close()
+
+
+def test_shared_stage_drain_retries_an_interrupted_wait_before_returning(monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+
+    from metis.engine.execution import runner
+
+    started = threading.Event()
+    release = threading.Event()
+    retried = threading.Event()
+    submit = runner.submit_with_current_context
+
+    def observe_submit(executor, function, stage_name, node, *args):
+        future = submit(executor, function, stage_name, node, *args)
+        if node.name == "waiter":
+            result = future.result
+            interrupted = False
+
+            def interrupt_wait(*args, **kwargs):
+                nonlocal interrupted
+                if not interrupted:
+                    interrupted = True
+                    assert not future.done()
+                    raise KeyboardInterrupt("interrupt while draining")
+                retried.set()
+                return result(*args, **kwargs)
+
+            future.result = interrupt_wait
+        return future
+
+    def wait_for_release(_invocation):
+        started.set()
+        assert release.wait(5)
+        return NodeResult({"value": "drained"})
+
+    def interrupt(_invocation):
+        assert started.wait(5)
+        raise KeyboardInterrupt("initial stage interrupt")
+
+    registrations = tuple(
+        NodeRegistration(
+            name, "initialize", EmptyNodeConfiguration, {}, {"value": str}, execute
+        )
+        for name, execute in (("waiter", wait_for_release), ("interrupt", interrupt))
+    )
+    stage = StageConfiguration.model_validate(
+        {"nodes": {"waiter": {}, "interrupt": {}}}
+    )
+    monkeypatch.setattr(runner, "submit_with_current_context", observe_submit)
+    with ThreadPoolExecutor(max_workers=2) as nodes:
+        with ThreadPoolExecutor(max_workers=1) as caller:
+            execution = caller.submit(
+                run_stage,
+                "initialize",
+                _compile(registrations, stage),
+                _node_context(),
+                {},
+                executor=nodes,
+            )
+            try:
+                assert retried.wait(2), "An interrupted wait skipped the active node"
+                assert not execution.done()
+            finally:
+                release.set()
+            with pytest.raises(KeyboardInterrupt, match="initial stage interrupt"):
+                execution.result(timeout=5)
+
+
+@pytest.mark.parametrize("boundary", ["node", "stage"])
+@pytest.mark.parametrize("status", [ExecutionStatus.OK, ExecutionStatus.INCONCLUSIVE])
+def test_cancellation_during_output_logging_rejects_success(
+    boundary, status, node_jobs, tmp_path
+):
+    from pydantic import model_serializer
+
+    from metis import runlog
+
+    caller = threading.current_thread()
+    cancellation = threading.Event()
+    captured = []
+
+    class Payload(BaseModel):
+        value: str
+
+        @model_serializer
+        def serialize(self):
+            if threading.current_thread() is caller:
+                if boundary == "stage":
+                    cancellation.set()
+            elif boundary == "node":
+                captured[0].jobs.cancel()
+            return {"value": self.value}
+
+    def execute(invocation):
+        captured.append(invocation.context)
+        return NodeResult({"value": Payload(value="must not publish")}, status)
+
+    node = NodeRegistration(
+        "late", "initialize", EmptyNodeConfiguration, {}, {"value": Payload}, execute
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"late": {}}})
+    context = _node_context()
+    context = replace(
+        context,
+        runtime=replace(
+            context.runtime,
+            jobs=node_jobs.with_cancellation(cancellation),
+            is_cancelled=cancellation.is_set,
+        ),
+    )
+    with runlog.open_runlog(runlog.RunLogConfig(path=tmp_path / "trace.ndjson")):
+        with pytest.raises(CancelledError, match=f"Execution {boundary} was cancelled"):
+            run_stage("initialize", _compile((node,), stage), context, {})
+    assert captured[0].runtime.is_cancelled()
+
+
+@pytest.mark.parametrize("stage_fails", [False, True])
+def test_owned_stage_retries_shutdown_and_preserves_first_error(
+    monkeypatch, node_jobs, stage_fails
+):
+    from concurrent.futures import ThreadPoolExecutor
+
+    from metis.engine.execution import runner
+
+    started = threading.Event()
+    release = threading.Event()
+    draining = threading.Event()
+    initial = KeyboardInterrupt("initial stage interrupt")
+    shutdown_error = KeyboardInterrupt("first shutdown interrupt")
+    owned_executors = []
+    captured = []
+    shutdown_attempts = 0
+
+    class InterruptedExecutor(ThreadPoolExecutor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            owned_executors.append(self)
+
+        def shutdown(self, *args, **kwargs):
+            nonlocal shutdown_attempts
+            shutdown_attempts += 1
+            if shutdown_attempts == 1:
+                raise shutdown_error
+            if shutdown_attempts == 2:
+                assert captured[0].runtime.is_cancelled()
+                raise KeyboardInterrupt("second shutdown interrupt")
+            return super().shutdown(*args, **kwargs)
+
+    submit = runner.submit_with_current_context
+
+    def observe_submit(executor, function, stage_name, node, *args):
+        future = submit(executor, function, stage_name, node, *args)
+        if stage_fails and node.name == "waiter":
+            result = future.result
+
+            def observe_drain(*args, **kwargs):
+                draining.set()
+                return result(*args, **kwargs)
+
+            future.result = observe_drain
+        return future
+
+    def waiter(invocation):
+        captured.append(invocation.context)
+        started.set()
+        if stage_fails:
+            assert release.wait(5)
+        return NodeResult({"value": "drained"})
+
+    def interrupt(_invocation):
+        assert started.wait(5)
+        if stage_fails:
+            raise initial
+        return NodeResult({"value": "done"})
+
+    registrations = tuple(
+        NodeRegistration(
+            name, "initialize", EmptyNodeConfiguration, {}, {"value": str}, execute
+        )
+        for name, execute in (("waiter", waiter), ("interrupt", interrupt))
+    )
+    stage = StageConfiguration.model_validate(
+        {"nodes": {"waiter": {}, "interrupt": {}}}
+    )
+    context = _node_context()
+    context = replace(
+        context, runtime=replace(context.runtime, max_workers=2, jobs=node_jobs)
+    )
+    monkeypatch.setattr(runner, "ThreadPoolExecutor", InterruptedExecutor)
+    monkeypatch.setattr(runner, "submit_with_current_context", observe_submit)
+    with ThreadPoolExecutor(max_workers=1) as caller:
+        execution = caller.submit(
+            run_stage, "initialize", _compile(registrations, stage), context, {}
+        )
+        try:
+            if stage_fails:
+                assert draining.wait(2), "Owned cleanup skipped its active handler"
+                assert not execution.done()
+        finally:
+            release.set()
+        with pytest.raises(KeyboardInterrupt) as raised:
+            execution.result(timeout=5)
+    assert raised.value is (initial if stage_fails else shutdown_error)
+    assert shutdown_attempts == 3
+    assert captured[0].runtime.is_cancelled()
+    assert not any(
+        thread.is_alive() for pool in owned_executors for thread in pool._threads
+    )

--- a/tests/test_execution_node_api.py
+++ b/tests/test_execution_node_api.py
@@ -1,7 +1,14 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
+from typing import Protocol
+from typing import ForwardRef
+
+import pytest
+
 import metis.execution_nodes as execution_nodes
+from metis.engine.execution.compiler import _annotations_compatible
 
 
 def test_execution_node_public_api_is_explicit() -> None:
@@ -15,6 +22,8 @@ def test_execution_node_public_api_is_explicit() -> None:
         "EmptyNodeConfiguration",
         "ExecutionDiagnostic",
         "ExecutionStatus",
+        "FinalReviewRun",
+        "JsonPromptRequest",
         "NodeCallbacks",
         "NodeCodeGraphs",
         "NodeContext",
@@ -36,3 +45,161 @@ def test_execution_node_public_api_is_explicit() -> None:
         "TriageDecision",
         "TriageRun",
     }
+
+
+type _MalformedPortAlias[T] = dict[T, 123]
+type _GenericPortAlias[T] = list[T]
+type _RecursivePortAlias[T] = T | list[_RecursivePortAlias[T]]
+type _CallablePortAlias[**P, R] = Callable[P, R]
+type _VariadicCallablePortAlias[*Ts] = Callable[[*Ts], None]
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    (
+        123,
+        object(),
+        list[123],
+        dict[str, list[123]],
+        list[...],
+        dict[str, ...],
+        tuple[...],
+        list[[int]],
+        dict[str, [int]],
+        tuple[[int]],
+        _MalformedPortAlias[str],
+        _GenericPortAlias[[int]],
+        _CallablePortAlias[[[int]], str],
+        _VariadicCallablePortAlias[[int]],
+        tuple[_GenericPortAlias.__type_params__[0], _GenericPortAlias[int]],
+    ),
+)
+def test_execution_node_rejects_non_type_port_annotations(annotation):
+    with pytest.raises(TypeError, match="unsupported annotation"):
+        execution_nodes.NodeRegistration(
+            "invalid",
+            "stage",
+            execution_nodes.EmptyNodeConfiguration,
+            {},
+            {"value": annotation},
+            lambda _invocation: execution_nodes.NodeResult({}),
+        )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    (
+        Callable[..., int],
+        Callable[[int, str], str],
+        tuple[int, ...],
+        _GenericPortAlias[int],
+        _RecursivePortAlias[int],
+        _CallablePortAlias[[int, str], str],
+        _CallablePortAlias[..., int],
+        _VariadicCallablePortAlias[int, str],
+    ),
+)
+def test_execution_node_accepts_concrete_generic_port_annotations(annotation):
+    registration = execution_nodes.NodeRegistration(
+        "valid",
+        "stage",
+        execution_nodes.EmptyNodeConfiguration,
+        {},
+        {"value": annotation},
+        lambda _invocation: execution_nodes.NodeResult({}),
+    )
+    assert registration.outputs["value"] is annotation
+
+
+def test_execution_node_preserves_one_shot_required_port_names():
+    registration = execution_nodes.NodeRegistration(
+        "valid",
+        "stage",
+        execution_nodes.EmptyNodeConfiguration,
+        {"value": int | None},
+        {},
+        lambda _invocation: execution_nodes.NodeResult({}),
+        required_when_bound=iter(["value"]),
+    )
+    assert registration.required_when_bound == frozenset({"value"})
+
+
+def test_execution_node_rejects_protocol_without_runtime_checks():
+    class UncheckedProtocol(Protocol):
+        def value(self) -> int: ...
+
+    with pytest.raises(TypeError, match="unsupported annotation"):
+        execution_nodes.NodeRegistration(
+            "invalid",
+            "stage",
+            execution_nodes.EmptyNodeConfiguration,
+            {"value": UncheckedProtocol},
+            {},
+            lambda _invocation: execution_nodes.NodeResult({}),
+        )
+
+
+@pytest.mark.parametrize(
+    "annotation", ("MissingPortType", list[ForwardRef("MissingPortType")])
+)
+def test_execution_node_rejects_unresolved_forward_types_before_execution(annotation):
+    with pytest.raises(TypeError, match="unsupported annotation"):
+        execution_nodes.NodeRegistration(
+            "invalid",
+            "stage",
+            execution_nodes.EmptyNodeConfiguration,
+            {"value": annotation},
+            {},
+            lambda _invocation: execution_nodes.NodeResult({}),
+        )
+
+
+@pytest.mark.parametrize(
+    "changes,error_type",
+    (
+        ({"name": 1}, ValueError),
+        ({"stage": None}, ValueError),
+        ({"inputs": []}, TypeError),
+        ({"outputs": None}, TypeError),
+        ({"inputs": {1: str}}, ValueError),
+        ({"capabilities": []}, TypeError),
+        (
+            {"capabilities": {1: execution_nodes.CapabilityRequirement.OPTIONAL}},
+            ValueError,
+        ),
+        ({"required_when_bound": "value"}, TypeError),
+    ),
+)
+def test_execution_node_rejects_malformed_registration_fields(changes, error_type):
+    arguments = {
+        "name": "valid",
+        "stage": "stage",
+        "configuration": execution_nodes.EmptyNodeConfiguration,
+        "inputs": {},
+        "outputs": {},
+        "execute": lambda _invocation: execution_nodes.NodeResult({}),
+    }
+    with pytest.raises(error_type):
+        execution_nodes.NodeRegistration(**(arguments | changes))
+
+
+type _ReorderedPortAlias[T, U] = tuple[U, T]
+type _UnusedPortAlias[T, U] = U | None
+type _UnionRecursivePortAlias[T] = T | _UnionRecursivePortAlias[T] | None
+
+
+@pytest.mark.parametrize(
+    "alias,underlying",
+    (
+        (_GenericPortAlias[int], list[int]),
+        (_RecursivePortAlias[int], int | list[_RecursivePortAlias[int]]),
+        (_CallablePortAlias[[int, str], str], Callable[[int, str], str]),
+        (_VariadicCallablePortAlias[int, str], Callable[[int, str], None]),
+        (_ReorderedPortAlias[int, str], tuple[str, int]),
+        (_UnusedPortAlias[int, str], str | None),
+        (_UnionRecursivePortAlias[int], int | None),
+    ),
+)
+def test_concrete_generic_alias_preserves_parameter_bindings(alias, underlying):
+    assert _annotations_compatible(alias, underlying)
+    assert _annotations_compatible(underlying, alias)

--- a/tests/test_execution_port_validation.py
+++ b/tests/test_execution_port_validation.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from copy import deepcopy
+from typing import Annotated
+from typing import Literal
+from typing import NewType
+from typing import ParamSpec
+from typing import TypedDict
+from typing import Unpack
+from unittest.mock import Mock
+
+import pytest
+from pydantic import AfterValidator
+from pydantic import BaseModel
+from pydantic import BeforeValidator
+from pydantic import TypeAdapter
+from pydantic import ValidationError
+from pydantic import model_validator
+
+from metis.engine.execution.catalog import NodeCatalog
+from metis.engine.execution.compiler import compile_stage
+from metis.engine.execution.contracts import annotation_adapter
+from metis.engine.execution.graph import StageConfiguration
+from metis.engine.execution.runner import _validate_value
+from metis.engine.execution.runner import run_stage
+from metis.execution_nodes import EmptyNodeConfiguration
+from metis.execution_nodes import ExecutionStatus
+from metis.execution_nodes import NodeRegistration
+from metis.execution_nodes import NodeResult
+from test_execution_graph import _node_context
+
+
+class Payload(BaseModel):
+    value: int
+
+
+class GenericPayload[T](BaseModel):
+    value: T
+
+
+class PayloadFields(TypedDict):
+    metadata: Payload
+    type: Payload
+
+
+class RecursivePayload(BaseModel):
+    child: "RecursivePayload | None" = None
+
+    @model_validator(mode="after")
+    def unchanged(self):
+        return self
+
+
+type OptionalPort[T] = T | None
+type RecursivePort[T] = T | list[RecursivePort[T]]
+
+FloatPort = NewType("FloatPort", float)
+Parameters = ParamSpec("Parameters")
+
+
+@pytest.mark.parametrize("direction", ("input", "output"))
+@pytest.mark.parametrize(
+    "annotation,value",
+    (
+        (float, 9007199254740993),
+        (Annotated[float | None, "nullable"], 1),
+        (FloatPort, 1),
+        (Literal[True], 1),
+        (Literal[1] | None, True),
+        (Literal[1], 1.0),
+        (Payload | None, {"value": 1}),
+        (Payload | int, {"value": 1}),
+        (Annotated[Payload, "model"], {"value": 1}),
+        (OptionalPort[Payload], {"value": 1}),
+        (GenericPayload[int] | None, {"value": 1}),
+        (list[Payload], [{"value": 1}]),
+        (PayloadFields, {"metadata": {"value": 1}, "type": {"value": 1}}),
+    ),
+)
+def test_node_ports_reject_implicit_scalar_and_model_conversion(
+    annotation, value, direction
+):
+    handler = Mock(
+        return_value=NodeResult({"value": value} if direction == "output" else {})
+    )
+    registration = NodeRegistration(
+        "port",
+        "initialize",
+        EmptyNodeConfiguration,
+        {"value": annotation} if direction == "input" else {},
+        {"value": annotation} if direction == "output" else {},
+        handler,
+    )
+    stage = StageConfiguration.model_validate({"nodes": {"port": {}}})
+    plan = compile_stage(
+        NodeCatalog((registration,), ()),
+        "initialize",
+        stage,
+        {},
+        {"value": annotation} if direction == "input" else {},
+    )
+    result = run_stage("initialize", plan, _node_context(), {"value": value})
+    assert result.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "execution.node_failed"
+    if direction == "input":
+        handler.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "annotation,value",
+    (
+        (float, 1.5),
+        (float | int, 1),
+        (int | float, 1.5),
+        (Literal[True] | int, 1),
+        (Literal[1] | bool, True),
+        (Literal[True, 1], 1),
+        (Literal[True, 1], True),
+        (Payload | None, None),
+        (Payload | None, Payload(value=1)),
+        (GenericPayload[int] | None, GenericPayload[int](value=1)),
+        (Payload | dict[str, int], {"value": 1}),
+        (list[Payload], [Payload(value=1)]),
+        (PayloadFields, {"metadata": Payload(value=1), "type": Payload(value=1)}),
+        (RecursivePort[float], [1.0, [2.0]]),
+    ),
+)
+def test_valid_port_values_and_union_branches_keep_their_types(annotation, value):
+    actual = _validate_value(annotation, value)
+    assert type(actual) is type(value)
+    assert actual == value
+    if isinstance(value, BaseModel):
+        assert actual is value
+
+
+def test_model_guards_preserve_metadata_recursive_definitions_and_cached_schemas():
+    before = deepcopy(RecursivePayload.__pydantic_core_schema__)
+    checked = []
+
+    def remember(value):
+        checked.append(value)
+        return value
+
+    annotation = Annotated[
+        list[Annotated[RecursivePayload | None, BeforeValidator(remember)]],
+        AfterValidator(remember),
+    ]
+    value = RecursivePayload(child=RecursivePayload())
+    assert _validate_value(annotation, [value, None]) == [value, None]
+    assert checked == [value, None, [value, None]]
+    with pytest.raises(ValidationError):
+        _validate_value(annotation, [{}])
+    with pytest.raises(ValidationError):
+        _validate_value(RecursivePort[float], [1])
+    assert RecursivePayload.__pydantic_core_schema__ == before
+    # Normal Pydantic construction remains available outside the port boundary.
+    assert (
+        TypeAdapter(RecursivePayload | None).validate_python({}, strict=True)
+        == RecursivePayload()
+    )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    (
+        Parameters.args,
+        Parameters.kwargs,
+        list[Parameters.args],
+        dict[str, Parameters.kwargs],
+    ),
+)
+def test_unresolved_parameter_parts_are_not_concrete_port_annotations(annotation):
+    with pytest.raises(TypeError, match="Expected a concrete port type"):
+        annotation_adapter(annotation)
+
+
+def test_model_metadata_validators_run_without_allowing_mapping_construction():
+    checked = []
+
+    class ValidatedPayload(BaseModel):
+        value: int
+
+        @model_validator(mode="wrap")
+        @classmethod
+        def remember(cls, value, handler):
+            checked.append("model")
+            return handler(value)
+
+    def before(value):
+        checked.append("before")
+        return value
+
+    def after(value):
+        checked.append("after")
+        return value
+
+    value = ValidatedPayload(value=1)
+    checked.clear()
+    annotation = (
+        Annotated[ValidatedPayload, BeforeValidator(before), AfterValidator(after)]
+        | None
+    )
+    assert _validate_value(annotation, value) is value
+    assert checked == ["before", "model", "after"]
+    checked.clear()
+    with pytest.raises(ValidationError):
+        _validate_value(annotation, {"value": 1})
+    assert checked == []
+
+
+type PackedPort[*Items] = tuple[*Items]
+type HeadPackedPort[Head, *Tail] = tuple[Head, *Tail]
+type TailPackedPort[*Prefix, Last] = tuple[*Prefix, Last]
+type NestedPackedPort[T] = list[PackedPort[T, str]]
+
+
+@pytest.mark.parametrize(
+    "annotation,valid,invalid",
+    (
+        (PackedPort[int, str], (1, "ok"), ((object(),), (1,), (1, "ok", 2), (1, 2))),
+        (
+            HeadPackedPort[int, str, bytes],
+            (1, "ok", b"ok"),
+            ((1, object()), (1, "ok"), (1, "ok", "bytes")),
+        ),
+        (
+            TailPackedPort[int, str, bytes],
+            (1, "ok", b"ok"),
+            ((1, "ok"), (1, "ok", "bytes")),
+        ),
+        (tuple[Unpack[tuple[int, str]]], (1, "ok"), ((object(),), (1, 2))),
+        (tuple[*tuple[int, str]], (1, "ok"), (((1, "ok"),), (1, 2))),
+        (tuple[int, *tuple[str, bytes]], (1, "ok", b"ok"), ((1, ("ok", b"ok")),)),
+        (NestedPackedPort[int], [(1, "ok")], ([(1,)], [(1, 2)])),
+        (dict[str, PackedPort[int, str]], {"x": (1, "ok")}, ({"x": (1,)},)),
+        (PackedPort[()], (), ((1,), (object(),))),
+        (tuple[Unpack[tuple[()]]], (), ((1,),)),
+        (tuple[*tuple[()]], (), ((1,),)),
+        (tuple[Unpack[tuple[int, ...]]], (), (("bad",),)),
+        (
+            PackedPort[float, Payload],
+            (1.0, Payload(value=1)),
+            ((1, Payload(value=1)), (1.0, {"value": 1})),
+        ),
+    ),
+)
+def test_concrete_tuple_unpacks_enforce_flat_lengths_and_item_types(
+    annotation, valid, invalid
+):
+    registration = NodeRegistration(
+        "packed",
+        "custom",
+        EmptyNodeConfiguration,
+        {},
+        {"value": annotation},
+        lambda invocation: NodeResult({}),
+    )
+    assert registration.outputs["value"] is annotation
+    assert _validate_value(annotation, valid) == valid
+    for value in invalid:
+        with pytest.raises(ValidationError):
+            _validate_value(annotation, value)
+
+
+def test_tuple_unpack_normalization_preserves_annotation_validators():
+    seen = []
+
+    def remember(value):
+        seen.append(value)
+        return value
+
+    annotation = Annotated[PackedPort[int, str], AfterValidator(remember)] | None
+    assert _validate_value(annotation, (1, "ok")) == (1, "ok")
+    assert seen == [(1, "ok")]
+    assert _validate_value(annotation, None) is None
+    with pytest.raises(ValidationError):
+        _validate_value(annotation, (1,))
+    assert seen == [(1, "ok")]
+
+
+type RecursivePackedPort[*Items] = (
+    PackedPort[*Items] | list[RecursivePackedPort[*Items]]
+)
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    (RecursivePackedPort[int, str], tuple[int, *tuple[str, ...]]),
+)
+def test_unsupported_tuple_unpack_shapes_fail_before_execution(annotation):
+    with pytest.raises(TypeError, match="tuple unpack.*unsupported"):
+        annotation_adapter(annotation)
+
+
+@pytest.mark.parametrize(
+    "annotation", (Unpack[tuple[int, str]], list[Unpack[tuple[int, str]]])
+)
+def test_tuple_unpack_cannot_be_used_as_a_standalone_item_type(annotation):
+    with pytest.raises(TypeError, match="must appear inside a tuple"):
+        annotation_adapter(annotation)

--- a/tests/test_execution_recursive_ports.py
+++ b/tests/test_execution_recursive_ports.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from typing import Literal
+from typing import NewType
+
+import pytest
+
+from metis.engine.execution.compiler import _annotations_compatible
+from metis.engine.execution.graph import StageConfiguration
+from metis.engine.execution.runner import run_stage
+from metis.execution_nodes import EmptyNodeConfiguration
+from metis.execution_nodes import ExecutionStatus
+from metis.execution_nodes import NodeRegistration
+from metis.execution_nodes import NodeResult
+from test_execution_graph import _compile
+from test_execution_graph import _node_context
+
+
+type _NativeA = int | list[_NativeA]
+type _NativeB = int | list[_NativeB]
+type _NativeWrong = str | list[_NativeWrong]
+type _GenericA[T] = list[_GenericA[T]] | T
+type _GenericB[T] = list[_GenericB[T]] | T
+type _MutualA = int | dict[str, _MutualAItems]
+type _MutualAItems = list[_MutualA]
+type _MutualB = int | dict[str, _MutualBItems]
+type _MutualBItems = list[_MutualB]
+type _PairA = tuple[_PairA, int] | None
+type _PairB = tuple[_PairB, str] | None
+type _TupleTree = int | tuple[_TupleTree, ...]
+type _SequenceTree = int | Sequence[_SequenceTree]
+type _LiteralTree = Literal[1] | list[_LiteralTree]
+type _SelfUnion = _SelfUnion | int
+_UserId = NewType("_UserId", int)
+type _IdTree = _UserId | list[_IdTree]
+
+
+@pytest.mark.parametrize(
+    "source,target,expected",
+    (
+        (_NativeA, _NativeB, True),
+        (_NativeA, _NativeWrong, False),
+        (_GenericA[int], _GenericB[int], True),
+        (_GenericA[int], _GenericB[str], False),
+        (_NativeA, _GenericB[int], True),
+        (_MutualA, _MutualB, True),
+        (_PairA, _PairB, False),
+        (_TupleTree, _SequenceTree, True),
+        (_SequenceTree, _TupleTree, False),
+        (_LiteralTree, _NativeB, True),
+        (_NativeA, _LiteralTree, False),
+        (_IdTree, _NativeB, True),
+        (_NativeA, _IdTree, False),
+        (_GenericA[int], _GenericB[int] | None, True),
+        (_GenericA[int] | None, _GenericB[int], False),
+        (_SelfUnion, int, True),
+        (int, _SelfUnion, True),
+    ),
+)
+def test_recursive_annotation_compatibility(source, target, expected):
+    assert _annotations_compatible(source, target) is expected
+
+
+def test_recursive_ports_compile_independently():
+    barrier = Barrier(4)
+    value = [1, [2]]
+    cases = (
+        (_NativeA, _NativeB, True),
+        (_NativeA, _NativeWrong, False),
+        (_GenericA[int], _GenericB[int], True),
+        (_GenericA[int], _GenericB[str], False),
+    )
+
+    def compile_case(case):
+        source, target, compatible = case
+        registrations = (
+            NodeRegistration(
+                "source",
+                "initialize",
+                EmptyNodeConfiguration,
+                {},
+                {"value": source},
+                lambda _: NodeResult({"value": value}),
+            ),
+            NodeRegistration(
+                "consumer",
+                "initialize",
+                EmptyNodeConfiguration,
+                {"value": target},
+                {"value": target},
+                lambda invocation: NodeResult(dict(invocation.inputs)),
+            ),
+        )
+        stage = StageConfiguration.model_validate(
+            {
+                "nodes": {
+                    "source": {},
+                    "consumer": {"inputs": {"value": "source.value"}},
+                },
+                "outputs": {"value": "consumer.value"},
+            }
+        )
+        barrier.wait(timeout=5)
+        if compatible:
+            result = run_stage(
+                "initialize", _compile(registrations, stage), _node_context(), {}
+            )
+            assert result.status is ExecutionStatus.OK
+            assert result.outputs["value"] == value
+        else:
+            with pytest.raises(ValueError, match="not compatible"):
+                _compile(registrations, stage)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(compile_case, case) for case in cases]
+        for future in futures:
+            future.result(timeout=10)

--- a/tests/test_execution_stage_api.py
+++ b/tests/test_execution_stage_api.py
@@ -1,10 +1,16 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+from threading import Event
+from typing import ForwardRef
+from typing import TypeVar
+
 import pytest
+from pydantic import BaseModel
 
 import metis.execution_stages as execution_stages
 from metis.engine.stages.catalog import StageCatalog
+from metis.engine.stages.configuration import ExecutionConfiguration
 
 
 class _BuiltinCollisionEntryPoint:
@@ -26,3 +32,147 @@ def test_execution_stage_contract_rejects_invalid_ports() -> None:
 def test_installed_execution_stage_cannot_shadow_a_builtin() -> None:
     with pytest.raises(ValueError, match="conflicts with a built-in stage"):
         StageCatalog(("review",), (_BuiltinCollisionEntryPoint(),))
+
+
+@pytest.mark.parametrize(
+    ("node_name", "outputs"),
+    (
+        ("result", ()),
+        ("result", {"filename": "result.filename"}),
+        ("private_result", {"filename": "private_result.filename"}),
+        ("private_result", {"filename": "private_result.destination"}),
+        ("private_result", {"filename": "private_result"}),
+        ("filename", ("filename",)),
+    ),
+)
+def test_filename_follows_the_stage_output_producer(node_name, outputs):
+    configuration = ExecutionConfiguration.model_validate(
+        {
+            "inputs": {"review_request": {"mode": "code"}},
+            "stages": {
+                "review": {
+                    "outputs": outputs,
+                    "nodes": {
+                        node_name: {"formats": ["json"], "filename": "results/review"}
+                    },
+                }
+            },
+        }
+    )
+
+    assert configuration.stages.review.nodes[node_name].filename == "results/review"
+
+
+@pytest.mark.parametrize(
+    ("node_name", "outputs"),
+    (
+        ("private_result", ()),
+        ("private_result", {"filename": "other.filename"}),
+        ("result", {"filename": "private_result.filename"}),
+        ("private_result", {"formats": "private_result.formats"}),
+        ("private_result", ("private_result",)),
+    ),
+)
+def test_filename_rejects_an_unpublished_or_different_producer(node_name, outputs):
+    with pytest.raises(ValueError, match="producer of its filename output"):
+        ExecutionConfiguration.model_validate(
+            {
+                "inputs": {"review_request": {"mode": "code"}},
+                "stages": {
+                    "review": {
+                        "outputs": outputs,
+                        "nodes": {
+                            node_name: {
+                                "formats": ["json"],
+                                "filename": "results/review",
+                            }
+                        },
+                    }
+                },
+            }
+        )
+
+
+def test_filename_rejects_multiple_configured_producers():
+    with pytest.raises(ValueError, match="configures multiple filenames"):
+        ExecutionConfiguration.model_validate(
+            {
+                "inputs": {"review_request": {"mode": "code"}},
+                "stages": {
+                    "review": {
+                        "outputs": {"filename": "private_result.filename"},
+                        "nodes": {
+                            "private_result": {
+                                "formats": ["json"],
+                                "filename": "results/private",
+                            },
+                            "result": {
+                                "formats": ["json"],
+                                "filename": "results/review",
+                            },
+                        },
+                    }
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    (
+        lambda: execution_stages.StageContract({1: str}),
+        lambda: execution_stages.StageContract({}, {None: str}),
+        lambda: execution_stages.StageRegistration(
+            1, execution_stages.StageContract({})
+        ),
+        lambda: execution_stages.StageRegistration(
+            None, execution_stages.StageContract({})
+        ),
+    ),
+)
+def test_execution_stage_names_reject_non_strings(factory):
+    with pytest.raises(ValueError, match="[Ii]nvalid"):
+        factory()
+
+
+type _OptionalStagePort[T] = T | None
+
+
+class _StagePayload[T](BaseModel):
+    value: T
+
+
+@pytest.mark.parametrize("direction", ("inputs", "required_outputs"))
+@pytest.mark.parametrize(
+    "annotation",
+    (
+        TypeVar("Unbound") | None,
+        ForwardRef("UnknownPort") | None,
+        _OptionalStagePort,
+        123,
+    ),
+)
+def test_stage_contract_rejects_unsupported_annotations_at_construction(
+    direction, annotation
+):
+    with pytest.raises(TypeError, match="port 'value'.*unsupported annotation"):
+        execution_stages.StageContract(
+            **({"inputs": {}} | {direction: {"value": annotation}})
+        )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    (
+        int | None,
+        _OptionalStagePort[_StagePayload[int]],
+        _StagePayload[list[str]],
+        Event,
+    ),
+)
+def test_stage_contract_preserves_supported_concrete_annotations(annotation):
+    contract = execution_stages.StageContract(
+        {"value": annotation}, {"result": annotation}
+    )
+    assert contract.inputs["value"] is annotation
+    assert contract.required_outputs["result"] is annotation

--- a/tests/test_external_stages.py
+++ b/tests/test_external_stages.py
@@ -200,3 +200,88 @@ elif mode == "validation":
 else:
     raise SystemExit(f"unknown mode: {mode}")
 """
+
+
+@pytest.mark.parametrize("command", [[], [""], ["   "]])
+def test_external_command_rejects_missing_executable(command):
+    with pytest.raises(ValidationError):
+        ExternalStageCommandModel(command=command)
+
+
+@pytest.mark.parametrize("argument", ["", "  payload  "])
+def test_external_command_preserves_literal_arguments(argument):
+    stage = ExternalStageCommandModel(
+        command=[sys.executable, "-c", "import sys; print(repr(sys.argv[1]))", argument]
+    )
+    result = ExternalStageRunner().run_sync(stage, bindings={})
+    assert result.stdout.strip() == repr(argument)
+
+
+@pytest.mark.parametrize("stage", ["analysis", "validation"])
+@pytest.mark.parametrize("occupied", ["output", "request"])
+def test_external_stage_rejects_previous_artifacts_before_launch(
+    tmp_path, stage, occupied
+):
+    runner = Mock()
+    service = ExternalStageService(
+        codebase_path=str(tmp_path),
+        config={stage: {"inert": {"command": ["local-test", "{request_path}"]}}},
+        runner=runner,
+    )
+    directory = tmp_path / "run"
+    directory.mkdir()
+    output = "analysis.sarif" if stage == "analysis" else "validation-decision.json"
+    previous = directory / (output if occupied == "output" else f"{stage}-request.json")
+    previous.write_text("old artifact", encoding="utf-8")
+    input_path = tmp_path / "empty.sarif"
+    input_path.write_text(json.dumps({"version": "2.1.0", "runs": []}))
+    with pytest.raises(FileExistsError):
+        if stage == "analysis":
+            service.run_analysis(
+                "inert", prompt="echo local metadata", run_dir=directory
+            )
+        else:
+            service.run_validation("inert", input_sarif=input_path, run_dir=directory)
+    runner.run_sync.assert_not_called()
+    assert previous.read_text() == "old artifact"
+
+
+def test_concurrent_external_requests_cannot_share_artifacts(tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event
+    from metis.engine.external_stages.runner import ExternalStageProcessResult
+
+    started, release = Event(), Event()
+    runner = Mock()
+
+    def run(stage, *, bindings):
+        started.set()
+        assert release.wait(5)
+        bindings["output_sarif"].write_text(
+            json.dumps({"version": "2.1.0", "runs": []})
+        )
+        return ExternalStageProcessResult(("inert",), 0, "", "")
+
+    runner.run_sync.side_effect = run
+    service = ExternalStageService(
+        codebase_path=str(tmp_path),
+        config={"analysis": {"inert": {"command": ["local-test", "{request_path}"]}}},
+        runner=runner,
+    )
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        first = pool.submit(
+            service.run_analysis,
+            "inert",
+            prompt="local metadata",
+            run_dir=tmp_path / "run",
+        )
+        try:
+            assert started.wait(5)
+            with pytest.raises(FileExistsError):
+                service.run_analysis(
+                    "inert", prompt="other metadata", run_dir=tmp_path / "run"
+                )
+        finally:
+            release.set()
+        assert first.result(timeout=5).output_sarif.is_file()
+    runner.run_sync.assert_called_once()

--- a/tests/test_generated_output_paths.py
+++ b/tests/test_generated_output_paths.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from metis.cli import entry, utils
+from metis.engine.external_stages import service as external_service
+from metis.usage import runtime as usage_runtime
+
+
+class FixedClock(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 9, 4, 12, 0, 0, tzinfo=tz)
+
+
+@pytest.mark.parametrize("kind", ["command", "graph", "graph_fallback"])
+def test_generated_cli_paths_preserve_successive_outputs(monkeypatch, tmp_path, kind):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(entry, "datetime", FixedClock)
+    monkeypatch.setattr(utils, "datetime", FixedClock)
+    saved = []
+    for iteration in range(2):
+        if kind == "command":
+            args = SimpleNamespace(output_file=None)
+            entry.determine_output_file("ask", args, [])
+            paths = args.output_file
+        else:
+            paths = utils.output_files_for_formats(
+                ["configured.json"] if kind == "graph_fallback" else None,
+                ("json", "csv"),
+                command="graph_review",
+                generated_output=True,
+                reserved_paths={Path("configured.json"), Path("configured.csv")},
+            )
+            assert Path(paths[0]).with_suffix(".csv") == Path(paths[1])
+        utils.save_output(paths, {"iteration": iteration, "reviews": []}, quiet=True)
+        saved.append(Path(paths[0]))
+    assert [json.loads(path.read_text())["iteration"] for path in saved] == [0, 1]
+
+
+def test_generated_usage_paths_preserve_successive_sessions(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(usage_runtime, "datetime", FixedClock)
+    paths = [
+        usage_runtime.UsageRuntime(tmp_path / label).save_run_summary()
+        for label in ("first", "second")
+    ]
+    assert [json.loads(Path(path).read_text())["project_name"] for path in paths] == [
+        "first",
+        "second",
+    ]
+
+
+def test_generated_external_run_directories_are_independent(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(external_service, "datetime", FixedClock)
+    first = external_service._resolve_run_dir(None)
+    second = external_service._resolve_run_dir(None)
+    assert first != second
+    assert first.parent == second.parent == tmp_path / "results" / "external_stages"
+    assert external_service._resolve_run_dir(first) == first
+
+
+def test_explicit_output_paths_retain_replacement_behavior(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    for iteration in range(2):
+        args = SimpleNamespace(output_file=["explicit.json"])
+        entry.determine_output_file("ask", args, [])
+        assert args.output_file == ["explicit.json"]
+        paths = utils.output_files_for_formats(
+            args.output_file, ("json",), command="review"
+        )
+        assert paths == ["explicit.json"]
+        utils.save_output(paths, {"iteration": iteration}, quiet=True)
+        usage_runtime.UsageRuntime(tmp_path / str(iteration)).save_run_summary(
+            "usage.json"
+        )
+    assert json.loads(Path("explicit.json").read_text()) == {"iteration": 1}
+    assert json.loads(Path("usage.json").read_text())["project_name"] == "1"
+    assert external_service._resolve_run_dir("explicit") == tmp_path / "explicit"

--- a/tests/test_indexing_selection.py
+++ b/tests/test_indexing_selection.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import closing
+from pathlib import Path
+
+from fsspec.implementations.local import LocalFileSystem
+from llama_index.core import SimpleDirectoryReader
+from llama_index.core.schema import Document
+import pytest
+
+from metis.engine import MetisEngine
+
+
+@pytest.fixture
+def index_engine(
+    tmp_path, dummy_backend, dummy_llm, dummy_embedding_provider, capability_settings
+):
+    with closing(
+        MetisEngine(
+            codebase_path=str(tmp_path),
+            vector_backend=dummy_backend,
+            llm_provider=dummy_llm,
+            embedding_provider=dummy_embedding_provider,
+            capability_settings=capability_settings,
+            max_workers=2,
+            max_token_length=2048,
+            llama_query_model="inert-test",
+            similarity_top_k=3,
+        )
+    ) as engine:
+        yield engine
+
+
+def test_index_reader_never_opens_ignored_files(index_engine, tmp_path, monkeypatch):
+    (tmp_path / "keep.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "drop.py").write_text("value = 2\n", encoding="utf-8")
+    (tmp_path / ".metisignore").write_text("drop.py\n", encoding="utf-8")
+    real_open = LocalFileSystem.open
+    opened = []
+    prepared = []
+
+    def checked_open(self, path, *args, **kwargs):
+        opened.append(Path(path).name)
+        if Path(path).name == "drop.py":
+            raise PermissionError("Ignored files must not be opened")
+        return real_open(self, path, *args, **kwargs)
+
+    def prepare(code_docs, doc_docs, *_args):
+        prepared.extend(Path(doc.id_).name for doc in [*code_docs, *doc_docs])
+        yield None
+        return [], []
+
+    monkeypatch.setattr(LocalFileSystem, "open", checked_open)
+    monkeypatch.setattr(
+        "metis.engine.capabilities.indexing.prepare_nodes_iter", prepare
+    )
+    index_engine.indexing.index_prepare_nodes()
+
+    assert opened == ["keep.py"]
+    assert prepared == ["keep.py"]
+
+
+@pytest.mark.parametrize("all_ignored", [False, True])
+def test_empty_index_selection_finishes_without_a_reader(
+    index_engine, tmp_path, monkeypatch, dummy_backend, all_ignored
+):
+    if all_ignored:
+        (tmp_path / "drop.py").write_text("value = 1\n", encoding="utf-8")
+        (tmp_path / ".metisignore").write_text("*\n", encoding="utf-8")
+
+    def unexpected_reader(**_kwargs):
+        pytest.fail("An empty selection must not construct a file reader")
+
+    monkeypatch.setattr(
+        "metis.engine.capabilities.indexing.SimpleDirectoryReader", unexpected_reader
+    )
+    assert index_engine.indexing.count_index_items() == 0
+    assert list(index_engine.indexing.index_prepare_nodes_iter()) == []
+    assert index_engine._state.pending_nodes == ([], [])
+    index_engine.indexing.index_finalize_embeddings()
+    assert index_engine._state.pending_nodes is None
+    assert dummy_backend.index_nodes.call_args.args == ([], [])
+
+
+def test_index_count_ignores_review_filters(index_engine, tmp_path):
+    for name in ("keep.py", "other.py", "ignored.py", "README.md"):
+        (tmp_path / name).write_text("inert text\n", encoding="utf-8")
+    (tmp_path / ".metisignore").write_text("ignored.py\n", encoding="utf-8")
+    index_engine._config.review_code_include_paths = ["keep.py"]
+    index_engine._config.review_code_exclude_paths = ["other.py"]
+
+    assert len(index_engine.repository.get_code_files()) == 1
+    assert index_engine.indexing.count_index_items() == 3
+
+
+def test_multipart_documents_keep_origin_and_unique_ids(
+    index_engine, tmp_path, monkeypatch
+):
+    class MultipartReader:
+        def load_data(self, file, extra_info):
+            return [
+                Document(text="page one", metadata=extra_info),
+                Document(text="page two", metadata=extra_info),
+            ]
+
+    monkeypatch.setattr(
+        SimpleDirectoryReader,
+        "supported_suffix_fn",
+        staticmethod(lambda: {".md": MultipartReader}),
+    )
+    (tmp_path / "input.md").write_text("inert text\n", encoding="utf-8")
+    (tmp_path / ".metisignore").write_text("*\n!input.md\n", encoding="utf-8")
+    index_engine.indexing.index_prepare_nodes()
+
+    code_nodes, doc_nodes = index_engine._state.pending_nodes
+    assert code_nodes == []
+    assert [node.text for node in doc_nodes] == ["page one", "page two"]
+    assert [node.ref_doc_id for node in doc_nodes] == [
+        f"{tmp_path.name}/input.md_part_0",
+        f"{tmp_path.name}/input.md_part_1",
+    ]
+    assert all(
+        node.metadata["file_path"] == str(tmp_path / "input.md") for node in doc_nodes
+    )
+
+
+def test_configured_document_extensions_are_case_insensitive(index_engine, tmp_path):
+    index_engine._config.plugin_config["docs"]["supported_extensions"] = [".MD"]
+    (tmp_path / "input.MD").write_text("retained text\n", encoding="utf-8")
+
+    assert index_engine.indexing.count_index_items() == 1
+    index_engine.indexing.index_prepare_nodes()
+    code_nodes, doc_nodes = index_engine._state.pending_nodes
+    assert code_nodes == []
+    assert [node.text for node in doc_nodes] == ["retained text"]

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -2,15 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import stat
+import subprocess
+import sys
+from textwrap import dedent
 from pathlib import Path
 
 import pytest
 
+from metis.json_io import atomic_text_writer
 from metis.json_io import write_json_atomic
 
 
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), -float("inf")])
 def test_write_json_atomic_preserves_target_and_cleans_temporary_file(
     tmp_path: Path,
+    invalid: float,
 ) -> None:
     target = tmp_path / "result.json"
     write_json_atomic(
@@ -27,7 +33,115 @@ def test_write_json_atomic_preserves_target_and_cleans_temporary_file(
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
     with pytest.raises(ValueError):
-        write_json_atomic(target, {"value": float("nan")}, indent=2, allow_nan=False)
+        write_json_atomic(target, {"nested": [{"value": invalid}]}, indent=2)
 
     assert target.read_text(encoding="utf-8") == expected
+    assert list(tmp_path.iterdir()) == [target]
+
+
+@pytest.mark.parametrize("format_name", ["json", "text"])
+@pytest.mark.parametrize(
+    "operation", ["fsync", "directory_chmod", "file_chmod", "replace"]
+)
+def test_output_io_failure_keeps_previous_complete_report(
+    monkeypatch, tmp_path, operation, format_name
+):
+    from metis import json_io
+
+    target = tmp_path / "result.json"
+    target.write_text('{"previous": true}', encoding="utf-8")
+    target.chmod(0o640)
+
+    def fail(*_args, **_kwargs):
+        raise OSError(f"failed {operation}")
+
+    if operation.endswith("chmod"):
+        chmod = Path.chmod
+
+        def fail_chmod(path, mode):
+            if path.is_dir() == (operation == "directory_chmod"):
+                fail()
+            chmod(path, mode)
+
+        monkeypatch.setattr(Path, "chmod", fail_chmod)
+    else:
+        monkeypatch.setattr(json_io.os, operation, fail)
+    with pytest.raises(OSError, match=f"failed {operation}"):
+        if format_name == "json":
+            write_json_atomic(target, {"replacement": True}, indent=2)
+        else:
+            with atomic_text_writer(target) as handle:
+                handle.write("replacement")
+
+    assert target.read_text() == '{"previous": true}'
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+    assert list(tmp_path.iterdir()) == [target]
+
+
+@pytest.mark.parametrize("umask", [0o022, 0o002, 0o777])
+def test_atomic_text_writer_preserves_creation_and_existing_modes(tmp_path, umask):
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            dedent("""
+                import os
+                from pathlib import Path
+                import stat
+                import sys
+                from metis.json_io import atomic_text_writer, write_json_atomic
+
+                root = Path(sys.argv[1])
+                mask = int(sys.argv[2])
+                os.umask(mask)
+                target = root / "report.txt"
+                with atomic_text_writer(target) as handle:
+                    handle.write("complete")
+                    temporary = Path(handle.name)
+                    assert temporary.parent.parent == root
+                    assert stat.S_IMODE(temporary.parent.stat().st_mode) == 0o700
+                    assert not target.exists()
+                assert stat.S_IMODE(target.stat().st_mode) == 0o666 & ~mask
+                assert list(root.iterdir()) == [target]
+                target.chmod(0o640)
+                with atomic_text_writer(target) as handle:
+                    handle.write("replacement")
+                assert target.read_text() == "replacement"
+                assert stat.S_IMODE(target.stat().st_mode) == 0o640
+                private = root / "report.json"
+                write_json_atomic(private, {}, indent=2)
+                assert stat.S_IMODE(private.stat().st_mode) == 0o600
+                assert set(root.iterdir()) == {target, private}
+            """),
+            str(tmp_path),
+            str(umask),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_atomic_text_writer_supports_valid_long_basenames(tmp_path):
+    target = tmp_path / ("r" * 240 + ".txt")
+    target.write_text("previous", encoding="utf-8")
+
+    with atomic_text_writer(target) as handle:
+        handle.write("replacement")
+
+    assert target.read_text() == "replacement"
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_atomic_text_writer_cleans_up_after_interruption(tmp_path):
+    target = tmp_path / "report.txt"
+    target.write_text("previous", encoding="utf-8")
+
+    with pytest.raises(KeyboardInterrupt):
+        with atomic_text_writer(target) as handle:
+            handle.write("partial replacement")
+            raise KeyboardInterrupt
+
+    assert target.read_text() == "previous"
     assert list(tmp_path.iterdir()) == [target]

--- a/tests/test_language_plugin_registry.py
+++ b/tests/test_language_plugin_registry.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import importlib
-import inspect
 import logging
 import sys
 import types
@@ -15,7 +14,11 @@ import pytest
 from llama_index.core.schema import Document
 
 from metis.configuration import load_plugin_config
+from metis.configuration import load_runtime_config
+from metis.configuration import load_yaml
+from metis.plugins import registry as registry_module
 from metis.engine.capabilities.indexing import IndexingService
+from metis.engine.runtime import EngineState
 from metis.plugins.base import ConfigBackedLanguagePlugin
 
 REQUIRED_PROMPT_KEYS = (
@@ -24,31 +27,6 @@ REQUIRED_PROMPT_KEYS = (
     "security_review_checks",
     "validation_review",
 )
-
-
-def _import_registry_api():
-    try:
-        module = importlib.import_module("metis.plugins.registry")
-    except ModuleNotFoundError as exc:
-        pytest.xfail(
-            f"Planned lazy language plugin registry module is not available yet: {exc}"
-        )
-
-    missing = [
-        name
-        for name in (
-            "LanguagePluginManifest",
-            "LanguagePluginHandle",
-            "LanguagePluginRegistry",
-        )
-        if not hasattr(module, name)
-    ]
-    if missing:
-        pytest.fail(
-            "metis.plugins.registry is missing planned API symbols: "
-            + ", ".join(missing)
-        )
-    return module
 
 
 def _make_manifest(registry_module, **overrides):
@@ -67,48 +45,12 @@ def _make_manifest(registry_module, **overrides):
         "prompt_profile": "c_family",
     }
     data.update(overrides)
-    manifest_cls = registry_module.LanguagePluginManifest
-    try:
-        return manifest_cls(**data)
-    except TypeError:
-        if hasattr(manifest_cls, "model_validate"):
-            return manifest_cls.model_validate(data)
-        pytest.fail(
-            "LanguagePluginManifest should accept the plan fields as keyword "
-            "arguments or expose model_validate(data)."
-        )
+    return registry_module.LanguagePluginManifest(**data)
 
 
 def _build_registry(registry_module, manifests, *, plugin_config=None):
-    registry_cls = registry_module.LanguagePluginRegistry
-
-    ctor = inspect.signature(registry_cls)
-    if "manifests" in ctor.parameters:
-        kwargs = {"manifests": manifests}
-        if plugin_config is not None and "plugin_config" in ctor.parameters:
-            kwargs["plugin_config"] = plugin_config
-        return registry_cls(**kwargs)
-
-    for factory_name in ("from_manifests", "from_config"):
-        factory = getattr(registry_cls, factory_name, None)
-        if factory is None:
-            continue
-        sig = inspect.signature(factory)
-        kwargs = {}
-        if "manifests" in sig.parameters:
-            kwargs["manifests"] = manifests
-        if "plugin_config" in sig.parameters:
-            kwargs["plugin_config"] = plugin_config or {
-                "docs": {},
-                "general_prompts": {},
-                "plugins": {},
-            }
-        if kwargs:
-            return factory(**kwargs)
-
-    pytest.fail(
-        "LanguagePluginRegistry should expose a manifest-based construction path "
-        "for unit tests, such as __init__(manifests=...) or from_manifests(...)."
+    return registry_module.LanguagePluginRegistry(
+        manifests, plugin_config=plugin_config
     )
 
 
@@ -145,7 +87,6 @@ def _install_fake_plugin_module(monkeypatch, module_name: str):
 def test_supported_language_names_comes_from_manifests_without_importing_plugins(
     monkeypatch,
 ):
-    registry_module = _import_registry_api()
     import_calls = []
     real_import_module = importlib.import_module
 
@@ -181,7 +122,6 @@ def test_supported_language_names_comes_from_manifests_without_importing_plugins
 
 
 def test_get_manifest_for_path_matches_extensions_and_systemverilog_suffix_patterns():
-    registry_module = _import_registry_api()
     registry = _build_registry(
         registry_module,
         [
@@ -212,7 +152,6 @@ def test_codegraph_provider_uses_manifest_capabilities_without_loading_plugins(
     monkeypatch,
     caplog,
 ):
-    registry_module = _import_registry_api()
     import_calls = []
     real_import_module = importlib.import_module
 
@@ -255,7 +194,6 @@ def test_codegraph_provider_uses_manifest_capabilities_without_loading_plugins(
 
 
 def test_codegraph_capability_rejects_implementation_configuration():
-    registry_module = _import_registry_api()
 
     with pytest.raises(ValueError, match="codegraph as a boolean"):
         _make_manifest(
@@ -268,7 +206,6 @@ def test_get_plugin_for_path_imports_and_instantiates_only_selected_plugin_once(
     monkeypatch,
     caplog,
 ):
-    registry_module = _import_registry_api()
     state = _install_fake_plugin_module(monkeypatch, "test_lazy_registry_plugin")
     import_calls = []
     real_import_module = importlib.import_module
@@ -318,23 +255,7 @@ def test_get_plugin_for_path_imports_and_instantiates_only_selected_plugin_once(
     )
 
 
-def test_manifest_without_implementation_uses_cached_config_backed_plugin() -> None:
-    registry_module = _import_registry_api()
-    registry = _build_registry(
-        registry_module,
-        [_make_manifest(registry_module, implementation="")],
-    )
-
-    plugin = registry.get_plugin("c")
-
-    assert plugin is registry.get_plugin_for_extension(".c")
-    assert plugin.get_name() == "c"
-    assert plugin.get_supported_extensions() == [".c", ".h"]
-    assert "security_review" in plugin.get_prompts()
-
-
 def test_builtin_perl_manifest_matches_only_supported_extensions() -> None:
-    registry_module = _import_registry_api()
     registry = registry_module.LanguagePluginRegistry.from_config(load_plugin_config())
 
     for path in (
@@ -350,7 +271,6 @@ def test_builtin_perl_manifest_matches_only_supported_extensions() -> None:
 
 
 def test_builtin_perl_plugin_is_config_backed_and_cached() -> None:
-    registry_module = _import_registry_api()
     registry = registry_module.LanguagePluginRegistry.from_config(load_plugin_config())
 
     plugin = registry.get_plugin_for_path("lib/Security.pm")
@@ -370,7 +290,6 @@ def test_startup_plugin_config_excludes_language_prompt_configs():
 
 
 def test_registry_loads_required_prompt_keys_for_supported_languages():
-    registry_module = _import_registry_api()
     registry = registry_module.LanguagePluginRegistry.from_config(load_plugin_config())
 
     assert registry.codegraph_registration_for_path("src/example.c") == "c"
@@ -413,7 +332,6 @@ def test_registry_loads_required_prompt_keys_for_supported_languages():
 
 
 def test_explicit_replacement_overrides_resolved_manifest_fields(monkeypatch):
-    registry_module = _import_registry_api()
     builtin = _make_manifest(
         registry_module,
         name="c",
@@ -450,7 +368,6 @@ def test_explicit_replacement_overrides_resolved_manifest_fields(monkeypatch):
 
 
 def test_entry_point_accepts_manifest_object(monkeypatch):
-    registry_module = _import_registry_api()
     manifest = _make_manifest(
         registry_module,
         name="private",
@@ -468,7 +385,6 @@ def test_entry_point_accepts_manifest_object(monkeypatch):
 
 
 def test_plugin_constructor_type_error_is_not_retried_without_config(monkeypatch):
-    registry_module = _import_registry_api()
     module = types.ModuleType("broken_language_plugin")
     calls = []
 
@@ -540,7 +456,7 @@ def test_index_prepare_nodes_includes_suffix_pattern_code_files(tmp_path, monkey
         plugin_config={"docs": {"supported_extensions": [".md"]}},
         vector_backend=vector_backend,
     )
-    state = SimpleNamespace(pending_nodes=None)
+    state = EngineState()
     monkeypatch.setattr(
         "metis.engine.capabilities.indexing.SimpleDirectoryReader", Reader
     )
@@ -556,3 +472,235 @@ def test_index_prepare_nodes_includes_suffix_pattern_code_files(tmp_path, monkey
     assert str(source) in captured["input_files"]
     assert str(ignored) not in captured["input_files"]
     assert state.pending_nodes[0] == [f"code-node:{tmp_path.name}/unit.sv.vp"]
+
+
+@pytest.mark.parametrize("profile_source", ("inherits", "manifest"))
+def test_raw_yaml_registers_config_only_language_with_external_profile(
+    tmp_path, monkeypatch, profile_source
+):
+    package_name = f"language_contract_{profile_source}"
+    package = tmp_path / package_name
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "shared.yaml").write_text(
+        "prompts: {shared: inherited, overridden: old}\n", encoding="utf-8"
+    )
+    inheritance = (
+        f"inherits: {package_name}:shared.yaml\n"
+        if profile_source == "inherits"
+        else ""
+    )
+    (package / "language.yaml").write_text(
+        inheritance + "prompts: {local: local, overridden: new}\n", encoding="utf-8"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    profile = (
+        f"    prompt_profile: {package_name}:shared.yaml\n"
+        if profile_source == "manifest"
+        else ""
+    )
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        "llm_provider: {name: ollama, model: test-model}\n"
+        "language_plugins:\n"
+        "  contract_demo:\n"
+        "    extensions: [.contractdemo]\n"
+        f"    config_resource: {package_name}:language.yaml\n" + profile,
+        encoding="utf-8",
+    )
+
+    try:
+        runtime = load_runtime_config(config_path)
+        registry = registry_module.LanguagePluginRegistry.from_config(
+            runtime["plugin_config"]
+        )
+        assert package_name not in sys.modules
+        plugin = registry.get_plugin_for_path("sample.contractdemo")
+
+        assert isinstance(plugin, ConfigBackedLanguagePlugin)
+        assert plugin is registry.get_plugin("contract_demo")
+        assert plugin.get_supported_extensions() == [".contractdemo"]
+        assert plugin.get_prompts() == {
+            "shared": "inherited",
+            "local": "local",
+            "overridden": "new",
+        }
+        sections = plugin.plugin_config["plugins"]
+        assert list(sections) == ["contract_demo"]
+        assert len(sections) == 1
+        assert (
+            sections.copy()
+            == dict(sections)
+            == {"contract_demo": sections["CONTRACT_DEMO"]}
+        )
+
+    finally:
+        sys.modules.pop(package_name, None)
+
+
+@pytest.mark.parametrize(
+    "invalid_field",
+    (
+        "extensions: .demo",
+        "priority: true",
+        'capabilities: {codegraph: "false"}',
+        "extension: [.demo]",
+    ),
+)
+def test_language_manifest_rejects_malformed_raw_fields(tmp_path, invalid_field):
+    path = tmp_path / "manifest.yaml"
+    path.write_text(
+        "name: demo\nconfig_resource: languages/c.yaml\n" + invalid_field + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        registry_module.LanguagePluginManifest.from_mapping(load_yaml(path))
+
+
+def test_language_override_uses_manifest_name_normalization(tmp_path):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        "llm_provider: {name: ollama, model: test-model}\n"
+        "language_plugins:\n"
+        '  " C ": {name: " c ", extensions: [.contract-c]}\n',
+        encoding="utf-8",
+    )
+
+    runtime = load_runtime_config(config_path)
+    registry = registry_module.LanguagePluginRegistry.from_config(
+        runtime["plugin_config"]
+    )
+
+    manifest = registry.get_manifest_for_path("example.contract-c")
+    assert manifest.name == "c"
+    assert manifest.config_resource == "languages/c.yaml"
+
+
+def test_language_override_rejects_duplicate_normalized_names(tmp_path):
+    config_path = tmp_path / "metis.yaml"
+    config_path.write_text(
+        "llm_provider: {name: ollama, model: test-model}\n"
+        "language_plugins:\n"
+        "  C: {extensions: [.first]}\n"
+        "  c: {extensions: [.second]}\n",
+        encoding="utf-8",
+    )
+    runtime = load_runtime_config(config_path)
+
+    with pytest.raises(ValueError, match="Duplicate language plugin override 'c'"):
+        registry_module.LanguagePluginRegistry.from_config(runtime["plugin_config"])
+
+
+@pytest.mark.parametrize(
+    ("name", "nested_name"),
+    [("c", "cpp"), ("new_language", "c"), ("c", None)],
+)
+def test_language_override_cannot_change_identity(name, nested_name):
+    with pytest.raises(ValueError, match="name must"):
+        registry_module.LanguagePluginRegistry.from_config(
+            {
+                "language_plugins": {
+                    name: {
+                        "name": nested_name,
+                        "extensions": [".replacement"],
+                        "config_resource": "languages/c.yaml",
+                    }
+                }
+            }
+        )
+
+
+def test_language_registry_rejects_duplicate_normalized_names():
+    with pytest.raises(ValueError, match="Duplicate language plugin name 'c'"):
+        _build_registry(
+            registry_module,
+            [
+                _make_manifest(registry_module),
+                _make_manifest(registry_module, name=" C "),
+            ],
+        )
+
+
+@pytest.mark.parametrize("priorities", [(0, 10), (10, 10)])
+def test_language_aliases_use_priority_and_reject_ambiguity(priorities):
+    manifests = [
+        _make_manifest(
+            registry_module, name=name, aliases=["shared"], priority=priority
+        )
+        for name, priority in zip(("first", "second"), priorities)
+    ]
+    for ordered in (manifests, manifests[::-1]):
+        registry = _build_registry(registry_module, ordered)
+        if priorities[0] == priorities[1]:
+            with pytest.raises(ValueError, match="Ambiguous language plugin match"):
+                registry.get_manifest("shared")
+        else:
+            assert registry.get_manifest("SHARED").name == "second"
+        assert registry.get_manifest("first").name == "first"
+
+
+def test_canonical_language_name_precedes_alias_priority():
+    registry = _build_registry(
+        registry_module,
+        [
+            _make_manifest(registry_module, name="first"),
+            _make_manifest(
+                registry_module, name="second", aliases=["first"], priority=100
+            ),
+        ],
+    )
+    assert registry.get_manifest("first").name == "first"
+
+
+@pytest.mark.parametrize("section", ("splitting", "prompts"))
+@pytest.mark.parametrize("source", ("language", "profile"))
+def test_language_config_validates_merged_sections_before_caching(
+    tmp_path, monkeypatch, section, source
+):
+    package_name = f"language_invalid_{section}_{source}"
+    package = tmp_path / package_name
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    language_path = package / "language.yaml"
+    profile_path = package / "profile.yaml"
+    language_path.write_text(
+        f"inherits: {package_name}:profile.yaml\n", encoding="utf-8"
+    )
+    profile_path.write_text("custom_setting: {preserved: true}\n", encoding="utf-8")
+    malformed = language_path if source == "language" else profile_path
+    with malformed.open("a", encoding="utf-8") as handle:
+        handle.write(f"{section}: []\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    registry = _build_registry(
+        registry_module,
+        [
+            _make_manifest(
+                registry_module,
+                implementation="",
+                config_resource=f"{package_name}:language.yaml",
+            )
+        ],
+    )
+    try:
+        plugin = registry.get_plugin("c")
+        for get_config in (
+            plugin.get_prompts,
+            lambda: registry.get_prompts_for_language("c"),
+        ):
+            with pytest.raises(
+                ValueError, match=f"resource .*{section} must be a mapping"
+            ):
+                get_config()
+        malformed.write_text(
+            malformed.read_text(encoding="utf-8").replace(
+                f"{section}: []", f"{section}: {{}}"
+            ),
+            encoding="utf-8",
+        )
+        assert plugin.get_prompts() == {}
+        assert plugin.plugin_config["plugins"]["c"]["custom_setting"] == {
+            "preserved": True
+        }
+    finally:
+        sys.modules.pop(package_name, None)

--- a/tests/test_memory_backend.py
+++ b/tests/test_memory_backend.py
@@ -30,29 +30,6 @@ def test_sqlite_memory_store_closes_connections(tmp_path, monkeypatch):
             connection.execute("SELECT 1")
 
 
-def test_sqlite_memory_store_round_trips_namespace_key_value(tmp_path):
-    store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
-    namespace = ("metis", "profiles", "repo")
-    value = {
-        "artifact_type": "target_profile",
-        "schema_version": 1,
-        "repo_fingerprint": "repo1",
-        "input_fingerprint": "input1",
-        "memory_type": "semantic",
-        "metadata": {"authority": "documented"},
-        "summary_text": "Documented trust boundary",
-        "search_text": "trust boundary cli filesystem",
-    }
-
-    store.put(namespace, "active", value)
-
-    item = store.get(namespace, "active")
-    assert item is not None
-    assert item.namespace == namespace
-    assert item.key == "active"
-    assert item.value == value
-
-
 def test_sqlite_memory_store_search_filter_namespaces_and_delete(tmp_path):
     store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
     store.put(

--- a/tests/test_memory_contracts.py
+++ b/tests/test_memory_contracts.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from langgraph.store.base import PutOp
+from langgraph.store.memory import InMemoryStore
+import pytest
+
+from metis.memory import MemoryRecord
+from metis.memory import MemoryService
+from metis.memory import SQLiteMemoryStore
+
+
+@pytest.fixture(params=["sqlite", "memory"])
+def service(request, tmp_path):
+    store = (
+        SQLiteMemoryStore(tmp_path / "memory.sqlite3")
+        if request.param == "sqlite"
+        else InMemoryStore()
+    )
+    return MemoryService(store)
+
+
+def _record(key="note", namespace=("repo", "notes"), **values):
+    return MemoryRecord.create(
+        namespace=namespace,
+        key=key,
+        tool_version="test",
+        artifact_type="note",
+        repo_fingerprint="repo",
+        input_fingerprint="input",
+        memory_type="semantic",
+        **values,
+    )
+
+
+_INVALID_NAMESPACES = [
+    (),
+    ("repo", 1),
+    ("repo", "bad.label"),
+    ("repo", ""),
+    ("langgraph", "notes"),
+    ["repo", "notes"],
+    "repo",
+]
+
+
+@pytest.mark.parametrize("namespace", _INVALID_NAMESPACES)
+def test_replacement_rejects_invalid_namespaces_and_preserves_old_records(
+    service, namespace
+):
+    service.put_record(_record("old"))
+    with pytest.raises(ValueError, match="namespace"):
+        service.replace_records((), [_record("new"), _record("invalid", namespace)])
+    assert [record.key for record in service.iter_records()] == ["old"]
+    assert service.reset_records() == 1
+    assert list(service.iter_records()) == []
+
+
+@pytest.mark.parametrize("namespace", _INVALID_NAMESPACES)
+def test_native_sqlite_replacement_validates_every_namespace_before_mutation(
+    tmp_path, monkeypatch, namespace
+):
+    store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
+    store.put(("repo",), "old", {"value": "old"})
+
+    def unexpected_delete(*_args):
+        pytest.fail("invalid replacement started deleting the old snapshot")
+
+    monkeypatch.setattr(store, "_delete", unexpected_delete)
+    with pytest.raises(ValueError, match="namespace"):
+        store.replace_records(
+            (),
+            [
+                PutOp(("repo",), "valid", {"value": "valid"}),
+                PutOp(namespace, "invalid", {"value": "invalid"}),
+            ],
+        )
+    assert store.get(("repo",), "old").value == {"value": "old"}
+    assert store.get(("repo",), "valid") is None
+
+
+def test_sqlite_batch_rejects_invalid_namespace_and_rolls_back(tmp_path):
+    store = SQLiteMemoryStore(tmp_path / "memory.sqlite3")
+    store.put(("repo",), "old", {"value": "old"})
+    with pytest.raises(ValueError, match="namespace"):
+        store.batch(
+            [
+                PutOp(("repo",), "old", None),
+                PutOp(("repo", 1), "invalid", {"value": "invalid"}),
+            ]
+        )
+    assert [(item.namespace, item.key) for item in store.search(())] == [
+        (("repo",), "old")
+    ]
+
+
+@pytest.mark.parametrize("prefix", [("repo", ""), ["repo"], "repo"])
+def test_invalid_reset_prefix_cannot_clear_records(service, prefix):
+    service.put_record(_record("old"))
+    with pytest.raises(ValueError, match="namespace"):
+        service.reset_records(prefix)
+    assert [record.key for record in service.iter_records()] == ["old"]
+
+
+def test_namespace_reset_preserves_parent_and_similarly_named_siblings(service):
+    for key, namespace in (
+        ("parent", ("repo_%",)),
+        ("old", ("repo_%", "安全")),
+        ("sibling", ("repo_%", "安全-other")),
+    ):
+        service.put_record(_record(key, namespace))
+    assert (
+        service.replace_records(
+            ("repo_%", "安全"),
+            [_record("new", ("repo_%", "安全", "child"))],
+        )
+        == 1
+    )
+    assert service.reset_records(("repo_%", "安全")) == 1
+    assert {record.key for record in service.iter_records()} == {"parent", "sibling"}
+
+
+@pytest.mark.parametrize("write_method", ["create", "put", "replace"])
+def test_memory_writes_snapshot_nested_record_values(service, write_method):
+    body = {"sections": [{"text": "original"}]}
+    metadata = {"labels": ["original"]}
+    record = _record(body_json=body, metadata=metadata)
+    if write_method == "create":
+        values = record.to_store_value()
+        values.pop("tool_version")
+        values.update(body_json=body, metadata=metadata)
+        record = service.create_record(
+            namespace=record.namespace,
+            key=record.key,
+            **values,
+        )
+    elif write_method == "put":
+        service.put_record(record)
+    else:
+        service.replace_records(record.namespace, [record])
+    before = service.store.get(record.namespace, record.key)
+    body["sections"][0]["text"] = "changed input"
+    metadata["labels"].append("changed input")
+    record.body_json["sections"][0]["text"] = "changed record"
+    record.metadata["labels"].append("changed record")
+    stored = service.get_record(record.namespace, record.key)
+    assert stored.body_json == {"sections": [{"text": "original"}]}
+    assert stored.metadata == {"labels": ["original"]}
+    assert stored.input_fingerprint == "input"
+    assert (
+        service.store.get(record.namespace, record.key).updated_at == before.updated_at
+    )
+
+
+@pytest.mark.parametrize("read_method", ["get", "search", "iter"])
+def test_memory_reads_return_owned_nested_values(service, read_method):
+    record = _record(body_json=[{"text": "original"}], metadata={"labels": ["a"]})
+    service.put_record(record)
+    if read_method == "get":
+        loaded = service.get_record(record.namespace, record.key)
+    elif read_method == "search":
+        loaded = service.search_records(record.namespace)[0]
+    else:
+        loaded = next(service.iter_records(record.namespace))
+    loaded.body_json[0]["text"] = "changed"
+    loaded.metadata["labels"].append("changed")
+    stored = service.get_record(record.namespace, record.key)
+    assert stored.body_json == [{"text": "original"}]
+    assert stored.metadata == {"labels": ["a"]}

--- a/tests/test_metisignore.py
+++ b/tests/test_metisignore.py
@@ -3,7 +3,6 @@
 
 from pathlib import Path
 import threading
-from types import SimpleNamespace
 
 import metis.engine.capabilities.indexing as indexing_service_mod
 from metis.engine import MetisEngine
@@ -174,31 +173,10 @@ def test_index_prepare_nodes_respects_nested_metisignore_allowlist(
 
     engine = _build_engine(tmp_path, dummy_backend, dummy_llm, capability_settings)
 
-    documents = [
-        SimpleNamespace(
-            id_=str(tmp_path / "src" / "keep.py"),
-            doc_id=str(tmp_path / "src" / "keep.py"),
-        ),
-        SimpleNamespace(
-            id_=str(tmp_path / "src" / "drop.py"),
-            doc_id=str(tmp_path / "src" / "drop.py"),
-        ),
-        SimpleNamespace(
-            id_=str(tmp_path / "README.md"),
-            doc_id=str(tmp_path / "README.md"),
-        ),
-        SimpleNamespace(
-            id_=str(tmp_path / "notes.md"),
-            doc_id=str(tmp_path / "notes.md"),
-        ),
-    ]
-
-    class _DummyReader:
-        def __init__(self, **_kwargs):
-            pass
-
-        def load_data(self):
-            return list(documents)
+    for name in ("src/keep.py", "src/drop.py", "README.md", "notes.md"):
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("inert text\n", encoding="utf-8")
 
     captured = {}
 
@@ -209,7 +187,6 @@ def test_index_prepare_nodes_respects_nested_metisignore_allowlist(
             yield None
         return (["code-node"], ["doc-node"])
 
-    monkeypatch.setattr(indexing_service_mod, "SimpleDirectoryReader", _DummyReader)
     monkeypatch.setattr(
         indexing_service_mod, "prepare_nodes_iter", _fake_prepare_nodes_iter
     )

--- a/tests/test_navigation_capability.py
+++ b/tests/test_navigation_capability.py
@@ -150,3 +150,14 @@ def test_shell_navigation_serializes_subprocesses(tmp_path, monkeypatch):
 
     assert results == ("match", "match")
     assert peak == 1
+
+
+@pytest.mark.parametrize("separator", ["\u2028", "\u2029", "\x85", "\v", "\f"])
+def test_navigation_uses_canonical_source_lines(tmp_path, separator):
+    (tmp_path / "input.txt").write_text(
+        f"first{separator}fragment\nsecond\n", encoding="utf-8"
+    )
+    runner = _build_runner(tmp_path)
+    assert runner.cat("input.txt") == f"1: first{separator}fragment\n2: second"
+    assert runner.sed("input.txt", 2, 2) == "2: second"
+    assert runner.grep("second", "input.txt") == "input.txt:2:second"

--- a/tests/test_persistence_e2e.py
+++ b/tests/test_persistence_e2e.py
@@ -1,0 +1,663 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise persistence across real connections and independently created services."""
+
+from concurrent.futures import CancelledError
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
+from pathlib import Path
+import sqlite3
+from threading import Barrier
+from threading import Event
+from threading import RLock
+from threading import Thread
+from types import SimpleNamespace
+
+from langgraph.store.memory import InMemoryStore
+import pytest
+
+from metis.cli import review_checkpoints
+from metis.cli.review_checkpoints import review_checkpoint_callbacks
+from metis.engine.codegraph import CodeGraph
+from metis.engine.codegraph import CodeGraphDiagnostic
+from metis.engine.codegraph import CodeGraphReference
+from metis.engine.codegraph import CodeGraphResult
+from metis.engine.codegraph import FunctionNode
+from metis.engine.execution.contracts import NodeCallbacks
+from metis.engine.nodes.codegraph import CodeGraphService
+from metis.engine.nodes.codegraph import store as graph_store
+from metis.engine.nodes.codegraph.store import SQLiteCodeGraphStore
+from metis.engine.repository import EngineRepository
+from metis.engine.runtime import EngineState
+from metis.engine.stages.review.checkpoints import ReviewCheckpointSession
+from metis.memory import MemoryRecord
+from metis.memory import MemoryService
+from metis.memory import SQLiteMemoryStore
+from metis.memory import service as memory_service
+from metis.plugins.registry import LanguagePluginRegistry
+from metis.version import __version__ as METIS_VERSION
+
+
+class _ObservedLock:
+    def __init__(self, lock):
+        self._lock = lock
+        self.contended = Event()
+
+    def __enter__(self):
+        if not self._lock.acquire(blocking=False):
+            self.contended.set()
+            assert self._lock.acquire(timeout=5)
+        return self
+
+    def __exit__(self, *_args):
+        self._lock.release()
+
+
+def _checkpoint_callbacks(root):
+    callbacks = review_checkpoint_callbacks(codebase_path=root, enabled=True)
+    return NodeCallbacks(
+        checkpoint=callbacks["review_checkpoint_callback"],
+        resume=callbacks["review_resume_callback"],
+    )
+
+
+def _memory_record(key, namespace=("repo", "notes")):
+    return MemoryRecord.create(
+        namespace=namespace,
+        key=key,
+        tool_version=METIS_VERSION,
+        artifact_type="note",
+        repo_fingerprint="repository",
+        input_fingerprint="input",
+        memory_type="semantic",
+        summary_text=key,
+        search_text=key,
+        metadata={"authority": "documented"},
+    )
+
+
+def _graph_service(root, factory):
+    registry = LanguagePluginRegistry(
+        [
+            {
+                "name": "fixture",
+                "config_resource": "languages/python.yaml",
+                "extensions": [".fixture"],
+                "capabilities": {"codegraph": True},
+            }
+        ]
+    )
+    config = SimpleNamespace(
+        codebase_path=str(root),
+        language_registry=registry,
+        metisignore_file=None,
+        review_code_include_paths=[],
+        review_code_exclude_paths=[],
+    )
+    return CodeGraphService(
+        config, EngineRepository(config, EngineState()), {"fixture": factory}
+    )
+
+
+def _save_graph(
+    store, *, failed=(), fingerprint="stable-input", producer_version=METIS_VERSION
+):
+    graph = CodeGraph()
+    graph.add_node(FunctionNode("module.fixture::entry", "module.fixture", "entry", 1))
+    return store.save(
+        fingerprint=fingerprint,
+        producer_version=producer_version,
+        graph=graph,
+        processed_files=("module.fixture",),
+        failed_files=failed,
+        diagnostics=(),
+    )
+
+
+def test_checkpoint_session_round_trip_keeps_concurrent_updates_ordered(tmp_path):
+    callbacks = _checkpoint_callbacks(tmp_path)
+    first_started, release_first, second_started = Event(), Event(), Event()
+    observed = []
+    session = None
+
+    def persist(payload, processed, total):
+        # Observers may inspect the session without acquiring the write-order lock.
+        observed.append(session.get(payload["key"]))
+        if payload["record"]["revision"] == 1:
+            first_started.set()
+            assert release_first.wait(5)
+        else:
+            second_started.set()
+        callbacks.checkpoint(payload, processed, total)
+
+    session = ReviewCheckpointSession("fixture", NodeCallbacks(checkpoint=persist))
+    write_lock = _ObservedLock(session._write_lock)
+    session._write_lock = write_lock
+    first = Thread(target=session.put, args=("same-key", {"revision": 1}), daemon=True)
+    second = Thread(target=session.put, args=("same-key", {"revision": 2}), daemon=True)
+    first.start()
+    try:
+        assert first_started.wait(5)
+        second.start()
+        assert write_lock.contended.wait(5)
+        assert not second_started.is_set()
+    finally:
+        release_first.set()
+        first.join(timeout=5)
+        if second.ident is not None:
+            second.join(timeout=5)
+    assert not first.is_alive() and not second.is_alive()
+
+    reopened = ReviewCheckpointSession("fixture", _checkpoint_callbacks(tmp_path))
+    assert observed == [{"revision": 1}, {"revision": 2}]
+    assert reopened.has_records
+    assert reopened.get("same-key") == session.get("same-key") == {"revision": 2}
+    reopened.put("other-key", {"revision": 3})
+    restarted = ReviewCheckpointSession("fixture", _checkpoint_callbacks(tmp_path))
+    assert restarted.get("same-key") == {"revision": 2}
+    assert restarted.get("other-key") == {"revision": 3}
+
+
+@pytest.mark.parametrize("failure_type", [None, RuntimeError, CancelledError])
+def test_checkpoint_session_defers_reentrant_writes_and_preserves_failures(
+    tmp_path, failure_type
+):
+    callbacks = _checkpoint_callbacks(tmp_path)
+    failure = failure_type("inert checkpoint failure") if failure_type else None
+    attempts, errors = [], []
+    session = None
+
+    def persist(payload, processed, total):
+        revision = payload["record"]["revision"]
+        attempts.append(revision)
+        if revision == 1:
+            session.put("key", {"revision": 2})
+            if failure is not None:
+                raise failure
+        callbacks.checkpoint(payload, processed, total)
+
+    session = ReviewCheckpointSession("fixture", NodeCallbacks(checkpoint=persist))
+
+    def write():
+        try:
+            session.put("key", {"revision": 1})
+        except BaseException as exc:
+            errors.append(exc)
+
+    worker = Thread(target=write, daemon=True)
+    worker.start()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert session.get("key") == {"revision": 2}
+    reopened = ReviewCheckpointSession("fixture", _checkpoint_callbacks(tmp_path))
+    if failure_type is CancelledError:
+        assert errors == [failure]
+        assert attempts == [1]
+        assert reopened.get("key") is None
+    else:
+        assert errors == []
+        assert attempts == [1, 2]
+        assert reopened.get("key") == {"revision": 2}
+
+    session.put("key", {"revision": 3})
+    assert attempts == ([1, 3] if failure_type is CancelledError else [1, 2, 3])
+    assert ReviewCheckpointSession("fixture", _checkpoint_callbacks(tmp_path)).get(
+        "key"
+    ) == {"revision": 3}
+
+
+def test_legacy_checkpoint_resume_isolates_producer_and_version(tmp_path):
+    path = tmp_path / ".metis/checkpoints/review.alpha.sqlite3"
+    path.parent.mkdir(parents=True)
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute(
+            "CREATE TABLE review_checkpoint_records (producer TEXT NOT NULL, "
+            "metis_version TEXT NOT NULL, record_key TEXT NOT NULL, payload TEXT NOT NULL, "
+            "PRIMARY KEY(producer, metis_version, record_key)) WITHOUT ROWID"
+        )
+        connection.executemany(
+            "INSERT INTO review_checkpoint_records VALUES (?, ?, ?, ?)",
+            [
+                ("alpha", METIS_VERSION, "same-key", '{"value":"alpha"}'),
+                ("beta", METIS_VERSION, "same-key", '{"value":"beta"}'),
+                ("alpha", "old-version", "stale", '{"value":"stale"}'),
+                ("alpha", METIS_VERSION, "malformed", "{invalid"),
+            ],
+        )
+    session = ReviewCheckpointSession("alpha", _checkpoint_callbacks(tmp_path))
+    assert session.get("same-key") == {"value": "alpha"}
+    assert session.get("stale") is None
+    assert session.get("malformed") is None
+    session.put("new-key", {"value": "new"})
+    restarted = ReviewCheckpointSession("alpha", _checkpoint_callbacks(tmp_path))
+    assert restarted.get("same-key") == {"value": "alpha"}
+    assert restarted.get("new-key") == {"value": "new"}
+    with closing(sqlite3.connect(path)) as connection, connection:
+        assert connection.execute(
+            "SELECT payload FROM review_checkpoint_records WHERE producer = 'beta'"
+        ).fetchone() == ('{"value":"beta"}',)
+
+
+def test_readonly_checkpoint_write_preserves_committed_resume(
+    tmp_path, monkeypatch, caplog
+):
+    session = ReviewCheckpointSession("fixture", _checkpoint_callbacks(tmp_path))
+    session.put("key", {"value": "committed"})
+    path = tmp_path / ".metis/checkpoints/review.fixture.sqlite3"
+    committed = path.read_bytes()
+    # SQLite itself raises READONLY; the injection only selects connection mode.
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            review_checkpoints,
+            "_connect_checkpoint",
+            lambda path: sqlite3.connect(f"{path.as_uri()}?mode=ro", uri=True),
+        )
+        session.put("key", {"value": "uncommitted"})
+    assert "Unable to save review checkpoint" in caplog.text
+    assert path.read_bytes() == committed
+    restarted = ReviewCheckpointSession("fixture", _checkpoint_callbacks(tmp_path))
+    assert restarted.get("key") == {"value": "committed"}
+    restarted.put("key", {"value": "retried"})
+    assert ReviewCheckpointSession("fixture", _checkpoint_callbacks(tmp_path)).get(
+        "key"
+    ) == {"value": "retried"}
+
+
+def test_materialization_retry_keeps_issued_references_across_service_restart(tmp_path):
+    (tmp_path / "module.fixture").write_text("entry\n", encoding="utf-8")
+    attempts = []
+
+    def build_graph(*, codebase_path, files, progress_callback=None):
+        attempts.append(files)
+        if len(attempts) == 1:
+            return CodeGraphResult(
+                CodeGraph(),
+                (),
+                diagnostics=tuple(
+                    CodeGraphDiagnostic(path, "incomplete fixture") for path in files
+                ),
+                failed_files=files,
+            )
+        graph = CodeGraph()
+        graph.add_node(
+            FunctionNode("module.fixture::entry", "module.fixture", "entry", 1)
+        )
+        return CodeGraphResult(graph, files)
+
+    def factory(_context):
+        return SimpleNamespace(build_graph=build_graph)
+
+    first_service = _graph_service(tmp_path, factory)
+    incomplete = first_service.materialize()
+    second_service = _graph_service(tmp_path, factory)
+    complete = second_service.materialize()
+    assert incomplete.failed_files
+    assert not complete.failed_files
+    assert incomplete.fingerprint == complete.fingerprint
+    assert complete.revision > incomplete.revision
+    restarted = _graph_service(tmp_path, factory)
+    assert restarted.load(incomplete).node_count() == 0
+    assert restarted.load(complete).get_node("module.fixture::entry") is not None
+    assert restarted.materialize() == complete
+    assert len(attempts) == 2
+
+
+def test_interrupted_materialization_can_retry_on_same_service(tmp_path):
+    (tmp_path / "module.fixture").write_text("entry\n", encoding="utf-8")
+    attempts = 0
+
+    def build_graph(*, codebase_path, files, progress_callback=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise KeyboardInterrupt("inert provider interruption")
+        return CodeGraphResult(CodeGraph(), files)
+
+    def factory(_context):
+        return SimpleNamespace(build_graph=build_graph)
+
+    service = _graph_service(tmp_path, factory)
+    with pytest.raises(KeyboardInterrupt, match="inert provider interruption"):
+        service.materialize()
+    # A bounded daemon thread keeps a latch regression from hanging the suite.
+    completed = Event()
+    references = []
+
+    def retry():
+        references.append(service.materialize())
+        completed.set()
+
+    worker = Thread(target=retry, daemon=True)
+    worker.start()
+    assert completed.wait(5)
+    worker.join(timeout=1)
+    assert service.load(references[0]).node_count() == 0
+
+
+@pytest.mark.parametrize("revision", [2**63 - 1, 2**63, 2**80])
+def test_unknown_graph_revisions_handle_sqlite_integer_limits(tmp_path, revision):
+    store = SQLiteCodeGraphStore(str(tmp_path))
+    original = _save_graph(store)
+    unknown = CodeGraphReference.model_validate(
+        {**original.model_dump(), "revision": revision}
+    )
+    with pytest.raises(ValueError, match="reference does not exist"):
+        store.load(unknown, codebase_path=str(tmp_path))
+    assert store.load(original, codebase_path=str(tmp_path)).node_count() == 1
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"message": None},
+        {"phase": "unsupported"},
+        {"partial_output": "yes"},
+        {"start_byte": 1.5, "end_byte": 2.5},
+        {"severity": []},
+        {"file_path": [], "severity": "error"},
+    ],
+)
+def test_invalid_provider_diagnostics_remain_loadable_and_can_retry(tmp_path, changes):
+    (tmp_path / "module.fixture").write_text("inert fixture", encoding="utf-8")
+    fields = {
+        "file_path": "module.fixture",
+        "message": "fixture",
+        "severity": "warning",
+    }
+    fields.update(changes)
+    diagnostics = (CodeGraphDiagnostic(**fields),)
+
+    def build_graph(*, files, **kwargs):
+        return CodeGraphResult(CodeGraph(), files, diagnostics=diagnostics)
+
+    def factory(_context):
+        return SimpleNamespace(build_graph=build_graph)
+
+    service = _graph_service(tmp_path, factory)
+    incomplete = service.materialize()
+    assert incomplete.failed_files == (str(tmp_path / "module.fixture"),)
+    assert "invalid diagnostic" in incomplete.diagnostics[0].message
+    assert service.load(incomplete).node_count() == 0
+    diagnostics = ()
+    complete = service.materialize()
+    assert not complete.failed_files
+    assert complete.revision > incomplete.revision
+    restarted = _graph_service(tmp_path, factory)
+    assert restarted.load(incomplete).node_count() == 0
+    assert restarted.load(complete).node_count() == 0
+    assert restarted.materialize() == complete
+
+
+@pytest.mark.parametrize("field", ["fingerprint", "producer_version"])
+def test_invalid_graph_reference_metadata_rolls_back_before_retry(tmp_path, field):
+    store = SQLiteCodeGraphStore(str(tmp_path))
+    original = _save_graph(store)
+    with closing(sqlite3.connect(store.location)) as connection:
+        before = tuple(connection.iterdump())
+    with pytest.raises(ValueError, match=field):
+        _save_graph(store, **{field: ""})
+    with closing(sqlite3.connect(store.location)) as connection:
+        assert tuple(connection.iterdump()) == before
+    assert store.load(original, codebase_path=str(tmp_path)).node_count() == 1
+    retried = _save_graph(store)
+    assert retried.revision == original.revision + 1
+    assert store.load(retried, codebase_path=str(tmp_path)).node_count() == 1
+
+
+@pytest.mark.parametrize("locations", [[], ["", "  "]])
+def test_graph_declarations_without_locations_survive_restart(tmp_path, locations):
+    graph = CodeGraph()
+    graph.add_public_declarations(
+        {"declared": locations, "located": ["module.fixture:1"]}
+    )
+    store = SQLiteCodeGraphStore(str(tmp_path))
+    reference = store.save(
+        fingerprint="declarations",
+        producer_version=METIS_VERSION,
+        graph=graph,
+        processed_files=(),
+        failed_files=(),
+        diagnostics=(),
+    )
+    reopened = SQLiteCodeGraphStore(str(tmp_path))
+    loaded = reopened.load(reference, codebase_path=str(tmp_path))
+    assert loaded.public_declarations == {
+        "declared": [],
+        "located": ["module.fixture:1"],
+    }
+    assert (
+        reopened.reference_for_fingerprint("declarations", codebase_path=str(tmp_path))
+        == reference
+    )
+
+
+def test_v2_graph_constraint_migration_preserves_references_with_two_initializers(
+    tmp_path,
+):
+    (tmp_path / "module.fixture").write_text("entry\n", encoding="utf-8")
+    initial = SQLiteCodeGraphStore(str(tmp_path))
+    reference = _save_graph(initial)
+    with closing(sqlite3.connect(initial.location)) as connection, connection:
+        connection.execute(
+            "CREATE UNIQUE INDEX legacy_fingerprint ON canonical_codegraph(fingerprint)"
+        )
+    ready = Barrier(2)
+
+    def open_store():
+        ready.wait(timeout=5)
+        return SQLiteCodeGraphStore(str(tmp_path))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        stores = [
+            future.result(timeout=5)
+            for future in [pool.submit(open_store), pool.submit(open_store)]
+        ]
+    later = _save_graph(stores[0], failed=("other.fixture",))
+    for issued in (reference, later):
+        assert (
+            stores[1]
+            .load(issued, codebase_path=str(tmp_path))
+            .get_node("module.fixture::entry")
+        )
+    assert (
+        stores[1].reference_for_fingerprint("stable-input", codebase_path=str(tmp_path))
+        == reference
+    )
+    with closing(graph_store._connect(initial.location)) as connection:
+        assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                "INSERT INTO codegraph_records VALUES (9999, 0, 'failed', 'absent', X'')"
+            )
+
+
+def test_newer_graph_schema_is_preserved_for_its_own_reader(tmp_path):
+    (tmp_path / "module.fixture").write_text("entry\n", encoding="utf-8")
+    store = SQLiteCodeGraphStore(str(tmp_path))
+    reference = _save_graph(store)
+    with closing(sqlite3.connect(store.location)) as connection, connection:
+        connection.execute("PRAGMA user_version = 999")
+    before = Path(store.location).read_bytes()
+    with pytest.raises(RuntimeError, match="newer schema"):
+        SQLiteCodeGraphStore(str(tmp_path))
+    assert Path(store.location).read_bytes() == before
+    assert store.load(reference, codebase_path=str(tmp_path)).get_node(
+        "module.fixture::entry"
+    )
+
+
+def test_graph_migration_failure_rolls_back_metadata_and_records(tmp_path, monkeypatch):
+    (tmp_path / "module.fixture").write_text("entry\n", encoding="utf-8")
+    store = SQLiteCodeGraphStore(str(tmp_path))
+    reference = _save_graph(store)
+    with closing(sqlite3.connect(store.location)) as connection, connection:
+        connection.execute(
+            "CREATE UNIQUE INDEX legacy_fingerprint ON canonical_codegraph(fingerprint)"
+        )
+
+    class InterruptedMigration(sqlite3.Connection):
+        def execute(self, sql, *args):
+            if sql.startswith("ALTER TABLE canonical_codegraph_revisions"):
+                raise sqlite3.OperationalError("inert migration interruption")
+            return super().execute(sql, *args)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            graph_store,
+            "_connect",
+            lambda path: sqlite3.connect(path, factory=InterruptedMigration),
+        )
+        with pytest.raises(RuntimeError, match="inert migration interruption"):
+            SQLiteCodeGraphStore(str(tmp_path))
+    assert store.load(reference, codebase_path=str(tmp_path)).get_node(
+        "module.fixture::entry"
+    )
+    with closing(sqlite3.connect(store.location)) as connection, connection:
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert (
+            connection.execute(
+                "SELECT name FROM sqlite_master WHERE name = 'canonical_codegraph_revisions'"
+            ).fetchall()
+            == []
+        )
+    reopened = SQLiteCodeGraphStore(str(tmp_path))
+    assert reopened.load(reference, codebase_path=str(tmp_path)).node_count() == 1
+
+
+def test_sqlite_memory_round_trip_survives_service_and_connection_restart(tmp_path):
+    path = tmp_path / "memory.sqlite3"
+    service = MemoryService(SQLiteMemoryStore(path))
+    record = _memory_record("active")
+    service.put_record(record)
+    service.close()
+    restarted = MemoryService(SQLiteMemoryStore(path))
+    loaded = restarted.get_record(record.namespace, record.key)
+    assert loaded is not None
+    assert loaded.namespace == record.namespace
+    assert loaded.key == record.key
+    assert loaded.to_store_value() == record.to_store_value()
+    assert restarted.search_records(record.namespace, query="active")[0].key == "active"
+    assert restarted.store.list_namespaces(prefix=("repo",)) == [record.namespace]
+
+
+def test_sqlite_namespace_replacement_is_one_snapshot_across_instances(tmp_path):
+    path = tmp_path / "memory.sqlite3"
+    first_inserted, release_first, second_started = Event(), Event(), Event()
+
+    class PausingStore(SQLiteMemoryStore):
+        def _put(self, connection, namespace, key, value):
+            super()._put(connection, namespace, key, value)
+            if key == "a-first":
+                first_inserted.set()
+                assert release_first.wait(5)
+
+    first = MemoryService(PausingStore(path))
+    second = MemoryService(SQLiteMemoryStore(path))
+    observer = MemoryService(SQLiteMemoryStore(path))
+    for key in ("old-first", "old-second"):
+        first.put_record(_memory_record(key))
+    first.put_record(_memory_record("untouched", ("repo", "other")))
+    # Initialize the other connection before pausing the first write transaction.
+    assert second.get_record(("repo", "notes"), "old-first") is not None
+
+    def replace_second():
+        second_started.set()
+        return second.replace_records(
+            ("repo", "notes"), [_memory_record("b-first"), _memory_record("b-second")]
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        writing = pool.submit(
+            first.replace_records,
+            ("repo", "notes"),
+            [_memory_record("a-first"), _memory_record("a-second")],
+        )
+        assert first_inserted.wait(5)
+        assert {record.key for record in observer.iter_records(("repo", "notes"))} == {
+            "old-first",
+            "old-second",
+        }
+        competing = pool.submit(replace_second)
+        assert second_started.wait(5)
+        release_first.set()
+        assert writing.result(timeout=5) == competing.result(timeout=5) == 2
+    restarted = MemoryService(SQLiteMemoryStore(path))
+    assert {record.key for record in restarted.iter_records(("repo", "notes"))} == {
+        "b-first",
+        "b-second",
+    }
+    assert restarted.search_records(("repo", "notes"), query="old") == []
+    assert restarted.search_records(("repo", "notes"), query="a") == []
+    assert restarted.get_record(("repo", "other"), "untouched") is not None
+
+
+def test_sqlite_namespace_failed_replacement_rolls_back_data_and_search_index(tmp_path):
+    path = tmp_path / "memory.sqlite3"
+    service = MemoryService(SQLiteMemoryStore(path))
+    service.put_record(_memory_record("old"))
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute(
+            "CREATE TRIGGER reject_fixture BEFORE INSERT ON memory_records "
+            "WHEN NEW.key = 'rejected' BEGIN SELECT RAISE(FAIL, 'inert rejected row'); END"
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="inert rejected row"):
+        service.replace_records(
+            ("repo", "notes"), [_memory_record("inserted"), _memory_record("rejected")]
+        )
+    reopened = MemoryService(SQLiteMemoryStore(path))
+    assert [record.key for record in reopened.iter_records(("repo", "notes"))] == [
+        "old"
+    ]
+    assert [
+        record.key for record in reopened.search_records(("repo",), query="old")
+    ] == ["old"]
+    assert reopened.search_records(("repo",), query="inserted") == []
+    assert reopened.reset_records(("repo", "notes")) == 1
+    assert (
+        MemoryService(SQLiteMemoryStore(path)).search_records(("repo",), query="old")
+        == []
+    )
+
+
+def test_temporary_memory_replacement_is_serial_across_service_wrappers(monkeypatch):
+    first_read, release_first, second_read = Event(), Event(), Event()
+
+    class PausingStore(InMemoryStore):
+        paused = False
+
+        def search(self, *args, **kwargs):
+            snapshot = super().search(*args, **kwargs)
+            if not self.paused:
+                self.paused = True
+                first_read.set()
+                assert release_first.wait(5)
+            else:
+                second_read.set()
+            return snapshot
+
+    store = PausingStore()
+    replacement_lock = _ObservedLock(RLock())
+    monkeypatch.setitem(
+        memory_service._IN_MEMORY_REPLACEMENT_LOCKS, store, replacement_lock
+    )
+    first, second = MemoryService(store), MemoryService(store)
+    first.put_record(_memory_record("old"))
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first_job = pool.submit(
+            first.replace_records, ("repo", "notes"), [_memory_record("first")]
+        )
+        try:
+            assert first_read.wait(5)
+            second_job = pool.submit(
+                second.replace_records, ("repo", "notes"), [_memory_record("second")]
+            )
+            assert replacement_lock.contended.wait(5)
+            assert not second_read.is_set()
+        finally:
+            release_first.set()
+        assert first_job.result(timeout=5) == second_job.result(timeout=5) == 1
+    assert [record.key for record in first.iter_records(("repo",))] == ["second"]
+    assert first.reset_records(("repo", "notes")) == 1
+    assert list(second.iter_records(("repo",))) == []

--- a/tests/test_pg_backend_mocked_unit.py
+++ b/tests/test_pg_backend_mocked_unit.py
@@ -7,9 +7,8 @@ from unittest.mock import Mock
 import pytest
 
 
-@pytest.mark.postgres
 def test_pg_vectorstore_mocked_init(monkeypatch):
-    from metis.vector_store import pgvector_store
+    pgvector_store = pytest.importorskip("metis.vector_store.pgvector_store")
     from metis.vector_store.pgvector_store import PGVectorStoreImpl
 
     code_store = Mock()
@@ -40,9 +39,8 @@ def test_pg_vectorstore_mocked_init(monkeypatch):
     assert from_params.call_args_list[1].kwargs["use_halfvec"] is False
 
 
-@pytest.mark.postgres
 def test_pg_vectorstore_passes_halfvec_and_rewrites_hnsw_dist_method(monkeypatch):
-    from metis.vector_store import pgvector_store
+    pgvector_store = pytest.importorskip("metis.vector_store.pgvector_store")
     from metis.vector_store.pgvector_store import PGVectorStoreImpl
 
     from_params = Mock(side_effect=[Mock(), Mock()])
@@ -76,9 +74,8 @@ def test_pg_vectorstore_passes_halfvec_and_rewrites_hnsw_dist_method(monkeypatch
         assert call.kwargs["hnsw_kwargs"]["hnsw_dist_method"] == "halfvec_cosine_ops"
 
 
-@pytest.mark.postgres
 def test_pg_vectorstore_preserves_none_hnsw_kwargs(monkeypatch):
-    from metis.vector_store import pgvector_store
+    pgvector_store = pytest.importorskip("metis.vector_store.pgvector_store")
     from metis.vector_store.pgvector_store import PGVectorStoreImpl
 
     from_params = Mock(side_effect=[Mock(), Mock()])
@@ -105,7 +102,6 @@ def test_pg_vectorstore_preserves_none_hnsw_kwargs(monkeypatch):
     assert from_params.call_args_list[1].kwargs["hnsw_kwargs"] is None
 
 
-@pytest.mark.postgres
 def test_build_pg_backend_passes_halfvec_runtime_flag(monkeypatch):
     from metis.cli import utils
 
@@ -116,7 +112,9 @@ def test_build_pg_backend_passes_halfvec_runtime_flag(monkeypatch):
             constructed.update(kwargs)
 
     monkeypatch.setattr(utils, "PG_SUPPORTED", True)
-    monkeypatch.setattr(utils, "PGVectorStoreImpl", FakePGVectorStoreImpl)
+    monkeypatch.setattr(
+        utils, "PGVectorStoreImpl", FakePGVectorStoreImpl, raising=False
+    )
 
     backend = utils.build_pg_backend(
         SimpleNamespace(project_schema="test_schema"),

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -92,3 +92,52 @@ def test_registry_loads_nested_entry_point_with_extras(monkeypatch):
         },
     )
     assert get_chat_provider("example") is ChatProvider
+
+
+@pytest.mark.parametrize("get_provider", [get_chat_provider, get_embedding_provider])
+def test_registry_failed_lookups_do_not_retain_callers(get_provider):
+    import gc
+    import weakref
+    from importlib.metadata import EntryPoint, EntryPoints
+
+    from metis.providers import registry
+
+    class Payload:
+        pass
+
+    def failed_lookup():
+        payload = Payload()
+        try:
+            get_provider("broken")
+        except ValueError as exc:
+            assert "must be named" in str(exc)
+        else:
+            pytest.fail("Malformed provider registration was accepted")
+        return weakref.ref(payload)
+
+    with (
+        patch.multiple(
+            registry,
+            _CHAT_PROVIDERS={},
+            _EMBEDDING_PROVIDERS={},
+            _PROVIDER_LOADERS={},
+            _PROVIDER_LOADER_ERRORS={},
+            _PROVIDER_LOADERS_DISCOVERED=False,
+        ),
+        patch.object(
+            registry.metadata,
+            "entry_points",
+            return_value=EntryPoints(
+                [
+                    EntryPoint(
+                        name="broken.invalid",
+                        value="inert:Unused",
+                        group="metis.providers",
+                    )
+                ]
+            ),
+        ),
+    ):
+        references = [failed_lookup() for _ in range(3)]
+        gc.collect()
+        assert all(reference() is None for reference in references)

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public extension contracts must import independently of engine orchestration."""
+
+from itertools import permutations
+import os
+from pathlib import Path
+import subprocess
+import sys
+from textwrap import dedent
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "order",
+    permutations(
+        ("metis.execution_nodes", "metis.execution_stages", "metis.capabilities")
+    ),
+)
+def test_public_contracts_import_concurrently_without_loading_engine(order):
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            dedent(
+                """
+                from concurrent.futures import ThreadPoolExecutor
+                import importlib
+                import sys
+                from threading import Barrier
+
+                start = Barrier(6, timeout=5)
+
+                def load(name):
+                    start.wait()
+                    return importlib.import_module(name)
+
+                with ThreadPoolExecutor(max_workers=6) as executor:
+                    modules = list(executor.map(load, sys.argv[1:]))
+
+                assert "metis.engine.core" not in sys.modules
+                for module in modules:
+                    namespace = {}
+                    exec(f"from {module.__name__} import *", namespace)
+                    assert namespace.keys() - {"__builtins__"} == set(module.__all__)
+                    for name in module.__all__:
+                        assert namespace[name] is getattr(module, name)
+
+                from metis.engine import ExecutionGraphError, MetisEngine, TriageOptions
+                from metis.engine import core
+                from metis.runtime_settings import TriageOptions as RuntimeTriageOptions
+
+                assert ExecutionGraphError is core.ExecutionGraphError
+                assert MetisEngine is core.MetisEngine
+                assert TriageOptions is RuntimeTriageOptions
+                namespace = {}
+                exec("from metis.engine import *", namespace)
+                assert namespace.keys() - {"__builtins__"} == {
+                    "ExecutionGraphError", "MetisEngine", "TriageOptions"
+                }
+                assert namespace["MetisEngine"] is MetisEngine
+                engine = importlib.import_module("metis.engine")
+                assert not hasattr(engine, "missing_extension_contract")
+                """
+            ),
+            *order,
+            *order,
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_reachability_provider_registry.py
+++ b/tests/test_reachability_provider_registry.py
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import closing
 import os
 import sqlite3
+from concurrent.futures import CancelledError
 from concurrent.futures import ThreadPoolExecutor
 from threading import Condition
 from threading import Event
+from threading import Thread
 from types import SimpleNamespace
 
 import pytest
@@ -28,6 +31,7 @@ from metis.engine.codegraph import Tag
 from metis.engine.codegraph import ValueAssignment
 from metis.engine.nodes.codegraph import CodeGraphSemanticsCatalog
 from metis.engine.nodes.codegraph import CodeGraphService
+from metis.engine.nodes.codegraph.progress import CODEGRAPH_PROGRESS
 from metis.plugins.c_family.semantics import CFamilyCodeGraphSemantics
 
 
@@ -173,7 +177,12 @@ def test_materialize_persists_and_reuses_codegraph(tmp_path):
     assert (tmp_path / ".metis" / "codegraph.sqlite3").is_file()
     assert service.load(second).get_node("new") is None
     assert service.load(second).nodes["module.py::entry"].parameter_count == 2
-    with sqlite3.connect(tmp_path / ".metis" / "codegraph.sqlite3") as connection:
+    with (
+        closing(
+            sqlite3.connect(tmp_path / ".metis" / "codegraph.sqlite3")
+        ) as connection,
+        connection,
+    ):
         metadata_columns = {
             row[1]
             for row in connection.execute("PRAGMA table_info(canonical_codegraph)")
@@ -354,7 +363,12 @@ def test_load_rejects_incomplete_stored_codegraph(tmp_path):
         {"python": lambda _context: _provider(graph)},
     )
     reference = service.materialize()
-    with sqlite3.connect(tmp_path / ".metis" / "codegraph.sqlite3") as connection:
+    with (
+        closing(
+            sqlite3.connect(tmp_path / ".metis" / "codegraph.sqlite3")
+        ) as connection,
+        connection,
+    ):
         connection.execute(
             "DELETE FROM codegraph_records WHERE kind = 'node' AND identity = ?",
             ("module.py::entry",),
@@ -372,7 +386,7 @@ def test_load_rejects_incomplete_stored_codegraph(tmp_path):
 def test_materialize_replaces_main_branch_store_schema(tmp_path):
     store_path = tmp_path / ".metis" / "codegraph.sqlite3"
     store_path.parent.mkdir()
-    with sqlite3.connect(store_path) as connection:
+    with closing(sqlite3.connect(store_path)) as connection, connection:
         connection.execute(
             """
             CREATE TABLE canonical_codegraph (
@@ -394,7 +408,7 @@ def test_materialize_replaces_main_branch_store_schema(tmp_path):
     )
 
     loaded = service.load(service.materialize())
-    with sqlite3.connect(store_path) as connection:
+    with closing(sqlite3.connect(store_path)) as connection, connection:
         columns = {
             row[1]
             for row in connection.execute("PRAGMA table_info(canonical_codegraph)")
@@ -431,7 +445,7 @@ def test_failed_persistence_keeps_previous_graph(tmp_path):
     )
     first = service.materialize()
     store_path = tmp_path / ".metis" / "codegraph.sqlite3"
-    with sqlite3.connect(store_path) as connection:
+    with closing(sqlite3.connect(store_path)) as connection, connection:
         connection.execute(
             """
             CREATE TRIGGER reject_blocked_node
@@ -447,7 +461,7 @@ def test_failed_persistence_keeps_previous_graph(tmp_path):
     with pytest.raises(RuntimeError, match="Unable to persist CodeGraph store"):
         service.materialize()
 
-    with sqlite3.connect(store_path) as connection:
+    with closing(sqlite3.connect(store_path)) as connection, connection:
         stored_names = tuple(
             row[0]
             for row in connection.execute(
@@ -513,6 +527,62 @@ def test_materialize_reports_incomplete_provider_coverage(tmp_path):
     assert "invalid file coverage" in reference.diagnostics[0].message
 
 
+@pytest.mark.parametrize("phase", ["initialize", "build", "progress"])
+def test_provider_cancellation_propagates_and_materialization_can_retry(
+    tmp_path, phase
+):
+    interruption = CancelledError("inert provider cancellation")
+    interrupted = False
+
+    def interrupt(at):
+        nonlocal interrupted
+        if phase == at and not interrupted:
+            interrupted = True
+            raise interruption
+
+    def build_graph(*, files, progress_callback, **_kwargs):
+        interrupt("build")
+        progress_callback({"event": CODEGRAPH_PROGRESS, "completed": 1})
+        return CodeGraphResult(CodeGraph(), files)
+
+    def factory(_context):
+        interrupt("initialize")
+        return SimpleNamespace(build_graph=build_graph)
+
+    def progress(event):
+        if event["event"] == CODEGRAPH_PROGRESS:
+            interrupt("progress")
+
+    service = CodeGraphService(
+        SimpleNamespace(codebase_path=str(tmp_path)),
+        _repository(("module.py",), lambda _path: "python"),
+        {"python": factory},
+    )
+    with pytest.raises(CancelledError) as caught:
+        service.materialize(progress_callback=progress)
+    assert caught.value is interruption
+    assert not service._materialize_active
+    assert service._last_materialization is None
+
+    references, errors = [], []
+
+    def retry():
+        try:
+            references.append(service.materialize(progress_callback=progress))
+        except BaseException as exc:
+            errors.append(exc)
+
+    worker = Thread(target=retry, daemon=True)
+    worker.start()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert errors == []
+    assert len(references) == 1
+    assert not references[0].failed_files
+    assert service.load(references[0]).node_count() == 0
+    assert service.materialize() == references[0]
+
+
 def test_concurrent_materialize_serializes_canonical_builds(tmp_path):
     builds = []
 
@@ -549,7 +619,7 @@ def test_concurrent_materialize_shares_an_incomplete_attempt(tmp_path):
     def build_graph(**_kwargs):
         builds.append("build")
         build_started.set()
-        release_build.wait()
+        assert release_build.wait(5)
         return CodeGraphResult(CodeGraph(), ())
 
     service = CodeGraphService(
@@ -560,12 +630,14 @@ def test_concurrent_materialize_shares_an_incomplete_attempt(tmp_path):
     service._materialize_condition = TrackingCondition()
     with ThreadPoolExecutor(max_workers=2) as executor:
         first = executor.submit(service.materialize)
-        build_started.wait()
-        second = executor.submit(service.materialize)
-        caller_waiting.wait()
-        release_build.set()
-        first_reference = first.result()
-        second_reference = second.result()
+        try:
+            assert build_started.wait(5)
+            second = executor.submit(service.materialize)
+            assert caller_waiting.wait(5)
+        finally:
+            release_build.set()
+        first_reference = first.result(timeout=5)
+        second_reference = second.result(timeout=5)
 
     assert first_reference == second_reference
     assert first_reference.failed_files == ("module.py",)
@@ -763,3 +835,36 @@ def test_semantics_tags_are_applied_and_persisted(tmp_path):
     }
     assert node.has_tag("trust.domain")
     assert not node.has_tag("risk.owner")
+
+
+@pytest.mark.parametrize("field", ["call_sites", "references", "global_references"])
+def test_invalid_relationship_metadata_isolates_provider_failure(tmp_path, field):
+    graph = CodeGraph()
+    node = FunctionNode("bad::node", "bad.txt", "node", 1)
+    graph.add_node(node)
+    if field == "global_references":
+        construct = GlobalConstruct("bad::global", "bad.txt", "global", 2)
+        construct.references = [{}]
+        graph.add_global(construct)
+    else:
+        setattr(node, field, [{}])
+    good = CodeGraph()
+    good.add_node(FunctionNode("good::node", "good.txt", "node", 1))
+    service = CodeGraphService(
+        SimpleNamespace(codebase_path=str(tmp_path)),
+        _repository(
+            ("bad.txt", "good.txt"),
+            lambda path: "a_bad" if path == "bad.txt" else "z_good",
+        ),
+        {
+            "a_bad": lambda context: _provider(graph),
+            "z_good": lambda context: _provider(good),
+        },
+    )
+    result = service._build(
+        ("bad.txt", "good.txt"), progress_callback=None, diagnostic_callback=None
+    )
+    assert result.failed_files == ("bad.txt",)
+    assert result.processed_files == ("good.txt",)
+    assert set(result.graph.nodes) == {"good::node"}
+    assert len(result.diagnostics) == 1

--- a/tests/test_runlog.py
+++ b/tests/test_runlog.py
@@ -3,16 +3,17 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import threading
-import time
-from concurrent.futures import CancelledError
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from pydantic import BaseModel
+from pydantic import model_serializer
 from langchain_core.messages import AIMessage
 from langchain_core.callbacks import CallbackManager
 from langchain_core.prompts import ChatPromptTemplate
@@ -176,6 +177,31 @@ def test_exception_closes_span_and_run_as_error(tmp_path):
     assert records[-1]["status"] == "error"
 
 
+@pytest.mark.parametrize("formatting_error", [RuntimeError, KeyboardInterrupt])
+def test_exception_formatting_preserves_original_failure(tmp_path, formatting_error):
+    class BrokenStringError(Exception):
+        def __str__(self):
+            raise formatting_error("exception text unavailable")
+
+    original = BrokenStringError()
+    session = runlog.open_runlog(_exact_config(tmp_path))
+    with pytest.raises(BrokenStringError) as raised:
+        with session:
+            with runlog.span("task", "failing"):
+                raise original
+
+    assert raised.value is original
+    assert runlog.current_runlog() is None
+    task_end = next(
+        record
+        for record in _records(session)
+        if record["record"] == "span.end" and record.get("kind") == "task"
+    )
+    assert task_end["error"]["type"] == "BrokenStringError"
+    assert task_end["error"]["message"] == "<exception str() failed>"
+    assert runlog.validate_runlog(session.ndjson_path).status == "error"
+
+
 def test_large_text_and_structured_payloads_use_atomic_blobs(tmp_path):
     config = _exact_config(tmp_path, blob_threshold=48)
     with runlog.open_runlog(config) as session:
@@ -261,6 +287,34 @@ def test_concurrent_writes_preserve_authoritative_line_order(tmp_path):
     assert len(ticks) == 800
     assert [record["seq"] for record in records] == list(range(len(records)))
     assert len({record["record_id"] for record in records}) == len(records)
+
+
+@pytest.mark.parametrize("lazy_attributes", [False, True])
+def test_reentrant_serialization_preserves_line_order(tmp_path, lazy_attributes):
+    class Payload(BaseModel):
+        value: int
+
+        @model_serializer
+        def serialize(self):
+            runlog.event("serializer.notice", {"value": self.value})
+            return {"value": self.value}
+
+    with runlog.open_runlog(_exact_config(tmp_path)) as session:
+        attributes = {"model": Payload(value=7)}
+        session.event("outer", (lambda: attributes) if lazy_attributes else attributes)
+
+    records = _records(session)
+    assert [record["seq"] for record in records] == list(range(len(records)))
+    assert [record["mono_ns"] for record in records] == sorted(
+        record["mono_ns"] for record in records
+    )
+    assert [record["name"] for record in records] == [
+        "metis",
+        "serializer.notice",
+        "outer",
+        "metis",
+    ]
+    assert runlog.validate_runlog(session.ndjson_path).events == 2
 
 
 def test_explicit_ndjson_path_is_never_appended(tmp_path):
@@ -392,164 +446,6 @@ def test_parallel_jobs_are_traced_with_compact_keys(tmp_path):
     runlog.validate_runlog(session.ndjson_path)
 
 
-def test_scheduler_accepts_none_jobs_without_losing_worker_capacity() -> None:
-    scheduler = JobScheduler(1)
-    with ThreadPoolExecutor(max_workers=1) as caller:
-        try:
-            result = caller.submit(
-                scheduler.limit(1).run,
-                [None, 2],
-                lambda value: value,
-                label=None,
-                result_key=str,
-            )
-            assert result.result(timeout=2) == [None, 2]
-        finally:
-            scheduler.close()
-
-
-def test_scheduler_shares_global_workers_across_node_limits() -> None:
-    scheduler = JobScheduler(2)
-    state_lock = threading.Lock()
-    active = 0
-    peak = 0
-
-    def work(value: int) -> int:
-        nonlocal active, peak
-        with state_lock:
-            active += 1
-            peak = max(peak, active)
-        time.sleep(0.02)
-        with state_lock:
-            active -= 1
-        return value
-
-    try:
-        jobs = scheduler.limit(2)
-        with ThreadPoolExecutor(max_workers=2) as callers:
-            first = callers.submit(
-                jobs.run,
-                [1, 2, 3],
-                work,
-                label=None,
-                result_key=str,
-            )
-            second = callers.submit(
-                jobs.run,
-                [4, 5, 6],
-                work,
-                label=None,
-                result_key=str,
-            )
-            assert sorted((*first.result(), *second.result())) == [1, 2, 3, 4, 5, 6]
-    finally:
-        scheduler.close()
-
-    assert peak == 2
-
-
-def test_scheduler_limit_one_bounds_submissions_and_runs_off_coordinator() -> None:
-    scheduler = JobScheduler(2)
-    first_started = threading.Event()
-    second_started = threading.Event()
-    release_first = threading.Event()
-    coordinator: list[int] = []
-    workers: list[int] = []
-
-    def work(value: int) -> int:
-        workers.append(threading.get_ident())
-        if value == 1:
-            first_started.set()
-            release_first.wait(timeout=2)
-        else:
-            second_started.set()
-        return value
-
-    def run() -> list[int]:
-        coordinator.append(threading.get_ident())
-        return scheduler.limit(1).run(
-            [1, 2],
-            work,
-            label=None,
-            result_key=str,
-        )
-
-    try:
-        with ThreadPoolExecutor(max_workers=1) as caller:
-            result = caller.submit(run)
-            try:
-                assert first_started.wait(timeout=1)
-                second_was_blocked = not second_started.wait(timeout=0.1)
-            finally:
-                release_first.set()
-            assert result.result() == [1, 2]
-    finally:
-        scheduler.close()
-
-    assert second_was_blocked
-    assert second_started.is_set()
-    assert all(worker != coordinator[0] for worker in workers)
-
-
-def test_scheduler_gives_a_new_run_the_next_available_worker() -> None:
-    scheduler = JobScheduler(2)
-    first_started = threading.Event()
-    second_started = threading.Event()
-    third_started = threading.Event()
-    other_started = threading.Event()
-    release_first = threading.Event()
-    release_second = threading.Event()
-    release_other = threading.Event()
-
-    def first_work(value: int) -> int:
-        if value == 1:
-            first_started.set()
-            release_first.wait(timeout=2)
-        elif value == 2:
-            second_started.set()
-            release_second.wait(timeout=2)
-        else:
-            third_started.set()
-        return value
-
-    def other_work(value: int) -> int:
-        other_started.set()
-        release_other.wait(timeout=2)
-        return value
-
-    try:
-        with ThreadPoolExecutor(max_workers=2) as callers:
-            first = callers.submit(
-                scheduler.limit(2).run,
-                [1, 2, 3],
-                first_work,
-                label=None,
-                result_key=str,
-            )
-            assert first_started.wait(timeout=1)
-            assert second_started.wait(timeout=1)
-            other = callers.submit(
-                scheduler.limit(2).run,
-                [4],
-                other_work,
-                label=None,
-                result_key=str,
-            )
-            assert not other_started.wait(timeout=0.05)
-            release_first.set()
-            assert other_started.wait(timeout=1)
-            assert not third_started.is_set()
-            release_second.set()
-            release_other.set()
-            assert sorted(first.result()) == [1, 2, 3]
-            assert other.result() == [4]
-    finally:
-        release_first.set()
-        release_second.set()
-        release_other.set()
-        scheduler.close()
-
-
 def test_scheduler_does_not_replenish_before_a_failure_is_collected() -> None:
     scheduler = JobScheduler(2)
     allow_failure = threading.Event()
@@ -604,56 +500,6 @@ def test_scheduler_does_not_replenish_before_a_failure_is_collected() -> None:
         allow_failure.set()
         release_collector.set()
         scheduler.close()
-
-
-def test_scheduler_cancellation_does_not_spin_or_start_queued_jobs() -> None:
-    scheduler = JobScheduler(2)
-    cancellation = threading.Event()
-    jobs = scheduler.limit(2).with_cancellation(cancellation)
-    release = threading.Event()
-    two_started = threading.Event()
-    state_lock = threading.Lock()
-    started = 0
-    wait_calls = 0
-    wait_for = scheduler._condition.wait_for
-
-    def tracked_wait_for(predicate, timeout=None):
-        nonlocal wait_calls
-        wait_calls += 1
-        return wait_for(predicate, timeout)
-
-    scheduler._condition.wait_for = tracked_wait_for
-
-    def work(value: int) -> int:
-        nonlocal started
-        with state_lock:
-            started += 1
-            if started == 2:
-                two_started.set()
-        release.wait(timeout=2)
-        return value
-
-    try:
-        with ThreadPoolExecutor(max_workers=1) as caller:
-            result = caller.submit(
-                jobs.run,
-                list(range(20)),
-                work,
-                label=None,
-                result_key=str,
-            )
-            assert two_started.wait(timeout=1)
-            jobs.cancel()
-            time.sleep(0.05)
-            assert wait_calls < 10
-            release.set()
-            with pytest.raises(CancelledError):
-                result.result()
-    finally:
-        release.set()
-        scheduler.close()
-
-    assert started == 2
 
 
 def test_prompt_retry_records_logical_attempts(tmp_path):
@@ -925,3 +771,86 @@ def test_runlog_preserves_existing_output_directory_permissions(tmp_path):
         assert output_dir.stat().st_mode & 0o777 == 0o750
         assert session.ndjson_path.stat().st_mode & 0o777 == 0o600
         assert session.meta_path.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.parametrize("threshold", [8, 8192])
+def test_surrogate_payloads_preserve_trace_lifecycle_and_values(tmp_path, threshold):
+    text = "source-\udcff.txt"
+    metadata = {text: "source", "source": text}
+    with runlog.open_runlog(
+        _exact_config(tmp_path, blob_threshold=threshold), metadata=metadata
+    ) as session:
+        session.event(
+            text,
+            {
+                "text": text,
+                "path": Path(text),
+                "mapping": {text: "value"},
+                "api_key": text,
+                "secret": r"source-\udcff.txt",
+            },
+            explanation=text,
+        )
+        session.event("after", {"value": "recorded"})
+        assert session.enabled
+
+    records = _records(session)
+    payload = next(record for record in records if record["name"] == text)
+    assert payload["explanation"] == text
+    assert payload["attributes"]["path"] == text
+    for field, expected in (("text", text), ("mapping", {text: "value"})):
+        value = payload["attributes"][field]
+        if isinstance(value, dict) and "$ref" in value:
+            value = json.loads((session.output_dir / value["$ref"]).read_text())
+        assert value == expected
+    secret = payload["attributes"]["api_key"]
+    assert secret == {
+        "$redacted": True,
+        "sha256": hashlib.sha256(text.encode("utf-8", "surrogatepass")).hexdigest(),
+    }
+    assert secret != payload["attributes"]["secret"]
+    assert any(record["name"] == "after" for record in records)
+    assert text in json.loads(session.meta_path.read_text())["metadata"]
+    assert runlog.validate_runlog(session.ndjson_path).status == "ok"
+
+
+def test_unicode_blob_bytes_and_hashes_keep_exact_content(tmp_path):
+    text = "£😀" * 20
+    surrogate = "value-\udcff" * 4
+    literal = surrogate.encode("utf-8", "backslashreplace").decode("utf-8")
+    structured = ["£", "😀"]
+    with runlog.open_runlog(_exact_config(tmp_path, blob_threshold=8)) as session:
+        session.event(
+            "payload",
+            {
+                "plain": text,
+                "structured": structured,
+                "surrogate": surrogate,
+                "literal": literal,
+                "api_key": text,
+            },
+        )
+    attributes = next(
+        record["attributes"]
+        for record in _records(session)
+        if record["name"] == "payload"
+    )
+    expected_bytes = {
+        "plain": text.encode("utf-8"),
+        "structured": json.dumps(
+            structured, ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8"),
+        "literal": literal.encode("utf-8"),
+    }
+    for field, expected in expected_bytes.items():
+        reference = attributes[field]
+        assert (session.output_dir / reference["$ref"]).read_bytes() == expected
+        assert reference["sha256"] == hashlib.sha256(expected).hexdigest()
+    reference = attributes["surrogate"]
+    assert json.loads((session.output_dir / reference["$ref"]).read_text()) == surrogate
+    assert reference["$ref"] != attributes["literal"]["$ref"]
+    assert (
+        attributes["api_key"]["sha256"]
+        == hashlib.sha256(text.encode("utf-8")).hexdigest()
+    )
+    assert runlog.validate_runlog(session.ndjson_path).status == "ok"

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -348,3 +348,18 @@ def test_generate_sarif_ignores_malformed_optional_anchor(anchor):
         "snippet": {"text": "first line\nsecond line"},
     }
     assert "anchor" not in entry["properties"]
+
+
+def test_generated_reports_own_nested_rule_metadata(monkeypatch):
+    from copy import deepcopy
+    from metis.sarif import writer
+
+    original = deepcopy(writer.RULES)
+    monkeypatch.setattr(writer, "RULES", deepcopy(original))
+    first = generate_sarif({"reviews": []})
+    first["runs"][0]["tool"]["driver"]["rules"][0]["defaultConfiguration"]["level"] = (
+        "local-only"
+    )
+    second = generate_sarif({"reviews": []})
+    assert writer.RULES == original
+    assert second["runs"][0]["tool"]["driver"]["rules"] == original

--- a/tests/test_sarif_triage.py
+++ b/tests/test_sarif_triage.py
@@ -325,3 +325,28 @@ def test_triage_request_propagates_metis_source_hints(engine, monkeypatch):
     assert captured["is_metis"] is True
     assert captured["source_tool"] == "Metis"
     assert "reasoning: Dangerous flow" in str(captured["explanation"])
+
+
+def test_annotation_projection_ignores_malformed_result_collections():
+    from metis.sarif.triage import apply_triage_annotations
+
+    report = {"reviews": []}
+    for results in (None, 1, True, "text", {}):
+        assert (
+            apply_triage_annotations(report, {"runs": [{"results": results}]}) is report
+        )
+
+
+def test_negative_annotation_indices_cannot_modify_neighbors():
+    from metis.sarif.triage import apply_triage_result
+
+    payload = {"runs": [{"results": [{}]}]}
+    for run_index, result_index in ((-1, 0), (-2, 0), (0, -1), (0, -2)):
+        assert not apply_triage_result(
+            payload,
+            run_index=run_index,
+            result_index=result_index,
+            status="inconclusive",
+            reason="local check",
+        )
+    assert payload == {"runs": [{"results": [{}]}]}

--- a/tests/test_stage_input_contracts.py
+++ b/tests/test_stage_input_contracts.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Annotated
+from unittest.mock import Mock
+
+import pytest
+from pydantic import AfterValidator
+
+from metis.engine.stages.catalog import StageCatalog
+from metis.engine.stages.configuration import ExecutionConfiguration
+from metis.execution_nodes import EmptyNodeConfiguration
+from metis.execution_nodes import ExecutionStatus
+from metis.execution_nodes import ExecutionDiagnostic
+from metis.execution_nodes import NodeRegistration
+from metis.execution_nodes import NodeResult
+from metis.execution_nodes import ReviewCommand
+from metis.execution_stages import StageContract
+from metis.execution_stages import StageRegistration
+from test_execution_graph import _service
+
+
+type _OptionalPort[T] = T | None
+
+
+def _input_service(monkeypatch, annotation, source, value, handler):
+    registration = StageRegistration("external", StageContract({"value": annotation}))
+    monkeypatch.setattr(StageCatalog, "resolve", lambda self, name: registration)
+    stage = {"outputs": {"seen": "observe.seen"}, "nodes": {"observe": {}}}
+    stages = {"external": stage}
+    if source == "root":
+        stage["inputs"] = {"value": "$inputs.review_request"}
+    elif source == "stage":
+        stage["inputs"] = {"value": "initialize.value"}
+        stages["initialize"] = {
+            "outputs": {"value": "produce.value"},
+            "nodes": {"produce": {}},
+        }
+    configuration = ExecutionConfiguration.model_validate(
+        {"inputs": {"review_request": value}, "stages": stages}
+    )
+    return _service(
+        configuration,
+        extra_registrations=(
+            NodeRegistration(
+                "observe",
+                "external",
+                EmptyNodeConfiguration,
+                {"value": ReviewCommand | None},
+                {"seen": bool},
+                handler,
+            ),
+            NodeRegistration(
+                "produce",
+                "initialize",
+                EmptyNodeConfiguration,
+                {},
+                {"value": ReviewCommand},
+                lambda invocation: NodeResult({"value": value}),
+            ),
+        ),
+    )[0]
+
+
+@pytest.mark.parametrize(
+    "source,valid",
+    (
+        ("root", False),
+        ("root", True),
+        ("stage", False),
+        ("stage", True),
+        ("unset", False),
+    ),
+)
+def test_stage_input_constraints_apply_before_node_execution(
+    monkeypatch, source, valid
+):
+    def requires_target(command):
+        if command is None or command.target != "expected":
+            raise ValueError("stage requires target expected")
+        return command
+
+    annotation = Annotated[ReviewCommand | None, AfterValidator(requires_target)]
+    value = (
+        ReviewCommand(mode="file", target="expected")
+        if valid
+        else ReviewCommand(mode="code")
+    )
+    handler = Mock(return_value=NodeResult({"seen": True}))
+    service = _input_service(monkeypatch, annotation, source, value, handler)
+    try:
+        result = service.execute_graph()
+    finally:
+        service.close()
+    if valid:
+        assert result.status is ExecutionStatus.OK
+        assert handler.call_args.args[0].inputs["value"] == value
+    else:
+        assert result.status is ExecutionStatus.ERROR
+        assert result.diagnostics[0].code == "execution.stage_input_invalid"
+        assert "stage requires target expected" in result.diagnostics[0].message
+        handler.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "source,present", (("unset", False), ("root", False), ("root", True))
+)
+def test_nullable_generic_stage_input_accepts_absent_null_and_present_values(
+    monkeypatch, source, present
+):
+    value = ReviewCommand(mode="code") if present else None
+    handler = Mock(return_value=NodeResult({"seen": True}))
+    service = _input_service(
+        monkeypatch, _OptionalPort[ReviewCommand], source, value, handler
+    )
+    try:
+        result = service.execute_graph()
+    finally:
+        service.close()
+    assert result.status is ExecutionStatus.OK
+    assert handler.call_args.args[0].inputs["value"] == value
+
+
+@pytest.mark.parametrize("value", (-1, 1))
+@pytest.mark.parametrize(
+    "node_status", (ExecutionStatus.OK, ExecutionStatus.INCONCLUSIVE)
+)
+def test_stage_output_constraints_preserve_valid_outputs_and_diagnostics(
+    monkeypatch, value, node_status
+):
+    validated = []
+
+    def positive(value):
+        validated.append(value)
+        if value <= 0:
+            raise ValueError("stage output must be positive")
+        return value
+
+    annotation = Annotated[int, AfterValidator(positive)]
+    registration = StageRegistration(
+        "external", StageContract({}, {"total": annotation, "independent": annotation})
+    )
+    monkeypatch.setattr(StageCatalog, "resolve", lambda self, name: registration)
+    outputs = {"total": value, "independent": 7, "extra": 3}
+    configuration = ExecutionConfiguration.model_validate(
+        {
+            "stages": {
+                "external": {
+                    "outputs": {name: f"produce.{name}" for name in outputs},
+                    "nodes": {"produce": {}},
+                }
+            }
+        }
+    )
+    warning = ExecutionDiagnostic("fixture.note", "original diagnostic", "warning")
+    node = NodeRegistration(
+        "produce",
+        "external",
+        EmptyNodeConfiguration,
+        {},
+        {name: int for name in outputs},
+        lambda invocation: NodeResult(outputs, node_status, (warning,)),
+    )
+    service, _ = _service(configuration, extra_registrations=(node,))
+    try:
+        result = service.execute_graph()
+    finally:
+        service.close()
+    assert validated == [value, 7]
+    assert result.diagnostics[0] == warning
+    if value > 0:
+        assert result.status is node_status
+        assert result.outputs["external"] == outputs
+        assert result.diagnostics == (warning,)
+    else:
+        assert result.status is ExecutionStatus.ERROR
+        assert result.outputs["external"] == {"independent": 7, "extra": 3}
+        assert result.diagnostics[1].code == "execution.stage_output_invalid"
+        assert "stage output must be positive" in result.diagnostics[1].message
+
+
+def test_close_during_stage_output_validation_cannot_publish_success(monkeypatch):
+    from concurrent.futures import CancelledError, ThreadPoolExecutor
+    from threading import Event
+
+    entered = Event()
+    release = Event()
+
+    def wait_for_close(value):
+        entered.set()
+        assert release.wait(4)
+        return value
+
+    registration = StageRegistration(
+        "external",
+        StageContract({}, {"value": Annotated[int, AfterValidator(wait_for_close)]}),
+    )
+    monkeypatch.setattr(StageCatalog, "resolve", lambda self, name: registration)
+    configuration = ExecutionConfiguration.model_validate(
+        {
+            "stages": {
+                "external": {
+                    "outputs": {"value": "produce.value"},
+                    "nodes": {"produce": {}},
+                }
+            }
+        }
+    )
+    node = NodeRegistration(
+        "produce",
+        "external",
+        EmptyNodeConfiguration,
+        {},
+        {"value": int},
+        lambda invocation: NodeResult({"value": 1}),
+    )
+    service, _ = _service(configuration, extra_registrations=(node,))
+    try:
+        with ThreadPoolExecutor(max_workers=2) as callers:
+            result = callers.submit(service.execute_graph)
+            try:
+                assert entered.wait(2)
+                closed = callers.submit(service.close)
+                with service._condition:
+                    assert service._condition.wait_for(lambda: service._closed, 2)
+                release.set()
+                with pytest.raises(CancelledError):
+                    result.result(2)
+                closed.result(2)
+            finally:
+                release.set()
+    finally:
+        service.close()

--- a/tests/test_terminal_output_bindings.py
+++ b/tests/test_terminal_output_bindings.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import nullcontext
+import json
+from types import SimpleNamespace
+from typing import Annotated
+
+import pytest
+
+from metis.cli import commands
+from metis.cli.command_runtime import CommandRuntime
+from metis.engine.stages.configuration import BUILTIN_STAGE_CONTRACTS
+from metis.engine.stages.configuration import ExecutionConfiguration
+from metis.execution_nodes import EmptyNodeConfiguration
+from metis.execution_nodes import NodeRegistration
+from metis.execution_nodes import NodeResult
+from test_execution_graph import _service
+
+
+type NullableFilename = str | None
+type InvalidNullableFilename = str | int | None
+
+
+@pytest.mark.parametrize(
+    ("output_files", "generated", "expected_base"),
+    (
+        (["generated.json"], True, "configured"),
+        (None, False, "configured"),
+        ([], False, "configured"),
+        (["explicit.sarif"], False, "explicit"),
+    ),
+)
+def test_review_command_uses_result_filename_unless_cli_path_is_explicit(
+    monkeypatch, output_files, generated, expected_base
+):
+    outputs = {
+        "filename": "configured",
+        "formats": ("sarif", "json"),
+        "findings": {"reviews": []},
+        "sarif": {"version": "2.1.0", "runs": []},
+    }
+    args = SimpleNamespace(
+        quiet=True,
+        triage=False,
+        output_file=output_files,
+        _metis_generated_output=generated,
+    )
+    monkeypatch.setattr(commands, "_execute_review", lambda *_args: outputs)
+    monkeypatch.setattr(
+        commands, "_finalize_review_output", lambda *_args, **_kwargs: None
+    )
+
+    commands.run_review_code(
+        object(), args, CommandRuntime(command="review_code", command_args=[])
+    )
+
+    assert args.output_file == [f"{expected_base}.sarif", f"{expected_base}.json"]
+
+
+@pytest.mark.parametrize("suffix", (".sarif", ".json"))
+@pytest.mark.parametrize("output_files", (None, [], ["explicit.sarif"]))
+def test_triage_command_uses_result_filename_unless_cli_path_is_explicit(
+    monkeypatch, tmp_path, suffix, output_files
+):
+    sarif = {"version": "2.1.0", "runs": []}
+    source = tmp_path / f"input{suffix}"
+    source.write_text(json.dumps(sarif if suffix == ".sarif" else {"reviews": []}))
+    args = SimpleNamespace(quiet=True, output_file=output_files)
+    saved = []
+    monkeypatch.setattr(
+        commands,
+        "run_triage_action",
+        lambda *_args, **_kwargs: {
+            "filename": "configured",
+            "formats": ("sarif", "json"),
+            "sarif": sarif,
+        },
+    )
+    monkeypatch.setattr(
+        commands, "save_output", lambda paths, *_args, **_kwargs: saved.extend(paths)
+    )
+
+    commands.run_triage(
+        object(), str(source), args, CommandRuntime(command="triage", command_args=[])
+    )
+
+    base = "explicit" if output_files else "configured"
+    assert saved == [f"{base}.sarif", f"{base}.json"]
+
+
+@pytest.mark.parametrize("stage_name", ("review", "triage", "initialize"))
+@pytest.mark.parametrize(
+    ("annotation", "valid"),
+    (
+        (str, True),
+        (NullableFilename, True),
+        (Annotated[NullableFilename, "filename"], True),
+        (int, False),
+        (int | None, False),
+        (InvalidNullableFilename, False),
+    ),
+)
+def test_optional_aliased_filename_declaration_matches_builtin_output_contract(
+    stage_name, annotation, valid
+):
+    annotations = dict(BUILTIN_STAGE_CONTRACTS[stage_name].required_outputs)
+    registration = NodeRegistration(
+        "private_result",
+        stage_name,
+        EmptyNodeConfiguration,
+        {},
+        {**annotations, "destination": annotation},
+        lambda _invocation: NodeResult({}),
+    )
+    configuration = ExecutionConfiguration.model_validate(
+        {
+            "inputs": {
+                "review_request": {"mode": "code"},
+                "sarif": {"version": "2.1.0", "runs": []},
+            },
+            "stages": {
+                stage_name: {
+                    "inputs": {"sarif": "$inputs.sarif"}
+                    if stage_name == "triage"
+                    else {},
+                    "outputs": {
+                        **{name: f"private_result.{name}" for name in annotations},
+                        "filename": "private_result.destination",
+                    },
+                    "nodes": {"private_result": {}},
+                }
+            },
+        }
+    )
+    expectation = (
+        nullcontext()
+        if valid or stage_name == "initialize"
+        else pytest.raises(
+            ValueError, match="output 'filename' has an incompatible type"
+        )
+    )
+    with expectation:
+        service, _ = _service(configuration, extra_registrations=(registration,))
+        service.close()

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 import json
 from pathlib import Path
 from types import SimpleNamespace
+import threading
 from unittest.mock import Mock
 
 import pytest
@@ -285,3 +287,116 @@ def test_embedding_event_cleans_pending_model_when_usage_is_skipped(scoped, payl
 
     assert handler._embedding_models == {}
     assert collector.snapshot()["total_tokens"] == 0
+
+
+@pytest.mark.parametrize("callback", ["langchain", "llamaindex"])
+@pytest.mark.parametrize(
+    "field", ["prompt_tokens", "completion_tokens", "total_tokens"]
+)
+@pytest.mark.parametrize("value", [float("inf"), float("-inf")])
+def test_usage_callbacks_ignore_nonfinite_counts(tmp_path, callback, field, value):
+    runtime = UsageRuntime(tmp_path)
+    counts = {field: value}
+    with runtime.command("inert"):
+        if callback == "langchain":
+            runtime.langchain_handler.on_llm_end(
+                SimpleNamespace(llm_output={"token_usage": counts}, generations=[])
+            )
+        else:
+            runtime.llamaindex_callback_manager.on_event_end(
+                CBEventType.LLM,
+                {EventPayload.RESPONSE: SimpleNamespace(additional_kwargs=counts)},
+            )
+    assert runtime.snapshot_total()["total_tokens"] == 0
+
+
+@pytest.mark.parametrize("access", ["finalize", "completed", "persisted"])
+def test_usage_command_returns_do_not_mutate_persisted_records(tmp_path, access):
+    runtime = UsageRuntime(tmp_path)
+    with runtime.command("inert") as command:
+        runtime.collector.record(
+            scope_id=command.scope_id,
+            operation="inert",
+            model="inert",
+            input_tokens=1,
+            output_tokens=2,
+        )
+    finalized = runtime.finalize_command(command)
+    returned = {
+        "finalize": finalized,
+        "completed": runtime.completed_commands()[0],
+        "persisted": runtime.build_persisted_payload()["commands"][0],
+    }[access]
+    returned["summary"]["total_tokens"] = 999
+    returned["cumulative"]["by_model"]["inert"]["input_tokens"] = 999
+
+    output_path = runtime.save_run_summary(str(tmp_path / "usage.json"))
+    payload = json.loads(Path(output_path).read_text(encoding="utf-8"))
+    assert payload["commands"][0]["summary"]["total_tokens"] == 3
+    assert (
+        payload["commands"][0]["cumulative"]["by_model"]["inert"]["input_tokens"] == 1
+    )
+    assert payload["totals"]["total_tokens"] == 3
+
+
+@pytest.mark.parametrize(
+    ("input_tokens", "output_tokens"), [(-5, 10), (10, -5), (-5, -5)]
+)
+def test_usage_total_uses_clamped_token_counts(input_tokens, output_tokens):
+    collector = UsageCollector()
+    collector.record(
+        scope_id="scope",
+        operation="inert",
+        model="inert",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+    total = collector.snapshot()
+    assert total["input_tokens"] == max(0, input_tokens)
+    assert total["output_tokens"] == max(0, output_tokens)
+    assert total["total_tokens"] == total["input_tokens"] + total["output_tokens"]
+    assert collector.snapshot_scope("scope") == total
+
+
+def test_concurrent_usage_export_cannot_include_commands_newer_than_totals(
+    tmp_path, monkeypatch
+):
+    runtime = UsageRuntime(tmp_path)
+    original_snapshot = runtime.snapshot_total
+    snapshot_taken = threading.Event()
+    command_done = threading.Event()
+    exporting_thread = threading.get_ident()
+
+    def paused_snapshot():
+        result = original_snapshot()
+        if threading.get_ident() == exporting_thread:
+            snapshot_taken.set()
+            assert command_done.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(runtime, "snapshot_total", paused_snapshot)
+
+    def complete_command():
+        assert snapshot_taken.wait(timeout=5)
+        with runtime.command("inert") as command:
+            runtime.collector.record(
+                scope_id=command.scope_id,
+                operation="inert",
+                model="inert",
+                input_tokens=1,
+                output_tokens=2,
+            )
+        runtime.finalize_command(command)
+        command_done.set()
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(complete_command)
+        output_path = runtime.save_run_summary(str(tmp_path / "usage.json"))
+        future.result(timeout=5)
+
+    payload = json.loads(Path(output_path).read_text(encoding="utf-8"))
+    command_tokens = sum(
+        item["summary"]["total_tokens"] for item in payload["commands"]
+    )
+    assert payload["totals"]["total_tokens"] >= command_tokens
+    assert runtime.completed_commands()[0]["summary"]["total_tokens"] == 3


### PR DESCRIPTION
- Validate YAML settings, defaults, duplicate keys, and provider configuration.
- Stabilize typed ports and configuration contracts for registered stages and nodes.
- Share bounded node/job pools with explicit limits and scoped cancellation.
- Drain workers before resource cleanup and protect shared capability and index state.
- Make persistent memory replacement atomic; preserve graph revisions and isolate checkpoint producers.
- Preserve partial results and report metadata; prevent output path collisions.
- Keep run-log status and usage reporting consistent under concurrent execution.
- Add credential-free E2E coverage for extensions, CLI flows, persistence, and shutdown.
- Remove superseded tests and redundant helpers; correct packaging and license metadata.