### PR TITLE
fix(sarif): bound and validate external-stage reports

### DIFF
--- a/docs/execution-graph.md
+++ b/docs/execution-graph.md
@@ -605,6 +605,40 @@ Nodes in that stage still use the normal stage-qualified node entry point:
 "verify.private_verifier" = "external_metis_nodes.verify:registration"
 ```
 
+### Command-backed analysis and validation
+
+The separate `ExternalStageService` API runs command-backed analysis and
+validation. Analysis commands produce SARIF. Validation commands consume SARIF
+and produce `metis.external.validation-result/v1` decision JSON; Metis applies
+those decisions and writes `validated.sarif`.
+
+SARIF and decision files must contain one UTF-8 JSON object without a BOM,
+duplicate keys, or non-finite numbers. Reads are capped at 25 MiB before parsing;
+parsed documents are then checked against these default limits:
+
+| Limit | Default |
+| --- | ---: |
+| Nesting depth | 32 |
+| JSON nodes, including mapping keys | 200,000 |
+| Mapping keys | 100,000 |
+| Bytes per string | 64 KiB |
+| Items per array | 10,000 |
+| Findings or validation decisions | 10,000 |
+
+The API accepts a `sarif_limits=SarifLimits(...)` argument to configure these
+bounds. They apply to analysis reports, validation input, decision JSON, and
+the final annotated report. The final report is checked before publication and
+written atomically as compact UTF-8 JSON, within the same file-size limit.
+
+Metis requires each finding's primary location to provide a physical file URI
+and an integer `startLine` from 1 through 2,147,483,647. Supplementary locations
+may instead use logical locations, artifact references, or address/offset
+information; context regions may use character or byte offsets. Absolute file
+URIs remain supported. Compared with the earlier command API, numeric strings
+and booleans for line numbers, malformed known fields, and oversized reports
+are now rejected. These checks do not constitute full SARIF schema validation
+and do not replace the typed contracts for installed execution-graph stages.
+
 ### External analysis with a bundled implementation
 
 A Review node may package a deterministic analyzer, library, or executable in

--- a/src/metis/engine/external_stages/service.py
+++ b/src/metis/engine/external_stages/service.py
@@ -12,9 +12,12 @@ from typing import Any
 from uuid import uuid4
 
 from metis.sarif.triage import apply_triage_result
-from metis.sarif.triage import load_sarif_file
-from metis.sarif.triage import save_sarif_file
-from metis.sarif.writer import SARIF_VERSION
+from metis.sarif.validation import DEFAULT_SARIF_LIMITS
+from metis.sarif.validation import SarifLimits
+from metis.sarif.validation import load_json_object_file
+from metis.sarif.validation import load_metis_sarif_file
+from metis.sarif.validation import save_metis_sarif_file
+from metis.sarif.validation import validate_metis_sarif as validate_metis_sarif
 
 from .runner import ExternalStageProcessResult
 from .runner import ExternalStageExecutionError
@@ -65,10 +68,12 @@ class ExternalStageService:
         codebase_path: str,
         config: dict[str, Any] | None,
         runner: ExternalStageRunner | None = None,
+        sarif_limits: SarifLimits = DEFAULT_SARIF_LIMITS,
     ):
         self.codebase_path = codebase_path
         self.config = ExternalStagesConfigModel.model_validate(config or {})
         self.runner = runner or ExternalStageRunner()
+        self.sarif_limits = sarif_limits
 
     def run_pipeline(
         self,
@@ -145,7 +150,7 @@ class ExternalStageService:
             log_path=resolved_run_dir / "analysis-process.json",
         )
         _require_file(output_sarif, "analysis SARIF")
-        validate_metis_sarif(load_sarif_file(output_sarif))
+        load_metis_sarif_file(output_sarif, limits=self.sarif_limits)
         return ExternalAnalysisResult(
             run_dir=resolved_run_dir,
             request_path=request_path,
@@ -167,7 +172,7 @@ class ExternalStageService:
         resolved_run_dir.mkdir(parents=True, exist_ok=True)
         codebase = _resolve_codebase_path(codebase_path or self.codebase_path)
         input_sarif_path = Path(input_sarif).resolve()
-        validate_metis_sarif(load_sarif_file(input_sarif_path))
+        load_metis_sarif_file(input_sarif_path, limits=self.sarif_limits)
         output_decision = resolved_run_dir / "validation-decision.json"
         validated_sarif = resolved_run_dir / "validated.sarif"
         for output in (output_decision, validated_sarif):
@@ -196,9 +201,8 @@ class ExternalStageService:
             log_path=resolved_run_dir / "validation-process.json",
         )
         _require_file(output_decision, "validation decision")
-        decisions = _load_validation_result(output_decision)
-        payload = load_sarif_file(input_sarif_path)
-        validate_metis_sarif(payload)
+        decisions = _load_validation_result(output_decision, self.sarif_limits)
+        payload = load_metis_sarif_file(input_sarif_path, limits=self.sarif_limits)
         for decision in decisions.decisions:
             applied = apply_triage_result(
                 payload,
@@ -213,7 +217,7 @@ class ExternalStageService:
                     "Validation decision references missing SARIF result: "
                     f"run={decision.run_index} result={decision.result_index}"
                 )
-        save_sarif_file(validated_sarif, payload)
+        save_metis_sarif_file(validated_sarif, payload, limits=self.sarif_limits)
         return ExternalValidationResult(
             run_dir=resolved_run_dir,
             request_path=request_path,
@@ -240,64 +244,6 @@ class ExternalStageService:
             raise ValueError(
                 f"Unknown external validation stage {name!r}; available: {available}"
             ) from exc
-
-
-def validate_metis_sarif(payload: dict[str, Any]) -> None:
-    if payload.get("version") != SARIF_VERSION:
-        raise ValueError(f"Metis SARIF must use version {SARIF_VERSION}")
-    runs = payload.get("runs")
-    if not isinstance(runs, list):
-        raise ValueError("Metis SARIF must contain a runs array")
-    for run_index, run in enumerate(runs):
-        if not isinstance(run, dict):
-            raise ValueError(f"Metis SARIF run {run_index} must be an object")
-        _validate_run(run, run_index)
-
-
-def _validate_run(run: dict[str, Any], run_index: int) -> None:
-    tool = run.get("tool")
-    if not isinstance(tool, dict):
-        raise ValueError(f"Metis SARIF run {run_index} missing tool object")
-    driver = tool.get("driver")
-    if not isinstance(driver, dict) or not str(driver.get("name") or "").strip():
-        raise ValueError(f"Metis SARIF run {run_index} missing tool.driver.name")
-    results = run.get("results")
-    if not isinstance(results, list):
-        raise ValueError(f"Metis SARIF run {run_index} missing results array")
-    for result_index, result in enumerate(results):
-        _validate_result(result, run_index, result_index)
-
-
-def _validate_result(result: Any, run_index: int, result_index: int) -> None:
-    prefix = f"Metis SARIF result {run_index}:{result_index}"
-    if not isinstance(result, dict):
-        raise ValueError(f"{prefix} must be an object")
-    if not str(result.get("ruleId") or "").strip():
-        raise ValueError(f"{prefix} missing ruleId")
-    message = result.get("message")
-    if not isinstance(message, dict) or not str(message.get("text") or "").strip():
-        raise ValueError(f"{prefix} missing message.text")
-    locations = result.get("locations")
-    if not isinstance(locations, list) or not locations:
-        raise ValueError(f"{prefix} missing locations")
-    first = locations[0]
-    if not isinstance(first, dict):
-        raise ValueError(f"{prefix} first location must be an object")
-    physical = first.get("physicalLocation")
-    if not isinstance(physical, dict):
-        raise ValueError(f"{prefix} missing physicalLocation")
-    artifact = physical.get("artifactLocation")
-    if not isinstance(artifact, dict) or not str(artifact.get("uri") or "").strip():
-        raise ValueError(f"{prefix} missing artifactLocation.uri")
-    region = physical.get("region")
-    if not isinstance(region, dict):
-        raise ValueError(f"{prefix} missing region")
-    try:
-        line = int(region.get("startLine"))
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{prefix} missing numeric region.startLine") from exc
-    if line < 1:
-        raise ValueError(f"{prefix} region.startLine must be positive")
 
 
 def _validate_analysis_bindings(name: str, stage: ExternalStageCommandModel) -> None:
@@ -330,10 +276,12 @@ def _validate_validation_bindings(name: str, stage: ExternalStageCommandModel) -
         )
 
 
-def _load_validation_result(path: Path) -> ValidationResultModel:
-    with path.open("r", encoding="utf-8") as handle:
-        payload = json.load(handle)
-    return ValidationResultModel.model_validate(payload)
+def _load_validation_result(path: Path, limits: SarifLimits) -> ValidationResultModel:
+    payload = load_json_object_file(path, limits=limits)
+    result = ValidationResultModel.model_validate(payload)
+    if len(result.decisions) > limits.max_findings:
+        raise ValueError("External validation exceeds the decision limit")
+    return result
 
 
 def _run_stage_and_log(

--- a/src/metis/sarif/validation.py
+++ b/src/metis/sarif/validation.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+from typing import Any
+from typing import TypeGuard
+
+from metis.json_io import atomic_text_writer
+from metis.sarif.triage import METIS_EVIDENCE_COVERAGE_KEY
+from metis.sarif.triage import METIS_EVIDENCE_REQUIREMENTS_KEY
+from metis.sarif.triage import METIS_FINDING_ID_KEY
+from metis.sarif.triage import METIS_MISSING_EVIDENCE_KEY
+from metis.sarif.triage import METIS_THREAT_MODEL_POLICY_KEY
+from metis.sarif.triage import METIS_TRIAGED_KEY
+from metis.sarif.triage import METIS_TRIAGE_REASON_KEY
+from metis.sarif.triage import METIS_TRIAGE_STATUS_KEY
+from metis.sarif.triage import METIS_TRIAGE_TIMESTAMP_KEY
+from metis.sarif.writer import SARIF_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class SarifLimits:
+    max_bytes: int = 25 * 1024 * 1024
+    max_depth: int = 32
+    max_nodes: int = 200_000
+    max_mapping_keys: int = 100_000
+    max_string_bytes: int = 64 * 1024
+    max_array_items: int = 10_000
+    max_findings: int = 10_000
+
+    def __post_init__(self) -> None:
+        for name in self.__dataclass_fields__:
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+DEFAULT_SARIF_LIMITS = SarifLimits()
+
+
+def parse_metis_sarif(
+    data: bytes,
+    *,
+    limits: SarifLimits = DEFAULT_SARIF_LIMITS,
+) -> dict[str, Any]:
+    """Parse and validate one bounded UTF-8 SARIF document."""
+    payload = _parse_json_object(data, limits)
+    validate_metis_sarif(payload, limits=limits)
+    return payload
+
+
+def _parse_json_object(data: bytes, limits: SarifLimits) -> dict[str, Any]:
+    if not isinstance(data, bytes):
+        raise TypeError("JSON data must be bytes")
+    if len(data) > limits.max_bytes:
+        raise ValueError("JSON exceeds the byte limit")
+    if data.startswith(b"\xef\xbb\xbf"):
+        raise ValueError("JSON must not contain a UTF-8 byte order mark")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ValueError("JSON must be valid UTF-8") from None
+
+    def object_from_pairs(pairs):
+        value = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError("JSON contains a duplicate mapping key")
+            value[key] = item
+        return value
+
+    def reject_constant(_value):
+        raise ValueError("JSON contains a non-finite number")
+
+    try:
+        payload = json.loads(
+            text,
+            object_pairs_hook=object_from_pairs,
+            parse_constant=reject_constant,
+        )
+    except (json.JSONDecodeError, RecursionError):
+        raise ValueError("Input must contain exactly one valid JSON document") from None
+    if not isinstance(payload, dict):
+        raise ValueError("JSON payload must be an object")
+    _validate_json_tree(payload, limits)
+    return payload
+
+
+def load_metis_sarif_file(
+    path: str | Path,
+    *,
+    limits: SarifLimits = DEFAULT_SARIF_LIMITS,
+) -> dict[str, Any]:
+    """Bound the file read before parsing and validating Metis SARIF."""
+    payload = load_json_object_file(path, limits=limits)
+    validate_metis_sarif(payload, limits=limits)
+    return payload
+
+
+def load_json_object_file(
+    path: str | Path,
+    *,
+    limits: SarifLimits = DEFAULT_SARIF_LIMITS,
+) -> dict[str, Any]:
+    """Read a bounded JSON object for a SARIF or external decision contract."""
+    with Path(path).open("rb") as stream:
+        data = stream.read(limits.max_bytes + 1)
+    return _parse_json_object(data, limits)
+
+
+def save_metis_sarif_file(
+    path: str | Path,
+    payload: dict[str, Any],
+    *,
+    limits: SarifLimits = DEFAULT_SARIF_LIMITS,
+) -> None:
+    """Validate and atomically publish compact UTF-8 SARIF within its limits."""
+    validate_metis_sarif(payload, limits=limits)
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_text_writer(target, mode=0o600) as stream:
+        for chunk in _bounded_json_chunks(payload, limits):
+            stream.write(chunk)
+
+
+def _bounded_json_chunks(payload: dict[str, Any], limits: SarifLimits) -> Iterator[str]:
+    encoder = json.JSONEncoder(
+        ensure_ascii=False, allow_nan=False, separators=(",", ":")
+    )
+    total = 0
+    for chunk in encoder.iterencode(payload):
+        total += len(chunk.encode("utf-8"))
+        if total > limits.max_bytes:
+            raise ValueError("SARIF exceeds the byte limit")
+        yield chunk
+
+
+def validate_metis_sarif(
+    payload: dict[str, Any],
+    *,
+    limits: SarifLimits = DEFAULT_SARIF_LIMITS,
+) -> None:
+    """Validate bounded Metis SARIF structure."""
+    if not isinstance(payload, dict):
+        raise ValueError("SARIF payload must be a JSON object")
+    _validate_json_tree(payload, limits)
+    for _ in _bounded_json_chunks(payload, limits):
+        pass
+
+    if payload.get("version") != SARIF_VERSION:
+        raise ValueError(f"Metis SARIF must use version {SARIF_VERSION}")
+    runs = payload.get("runs")
+    if not isinstance(runs, list):
+        raise ValueError("Metis SARIF must contain a runs array")
+    finding_count = 0
+    for run_index, run in enumerate(runs):
+        if not isinstance(run, dict):
+            raise ValueError(f"Metis SARIF run {run_index} must be an object")
+        finding_count += _validate_run(run, run_index)
+        if finding_count > limits.max_findings:
+            raise ValueError("Metis SARIF exceeds the finding limit")
+
+
+def _validate_json_tree(payload: dict[str, Any], limits: SarifLimits) -> None:
+    stack: list[tuple[Any, int]] = [(payload, 1)]
+    nodes = 0
+    mapping_keys = 0
+    while stack:
+        value, depth = stack.pop()
+        nodes += 1
+        if nodes > limits.max_nodes:
+            raise ValueError("JSON exceeds the constructed-node limit")
+        if depth > limits.max_depth:
+            raise ValueError("JSON exceeds the nesting limit")
+        if isinstance(value, dict):
+            mapping_keys += len(value)
+            nodes += len(value)
+            if mapping_keys > limits.max_mapping_keys:
+                raise ValueError("JSON exceeds the mapping-key limit")
+            if nodes > limits.max_nodes:
+                raise ValueError("JSON exceeds the constructed-node limit")
+            for key, item in value.items():
+                if type(key) is not str:
+                    raise ValueError("JSON mapping keys must be strings")
+                _validate_string(key, limits)
+                stack.append((item, depth + 1))
+        elif isinstance(value, list):
+            if len(value) > limits.max_array_items:
+                raise ValueError("JSON exceeds the array-item limit")
+            stack.extend((item, depth + 1) for item in value)
+        elif type(value) is str:
+            _validate_string(value, limits)
+        elif type(value) is float:
+            if not math.isfinite(value):
+                raise ValueError("JSON contains a non-finite number")
+        elif value is not None and type(value) not in {bool, int}:
+            raise ValueError("JSON payload must contain only JSON values")
+
+
+def _validate_string(value: str, limits: SarifLimits) -> None:
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        raise ValueError("JSON strings must contain Unicode scalar values") from None
+    if len(encoded) > limits.max_string_bytes:
+        raise ValueError("JSON exceeds the string limit")
+
+
+def _validate_run(
+    run: dict[str, Any],
+    run_index: int,
+) -> int:
+    tool = run.get("tool")
+    if not isinstance(tool, dict):
+        raise ValueError(f"Metis SARIF run {run_index} missing tool object")
+    driver = tool.get("driver")
+    if not isinstance(driver, dict) or not _nonempty_string(driver.get("name")):
+        raise ValueError(f"Metis SARIF run {run_index} missing tool.driver.name")
+    rules = driver.get("rules")
+    if "rules" in driver:
+        if not isinstance(rules, list):
+            raise ValueError(f"Metis SARIF run {run_index} rules must be an array")
+        for rule_index, rule in enumerate(rules):
+            if not isinstance(rule, dict) or not _nonempty_string(rule.get("id")):
+                raise ValueError(
+                    f"Metis SARIF rule {run_index}:{rule_index} missing id"
+                )
+    results = run.get("results")
+    if not isinstance(results, list):
+        raise ValueError(f"Metis SARIF run {run_index} missing results array")
+    for result_index, result in enumerate(results):
+        _validate_result(result, run_index, result_index)
+    return len(results)
+
+
+def _validate_result(
+    result: Any,
+    run_index: int,
+    result_index: int,
+) -> None:
+    prefix = f"Metis SARIF result {run_index}:{result_index}"
+    if not isinstance(result, dict):
+        raise ValueError(f"{prefix} must be an object")
+    if not _nonempty_string(result.get("ruleId")):
+        raise ValueError(f"{prefix} missing ruleId")
+    message = result.get("message")
+    if not isinstance(message, dict) or not _nonempty_string(message.get("text")):
+        raise ValueError(f"{prefix} missing message.text")
+    level = result.get("level")
+    if "level" in result and not isinstance(level, str):
+        raise ValueError(f"{prefix} level must be a string")
+    properties = result.get("properties")
+    if "properties" in result:
+        if not isinstance(properties, dict):
+            raise ValueError(f"{prefix} properties must be an object")
+        _validate_triage_properties(properties, prefix)
+    locations = result.get("locations")
+    if not isinstance(locations, list) or not locations:
+        raise ValueError(f"{prefix} missing locations")
+    for location_index, location in enumerate(locations):
+        _validate_location(location, prefix, location_index)
+
+
+def _validate_location(
+    location: Any,
+    prefix: str,
+    location_index: int,
+) -> None:
+    if not isinstance(location, dict):
+        raise ValueError(f"{prefix} location {location_index} must be an object")
+    primary = location_index == 0
+    logical = location.get("logicalLocations")
+    if "logicalLocations" in location and (
+        not isinstance(logical, list)
+        or any(not isinstance(item, dict) for item in logical)
+    ):
+        raise ValueError(f"{prefix} logicalLocations must be an array of objects")
+    physical = location.get("physicalLocation")
+    if not primary and "physicalLocation" not in location and logical:
+        return
+    if not isinstance(physical, dict):
+        raise ValueError(f"{prefix} location {location_index} missing physicalLocation")
+    artifact = physical.get("artifactLocation")
+    address = physical.get("address")
+    if "address" in physical and not isinstance(address, dict):
+        raise ValueError(f"{prefix} address must be an object")
+    if "artifactLocation" in physical and not isinstance(artifact, dict):
+        raise ValueError(f"{prefix} artifactLocation must be an object")
+    uri = artifact.get("uri") if isinstance(artifact, dict) else None
+    if (
+        primary or isinstance(artifact, dict) and "uri" in artifact
+    ) and not _nonempty_string(uri):
+        raise ValueError(f"{prefix} missing artifactLocation.uri")
+    if artifact is None and address is None:
+        raise ValueError(f"{prefix} missing artifactLocation or address")
+    region = physical.get("region")
+    if primary or "region" in physical:
+        if not isinstance(region, dict):
+            raise ValueError(f"{prefix} missing region")
+        _validate_region(region, f"{prefix} region", require_start_line=primary)
+    context_region = physical.get("contextRegion")
+    if "contextRegion" in physical:
+        if region is None:
+            raise ValueError(f"{prefix} contextRegion requires region")
+        if not isinstance(context_region, dict):
+            raise ValueError(f"{prefix} contextRegion must be an object")
+        _validate_region(context_region, f"{prefix} contextRegion")
+
+
+def _validate_region(
+    region: dict[str, Any], prefix: str, *, require_start_line: bool = False
+) -> None:
+    start = region.get("startLine")
+    if require_start_line or "startLine" in region:
+        if type(start) is not int:
+            raise ValueError(f"{prefix}.startLine must be an integer")
+        if not 1 <= start <= 2_147_483_647:
+            raise ValueError(f"{prefix}.startLine must be positive")
+    end = region.get("endLine")
+    if "endLine" in region:
+        if type(end) is not int:
+            raise ValueError(f"{prefix}.endLine must be an integer")
+        if not (start or 1) <= end <= 2_147_483_647:
+            raise ValueError(f"{prefix}.endLine precedes startLine")
+    for column in ("startColumn", "endColumn"):
+        if column in region and (type(region[column]) is not int or region[column] < 1):
+            raise ValueError(f"{prefix}.{column} must be a positive integer")
+    if start is not None and (end is None or end == start):
+        if "endColumn" in region and region["endColumn"] < region.get("startColumn", 1):
+            raise ValueError(f"{prefix}.endColumn precedes startColumn")
+    for offset, length in (("charOffset", "charLength"), ("byteOffset", "byteLength")):
+        if offset in region and (
+            type(region[offset]) is not int or region[offset] < -1
+        ):
+            raise ValueError(f"{prefix}.{offset} must be an integer of at least -1")
+        if length in region:
+            size = region[length]
+            if type(size) is not int or size < 0:
+                raise ValueError(f"{prefix}.{length} must be a non-negative integer")
+    if not any(key in region for key in ("startLine", "charOffset", "byteOffset")):
+        raise ValueError(f"{prefix} requires startLine, charOffset, or byteOffset")
+    snippet = region.get("snippet")
+    if "snippet" in region and (
+        not isinstance(snippet, dict)
+        or not {"text", "binary"} & snippet.keys()
+        or any(
+            not isinstance(snippet[key], str)
+            for key in ("text", "binary")
+            if key in snippet
+        )
+    ):
+        raise ValueError(f"{prefix}.snippet must contain text or binary strings")
+
+
+def _validate_triage_properties(properties: dict[str, Any], prefix: str) -> None:
+    if METIS_FINDING_ID_KEY in properties and not isinstance(
+        properties[METIS_FINDING_ID_KEY], str
+    ):
+        raise ValueError(f"{prefix} {METIS_FINDING_ID_KEY} must be a string")
+    if (
+        METIS_TRIAGED_KEY in properties
+        and type(properties[METIS_TRIAGED_KEY]) is not bool
+    ):
+        raise ValueError(f"{prefix} {METIS_TRIAGED_KEY} must be a boolean")
+    for key in (
+        METIS_TRIAGE_STATUS_KEY,
+        METIS_TRIAGE_REASON_KEY,
+        METIS_TRIAGE_TIMESTAMP_KEY,
+    ):
+        if key in properties and not isinstance(properties[key], str):
+            raise ValueError(f"{prefix} {key} must be a string")
+    for key in (METIS_EVIDENCE_REQUIREMENTS_KEY, METIS_MISSING_EVIDENCE_KEY):
+        if key in properties and (
+            not isinstance(properties[key], list)
+            or any(not isinstance(item, str) for item in properties[key])
+        ):
+            raise ValueError(f"{prefix} {key} must be an array of strings")
+    coverage = properties.get(METIS_EVIDENCE_COVERAGE_KEY)
+    if METIS_EVIDENCE_COVERAGE_KEY in properties and (
+        not isinstance(coverage, dict)
+        or any(
+            not isinstance(key, str) or type(value) is not int or value < 0
+            for key, value in coverage.items()
+        )
+    ):
+        raise ValueError(
+            f"{prefix} {METIS_EVIDENCE_COVERAGE_KEY} must map strings to counts"
+        )
+    threat_policy = properties.get(METIS_THREAT_MODEL_POLICY_KEY)
+    if METIS_THREAT_MODEL_POLICY_KEY in properties and not isinstance(
+        threat_policy, dict
+    ):
+        raise ValueError(f"{prefix} {METIS_THREAT_MODEL_POLICY_KEY} must be an object")
+
+
+def _nonempty_string(value: Any) -> TypeGuard[str]:
+    return isinstance(value, str) and bool(value.strip())

--- a/tests/test_external_stages.py
+++ b/tests/test_external_stages.py
@@ -14,8 +14,12 @@ from pydantic import ValidationError
 
 from metis.engine.external_stages.schemas import ExternalValidationDecisionModel
 from metis.engine.external_stages.schemas import ExternalStageCommandModel
+from metis.engine.external_stages.runner import ExternalStageProcessResult
 from metis.engine.external_stages.runner import ExternalStageRunner
 from metis.engine.external_stages.service import ExternalStageService
+from metis.sarif.validation import SarifLimits
+from metis.sarif.validation import load_metis_sarif_file
+from metis.sarif.writer import generate_sarif
 
 
 @pytest.mark.parametrize(
@@ -102,7 +106,7 @@ def test_external_stage_pipeline_invokes_black_boxes_and_applies_decisions(tmp_p
     assert result.analysis.output_sarif.is_file()
     assert result.validation is not None
     assert result.validation.validated_sarif.is_file()
-    payload = json.loads(result.validation.validated_sarif.read_text(encoding="utf-8"))
+    payload = load_metis_sarif_file(result.validation.validated_sarif)
     props = payload["runs"][0]["results"][0]["properties"]
     assert props["metisTriaged"] is True
     assert props["metisTriageStatus"] == "valid"
@@ -249,7 +253,6 @@ def test_external_stage_rejects_previous_artifacts_before_launch(
 def test_concurrent_external_requests_cannot_share_artifacts(tmp_path):
     from concurrent.futures import ThreadPoolExecutor
     from threading import Event
-    from metis.engine.external_stages.runner import ExternalStageProcessResult
 
     started, release = Event(), Event()
     runner = Mock()
@@ -285,3 +288,92 @@ def test_concurrent_external_requests_cannot_share_artifacts(tmp_path):
             release.set()
         assert first.result(timeout=5).output_sarif.is_file()
     runner.run_sync.assert_called_once()
+
+
+def _decision_service(tmp_path, data, limits):
+    runner = Mock()
+
+    def run(stage, *, bindings):
+        bindings["output_decision"].write_bytes(data)
+        return ExternalStageProcessResult(("inert",), 0, "", "")
+
+    runner.run_sync.side_effect = run
+    return ExternalStageService(
+        codebase_path=str(tmp_path),
+        config={"validation": {"inert": {"command": ["local-test", "{request_path}"]}}},
+        runner=runner,
+        sarif_limits=limits,
+    )
+
+
+@pytest.mark.parametrize(
+    ("data", "limits", "message"),
+    [
+        (b'{"decisions":[]}' + b" " * 100, {"max_bytes": 64}, "byte limit"),
+        (
+            json.dumps({"decisions": [{"reason": "x" * 65}]}).encode(),
+            {"max_string_bytes": 64},
+            "string limit",
+        ),
+        (
+            json.dumps(
+                {
+                    "decisions": [
+                        {
+                            "run_index": 0,
+                            "result_index": 0,
+                            "status": "invalid",
+                            "reason": "Checked",
+                        }
+                    ]
+                    * 2
+                }
+            ).encode(),
+            {"max_findings": 1},
+            "decision limit",
+        ),
+        (b'{"decisions":[{},{}]}', {"max_array_items": 1}, "array-item"),
+        (b'{"decisions":[{"reason":[[[[]]]]}]}', {"max_depth": 4}, "nesting"),
+        (b'{"decisions":[],"decisions":[]}', {}, "duplicate"),
+    ],
+)
+def test_external_decision_ingestion_is_bounded_before_publication(
+    tmp_path, data, limits, message
+):
+    input_path = tmp_path / "input.sarif"
+    input_path.write_text('{"version":"2.1.0","runs":[]}', encoding="utf-8")
+    service = _decision_service(tmp_path, data, SarifLimits(**limits))
+    with pytest.raises(ValueError, match=message):
+        service.run_validation(
+            "inert", input_sarif=input_path, run_dir=tmp_path / "run"
+        )
+    assert not (tmp_path / "run" / "validated.sarif").exists()
+
+
+def test_external_annotations_cannot_publish_report_exceeding_byte_limit(tmp_path):
+    payload = generate_sarif(
+        {"reviews": [{"file": "a.py", "reviews": [{"issue": "problem"}]}]}
+    )
+    input_data = json.dumps(payload, separators=(",", ":")).encode()
+    input_path = tmp_path / "input.sarif"
+    input_path.write_bytes(input_data)
+    decisions = json.dumps(
+        {
+            "decisions": [
+                {
+                    "run_index": 0,
+                    "result_index": 0,
+                    "status": "invalid",
+                    "reason": "Caf\u00e9 checked",
+                }
+            ]
+        }
+    ).encode()
+    limits = SarifLimits(max_bytes=len(input_data))
+    service = _decision_service(tmp_path, decisions, limits)
+    with pytest.raises(ValueError, match="byte limit"):
+        service.run_validation(
+            "inert", input_sarif=input_path, run_dir=tmp_path / "run"
+        )
+    assert not (tmp_path / "run" / "validated.sarif").exists()
+    assert input_path.read_bytes() == input_data

--- a/tests/test_sarif_validation.py
+++ b/tests/test_sarif_validation.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from metis.engine.external_stages.service import (
+    validate_metis_sarif as external_validate,
+)
+from metis.sarif.validation import SarifLimits
+from metis.sarif.validation import load_metis_sarif_file
+from metis.sarif.validation import parse_metis_sarif
+from metis.sarif.validation import save_metis_sarif_file
+from metis.sarif.validation import validate_metis_sarif
+from metis.sarif.writer import generate_sarif
+
+
+def _result(path: str = "src/a.py") -> dict:
+    return {
+        "ruleId": "R1",
+        "message": {"text": "issue"},
+        "locations": [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": path},
+                    "region": {"startLine": 1},
+                }
+            }
+        ],
+    }
+
+
+def _payload(*results: dict, path: str = "src/a.py") -> dict:
+    return {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "test"}},
+                "results": list(results or (_result(path),)),
+            }
+        ],
+    }
+
+
+def _encoded(payload: dict) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+
+
+def test_external_stage_reexports_shared_validator_without_path_regression():
+    assert external_validate is validate_metis_sarif
+    validate_metis_sarif(_payload(path="/legacy/external-stage.c"))
+
+
+def test_parse_sarif_validates_exact_byte_limit():
+    data = _encoded(_payload())
+    limits = SarifLimits(max_bytes=len(data))
+
+    assert parse_metis_sarif(data, limits=limits)["version"] == "2.1.0"
+
+    with pytest.raises(ValueError, match="byte limit"):
+        parse_metis_sarif(data, limits=SarifLimits(max_bytes=len(data) - 1))
+
+
+def test_load_sarif_file_bounds_input_before_parsing(tmp_path):
+    path = tmp_path / "result.sarif"
+    data = _encoded(_payload())
+    path.write_bytes(data)
+
+    assert load_metis_sarif_file(path, limits=SarifLimits(max_bytes=len(data)))
+    with pytest.raises(ValueError, match="byte limit"):
+        load_metis_sarif_file(path, limits=SarifLimits(max_bytes=len(data) - 1))
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (b"\xef\xbb\xbf" + _encoded(_payload()), "byte order mark"),
+        (b"\xff", "valid UTF-8"),
+        (b'{"version":"2.1.0","version":"2.1.0","runs":[]}', "duplicate"),
+        (b'{"version":"2.1.0","runs":[],"value":NaN}', "non-finite"),
+        (b'{"version":"2.1.0","runs":[]} {}', "one valid JSON document"),
+        (b'{"version":"2.1.0","runs":[],"value":"\\ud800"}', "Unicode scalar"),
+    ],
+)
+def test_parse_sarif_rejects_invalid_json_boundaries(data, message):
+    with pytest.raises(ValueError, match=message):
+        parse_metis_sarif(data)
+
+
+@pytest.mark.parametrize("line", [True, "1", 0, 2_147_483_648])
+def test_validate_sarif_requires_strict_bounded_line_numbers(line):
+    payload = _payload()
+    payload["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"][
+        "startLine"
+    ] = line
+
+    with pytest.raises(ValueError, match="startLine"):
+        validate_metis_sarif(payload)
+
+
+def test_validate_sarif_checks_every_location():
+    payload = _payload()
+    payload["runs"][0]["results"][0]["locations"].append({"legacyExtension": True})
+
+    with pytest.raises(ValueError, match="location 1"):
+        validate_metis_sarif(payload)
+
+
+def test_validate_sarif_enforces_injected_structural_limits_at_boundary():
+    payload = _payload()
+
+    validate_metis_sarif(
+        payload,
+        limits=SarifLimits(
+            max_depth=10,
+            max_nodes=34,
+            max_mapping_keys=15,
+            max_string_bytes=16,
+            max_array_items=1,
+            max_findings=1,
+        ),
+    )
+
+    limits_and_messages = (
+        ({"max_depth": 9}, "nesting"),
+        ({"max_nodes": 33}, "constructed-node"),
+        ({"max_mapping_keys": 14}, "mapping-key"),
+        ({"max_string_bytes": 15}, "string limit"),
+    )
+    for override, message in limits_and_messages:
+        with pytest.raises(ValueError, match=message):
+            validate_metis_sarif(payload, limits=SarifLimits(**override))
+
+    two_results = _payload(_result(), _result("src/b.py"))
+    with pytest.raises(ValueError, match="array-item"):
+        validate_metis_sarif(
+            two_results,
+            limits=SarifLimits(max_array_items=1, max_findings=2),
+        )
+    with pytest.raises(ValueError, match="finding limit"):
+        validate_metis_sarif(two_results, limits=SarifLimits(max_findings=1))
+
+
+def test_validate_writer_output_with_shared_anchors_matches_json_roundtrip():
+    anchor = {"file_path": "a.py", "start_line": 1, "end_line": 1}
+    payload = generate_sarif(
+        {
+            "reviews": [
+                {
+                    "file": "a.py",
+                    "reviews": [{"issue": str(i), "anchor": anchor} for i in range(2)],
+                }
+            ]
+        }
+    )
+    first, second = payload["runs"][0]["results"]
+    assert first["properties"]["anchor"] is second["properties"]["anchor"]
+    validate_metis_sarif(payload)
+    assert parse_metis_sarif(_encoded(payload)) == payload
+    result = _result()
+    with pytest.raises(ValueError, match="constructed-node"):
+        validate_metis_sarif(_payload(result, result), limits=SarifLimits(max_nodes=34))
+
+
+@pytest.mark.parametrize("container", [dict, list])
+def test_validate_sarif_rejects_cycles_with_bounded_traversal(container):
+    cycle = container()
+    if isinstance(cycle, dict):
+        cycle["self"] = cycle
+    else:
+        cycle.append(cycle)
+    payload = _payload()
+    payload["extension"] = cycle
+    with pytest.raises(ValueError, match="recursive|nesting|constructed-node"):
+        validate_metis_sarif(payload, limits=SarifLimits(max_depth=12, max_nodes=100))
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        {"logicalLocations": [{"fullyQualifiedName": "module.function"}]},
+        {"physicalLocation": {"artifactLocation": {"uri": "src/b.py"}}},
+        {
+            "physicalLocation": {
+                "artifactLocation": {"uri": "data.bin"},
+                "region": {
+                    "byteOffset": 0,
+                    "byteLength": 4,
+                    "snippet": {"binary": "AA=="},
+                },
+            }
+        },
+        {"physicalLocation": {"address": {"absoluteAddress": 1}}},
+    ],
+)
+def test_validate_sarif_preserves_supplementary_locations(location):
+    payload = _payload()
+    locations = payload["runs"][0]["results"][0]["locations"]
+    locations[0]["physicalLocation"]["contextRegion"] = {
+        "charOffset": 0,
+        "charLength": 4,
+    }
+    locations.append(location)
+    validate_metis_sarif(payload)
+    locations[0] = location
+    with pytest.raises(ValueError):
+        validate_metis_sarif(payload)
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        {"logicalLocations": "function"},
+        {"physicalLocation": []},
+        {"physicalLocation": {"artifactLocation": {"uri": 1}}},
+        {"physicalLocation": {"region": {"byteOffset": -2}}},
+        {"physicalLocation": {"region": {"byteOffset": 0, "byteLength": -1}}},
+        {"physicalLocation": {"region": {"charOffset": 0, "charLength": True}}},
+        {"physicalLocation": {"region": {"startLine": 2, "endLine": 1}}},
+        {"physicalLocation": {"region": {"startLine": 1, "startColumn": 0}}},
+        {
+            "physicalLocation": {
+                "region": {"startLine": 1, "startColumn": 3, "endColumn": 2}
+            }
+        },
+    ],
+)
+def test_validate_sarif_rejects_malformed_supplementary_locations(location):
+    payload = _payload()
+    physical = location.get("physicalLocation")
+    if isinstance(physical, dict) and "region" in physical:
+        physical["artifactLocation"] = {"uri": "data.bin"}
+    payload["runs"][0]["results"][0]["locations"].append(location)
+    with pytest.raises(ValueError):
+        validate_metis_sarif(payload)
+
+
+def test_validate_sarif_preserves_unknown_offset_sentinels():
+    payload = _payload()
+    region = payload["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
+        "region"
+    ]
+    region.update(charOffset=-1, byteOffset=-1)
+    validate_metis_sarif(payload)
+
+
+def test_save_sarif_enforces_exact_utf8_size_and_preserves_previous_output(tmp_path):
+    path = tmp_path / "result.sarif"
+    payload = _payload()
+    payload["runs"][0]["results"][0]["message"]["text"] = "Caf\u00e9 \U0001f40d"
+    encoded = _encoded(payload)
+    limits = SarifLimits(max_bytes=len(encoded))
+    save_metis_sarif_file(path, payload, limits=limits)
+    assert path.read_bytes() == encoded
+    assert load_metis_sarif_file(path, limits=limits) == payload
+    with pytest.raises(ValueError, match="byte limit"):
+        save_metis_sarif_file(
+            path, payload, limits=SarifLimits(max_bytes=len(encoded) - 1)
+        )
+    assert path.read_bytes() == encoded
+    payload["runs"][0]["results"][0]["message"]["text"] = ""
+    with pytest.raises(ValueError, match="message.text"):
+        save_metis_sarif_file(path, payload)
+    assert path.read_bytes() == encoded


### PR DESCRIPTION
- centralize SARIF validation and bound external decision JSON
- validate reports before atomic UTF-8 publication
- preserve supplementary locations and shared object references
- document limits and cover compatibility regressions